### PR TITLE
chore: purge stray Xomfit tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,12 @@ playground.xcworkspace
 # Personal Claude overrides (not shared)
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Sibling project guard — never track XomFit (fitness app lives in xomfit-ios repo)
+Xomfit/
+XomFit/
+Xomfit.xcodeproj/
+XomFit.xcodeproj/
+XomFitWatch/
+XomFitTests/
+XomFitUITests/


### PR DESCRIPTION
## Summary

Purges the stray `Xomfit/` directory (a fitness-app sibling that has no business in this repo) from the working tree and hardens `.gitignore` to prevent it from re-appearing.

**Files deleted:** 6 filesystem files (`.DS_Store` artifacts and Xcode workspace metadata — the actual source files were already absent from the index, the directory itself was untracked)

**`.gitignore` additions:**
- `Xomfit/`, `XomFit/`
- `Xomfit.xcodeproj/`, `XomFit.xcodeproj/`
- `XomFitWatch/`, `XomFitTests/`, `XomFitUITests/`

## Build Verification

`xcodebuild -scheme Xomify-iOS -sdk iphonesimulator clean build` — **SUCCEEDED** (12s)

Zero references to `Xomfit` or `XomFit` found in `Xomify-iOS.xcodeproj`.

## Links

- Epic plan: `docs/features/xomify-social-feed/PLAN.md`
- Sub-feature plan: `docs/features/repo-cleanup/PLAN.md`

## Notes

This is the blocking prerequisite for sub-features 2–10 of the `xomify-social-feed` epic. Do not merge downstream PRs before this one lands.

No XomBoard issue exists for this cleanup task — no `Closes #N` added.