### PR TITLE
ci: pipe all Spotify/API secrets into secrets.xcconfig

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -28,7 +28,9 @@ jobs:
         run: |
           cat > secrets.xcconfig << XCCONFIG
           SPOTIFY_CLIENT_ID = ${{ secrets.SPOTIFY_CLIENT_ID }}
-          SPOTIFY_REDIRECT_URI = ${{ secrets.SPOTIFY_REDIRECT_URI }}
+          SPOTIFY_CLIENT_SECRET = ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+          XOMIFY_API_ID = ${{ secrets.XOMIFY_API_ID }}
+          XOMIFY_API_TOKEN = ${{ secrets.XOMIFY_API_TOKEN }}
           XCCONFIG
 
       - name: Write App Store Connect API key


### PR DESCRIPTION
## Summary
- Workflow was only writing `SPOTIFY_CLIENT_ID` (plus an unused `SPOTIFY_REDIRECT_URI`) into `secrets.xcconfig`, so Info.plist placeholders for `SPOTIFY_CLIENT_SECRET`, `XOMIFY_API_ID`, `XOMIFY_API_TOKEN` resolved to empty — producing the "missing client id for Spotify login" failure in TestFlight.
- Now writes all four values from GitHub Secrets so Info.plist `$(VAR)` substitutions resolve at archive time.

## Test plan
- [ ] Fill real values for `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `XOMIFY_API_ID`, `XOMIFY_API_TOKEN` in repo secrets (currently `FILL_ME_IN` placeholders)
- [ ] Merge → next TestFlight build triggers via push to master
- [ ] Install build, confirm Spotify login proceeds past client-id check