### PR TITLE
fix: iOS 26 SDK (macos-26) + export compliance

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     name: Build & Upload to TestFlight
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
 
     steps:

--- a/Xomify-iOS/Info.plist
+++ b/Xomify-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Switch runner from \`macos-15\` (Xcode 16.4) to \`macos-26\` (Xcode 26.2 default)
- Add \`ITSAppUsesNonExemptEncryption = false\` to Info.plist

## Why
- **SDK**: Apple 90725 warning — apps uploaded after April 28, 2026 must be built with iOS 26 SDK
- **Compliance**: TestFlight flagged previous xomify build as 'missing compliance' because the Info.plist lacked the encryption-export key

## Test plan
- [ ] Archive with Xcode 26.2
- [ ] Upload succeeds without 90725 warning
- [ ] Build shows no 'missing compliance' flag in TestFlight