### PR TITLE
fix: rename home-screen display to 'Xomify'

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Xomify-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Xomify;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -324,6 +325,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Xomify-iOS/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Xomify;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
## Summary
- Set \`INFOPLIST_KEY_CFBundleDisplayName = Xomify\` in Debug and Release build configs

## Why
App shows as 'Xomify-iOS' on the home screen (inherited from target name via \`PRODUCT_NAME\`). CFBundleDisplayName overrides just the user-visible label without touching target / scheme / file paths.

## Test plan
- [ ] Next TestFlight build shows 'Xomify' on the home screen
- [ ] Bundle ID, target, scheme, URL schemes unchanged