### PR TITLE
ci: add workflow_dispatch trigger to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master, develop]
   push:
     branches: [develop]
+  workflow_dispatch:
 
 env:
   XCODE_VERSION: '16.1'


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` trigger to workflows that were missing it.

**Files updated:**
- `.github/workflows/build.yml`
- `.github/workflows/pr-checks.yml`

**Why:** Manual/on-demand workflow triggering was not possible without this trigger.

---
*Created by Forge (JarvisXomware)*