### PR TITLE
feat(ios): groups management — friend picker, owner badge, leave/delete

### DIFF
--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -16,13 +16,18 @@ final class GroupDetailViewModel {
     var isRefreshing = false
     var errorMessage: String?
 
-    /// User email inputs to add a member (typed inline).
+    /// User email inputs to add a member (typed inline / by-email fallback).
     var addMemberEmail: String = ""
     var isAddingMember = false
 
     /// Spotify URL input for adding by URL.
     var addSongUrl: String = ""
     var isAddingSong = false
+
+    /// Accepted-friends cache used by the add-member sheet picker.
+    var friends: [Friend] = []
+    var isLoadingFriends = false
+    var friendsError: String?
 
     private let xomify = XomifyService.shared
 
@@ -60,6 +65,23 @@ final class GroupDetailViewModel {
         isRefreshing = false
     }
 
+    // MARK: - Friends (for add-member picker)
+
+    func loadFriends() async {
+        guard !userEmail.isEmpty else { return }
+        isLoadingFriends = true
+        friendsError = nil
+        defer { isLoadingFriends = false }
+
+        do {
+            let response = try await xomify.getAllFriends(email: userEmail)
+            friends = response.accepted ?? []
+        } catch {
+            friendsError = error.localizedDescription
+            print("❌ GroupDetail: loadFriends failed - \(error)")
+        }
+    }
+
     // MARK: - Members
 
     func addMember() async {
@@ -78,6 +100,59 @@ final class GroupDetailViewModel {
         }
     }
 
+    /// Batch-add members via the friend picker. Optimistically inserts a
+    /// skeleton row per email, rolls back the skeleton on a per-email failure,
+    /// and finishes with a `refresh()` so server-canonical display names and
+    /// `joinedAt` land. Partial failures are reported via `errorMessage`.
+    func addMembers(_ emails: [String]) async {
+        let clean = emails
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !clean.isEmpty else { return }
+
+        var succeeded = 0
+        var failures: [String] = []
+
+        for email in clean {
+            // Optimistic insert (skip duplicates).
+            let alreadyPresent = members.contains { $0.email == email }
+            if !alreadyPresent {
+                members.append(GroupMember(
+                    email: email,
+                    displayName: nil,
+                    joinedAt: nil,
+                    isOwner: false
+                ))
+            }
+
+            do {
+                _ = try await xomify.addMember(
+                    email: userEmail,
+                    groupId: groupId,
+                    memberEmail: email
+                )
+                succeeded += 1
+            } catch {
+                // Roll back the skeleton we inserted.
+                if !alreadyPresent {
+                    members.removeAll { $0.email == email && $0.displayName == nil && $0.joinedAt == nil }
+                }
+                failures.append(email)
+                print("❌ GroupDetail: addMembers failed for \(email) - \(error)")
+            }
+        }
+
+        if succeeded == clean.count {
+            // Pull canonical rows (display names, joinedAt).
+            await refresh()
+        } else if succeeded > 0 {
+            errorMessage = "Added \(succeeded) of \(clean.count) — \(failures.count) failed."
+            await refresh()
+        } else {
+            errorMessage = "Couldn't add any members. Please try again."
+        }
+    }
+
     func removeMember(_ member: GroupMember) async {
         do {
             _ = try await xomify.removeMember(
@@ -89,6 +164,37 @@ final class GroupDetailViewModel {
         } catch {
             errorMessage = "Failed to remove member: \(error.localizedDescription)"
             print("❌ GroupDetail: removeMember failed - \(error)")
+        }
+    }
+
+    // MARK: - Leave / Delete (pessimistic)
+
+    /// Non-owner leave. Returns `true` on success so the view can dismiss.
+    @discardableResult
+    func leave() async -> Bool {
+        guard !userEmail.isEmpty, !groupId.isEmpty else { return false }
+        do {
+            _ = try await xomify.leaveGroup(email: userEmail, groupId: groupId)
+            return true
+        } catch {
+            errorMessage = "Failed to leave group: \(error.localizedDescription)"
+            print("❌ GroupDetail: leave failed - \(error)")
+            return false
+        }
+    }
+
+    /// Owner-only delete. Caller MUST verify `group?.ownerEmail == userEmail`
+    /// before invoking. Returns `true` on success.
+    @discardableResult
+    func delete() async -> Bool {
+        guard !userEmail.isEmpty, !groupId.isEmpty else { return false }
+        do {
+            _ = try await xomify.removeGroup(email: userEmail, groupId: groupId)
+            return true
+        } catch {
+            errorMessage = "Failed to delete group: \(error.localizedDescription)"
+            print("❌ GroupDetail: delete failed - \(error)")
+            return false
         }
     }
 

--- a/Xomify-iOS/ViewModels/GroupsViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupsViewModel.swift
@@ -13,6 +13,14 @@ final class GroupsViewModel {
     var errorMessage: String?
     var isCreating = false
 
+    /// Non-fatal informational banner (e.g. "3 of 5 members added").
+    var infoMessage: String?
+
+    /// Accepted-friends cache used by the create-sheet picker.
+    var friends: [Friend] = []
+    var isLoadingFriends = false
+    var friendsError: String?
+
     private let xomify = XomifyService.shared
 
     var isEmpty: Bool { groups.isEmpty }
@@ -48,12 +56,38 @@ final class GroupsViewModel {
         isRefreshing = false
     }
 
+    // MARK: - Friends (for create-sheet picker)
+
+    func loadFriends() async {
+        guard !userEmail.isEmpty else { return }
+        isLoadingFriends = true
+        friendsError = nil
+        defer { isLoadingFriends = false }
+
+        do {
+            let response = try await xomify.getAllFriends(email: userEmail)
+            friends = response.accepted ?? []
+        } catch {
+            friendsError = error.localizedDescription
+            print("❌ Groups: loadFriends failed - \(error)")
+        }
+    }
+
     // MARK: - Create
 
+    /// Creates a group and fans out `addMember` calls for each picked friend.
+    /// Returns the created group on success, `nil` on failure. Partial add
+    /// failures are surfaced via `infoMessage` ("N of M members added") — the
+    /// group itself is still created.
     @discardableResult
-    func create(name: String, description: String?) async -> XomifyGroup? {
+    func create(
+        name: String,
+        memberEmails: [String] = [],
+        description: String? = nil
+    ) async -> XomifyGroup? {
         guard !userEmail.isEmpty, !name.isEmpty, !isCreating else { return nil }
         isCreating = true
+        infoMessage = nil
         defer { isCreating = false }
 
         do {
@@ -62,13 +96,41 @@ final class GroupsViewModel {
                 name: name,
                 description: description
             )
-            // Prefer server response's group; fall back to reload.
+
+            let created: XomifyGroup?
             if let group = response.group {
+                created = group
                 groups.insert(group, at: 0)
-                return group
+            } else {
+                await load(email: userEmail)
+                created = groups.first
             }
-            await load(email: userEmail)
-            return groups.first
+
+            guard let group = created else { return nil }
+
+            // Fan-out add each picked member.
+            if !memberEmails.isEmpty {
+                var addedCount = 0
+                for email in memberEmails {
+                    do {
+                        _ = try await xomify.addMember(
+                            email: userEmail,
+                            groupId: group.groupId,
+                            memberEmail: email
+                        )
+                        addedCount += 1
+                    } catch {
+                        print("❌ Groups: addMember during create failed for \(email) - \(error)")
+                    }
+                }
+                if addedCount < memberEmails.count {
+                    infoMessage = "Group created. \(addedCount) of \(memberEmails.count) members added — try re-adding the rest from the group."
+                }
+                // Re-fetch to update memberCount on the list row.
+                await load(email: userEmail)
+            }
+
+            return group
         } catch {
             errorMessage = "Failed to create group: \(error.localizedDescription)"
             print("❌ Groups: create failed - \(error)")
@@ -85,6 +147,21 @@ final class GroupsViewModel {
         } catch {
             errorMessage = "Failed to leave group: \(error.localizedDescription)"
             print("❌ Groups: leave failed - \(error)")
+        }
+    }
+
+    // MARK: - Delete (owner-only — caller gates by ownership)
+
+    @discardableResult
+    func delete(_ group: XomifyGroup) async -> Bool {
+        do {
+            _ = try await xomify.removeGroup(email: userEmail, groupId: group.groupId)
+            groups.removeAll { $0.groupId == group.groupId }
+            return true
+        } catch {
+            errorMessage = "Failed to delete group: \(error.localizedDescription)"
+            print("❌ Groups: delete failed - \(error)")
+            return false
         }
     }
 }

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -8,11 +8,20 @@ struct GroupDetailView: View {
 
     @State private var viewModel = GroupDetailViewModel()
     @State private var selectedTab: Tab = .tracks
+    @State private var showingAddMembers = false
+    @State private var showLeaveConfirm = false
+    @State private var showDeleteConfirm = false
+
+    @Environment(\.dismiss) private var dismiss
 
     enum Tab: String, CaseIterable, Identifiable {
         case tracks = "Tracks"
         case members = "Members"
         var id: String { rawValue }
+    }
+
+    private var isOwner: Bool {
+        viewModel.group?.ownerEmail == viewerEmail
     }
 
     var body: some View {
@@ -38,16 +47,7 @@ struct GroupDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    Task { await viewModel.refresh() }
-                } label: {
-                    if viewModel.isRefreshing {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                }
-                .disabled(viewModel.isRefreshing)
+                toolbarMenu
             }
         }
         .task { await viewModel.load(email: viewerEmail, groupId: groupId) }
@@ -56,12 +56,86 @@ struct GroupDetailView: View {
             if let error = viewModel.errorMessage {
                 Text(error)
                     .font(.caption)
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .background(Color.red.opacity(0.15))
             }
         }
+        .sheet(isPresented: $showingAddMembers) {
+            AddMemberSheet(
+                viewModel: viewModel,
+                onDismiss: { showingAddMembers = false }
+            )
+        }
+        .confirmationDialog(
+            "Leave this group?",
+            isPresented: $showLeaveConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Leave Group", role: .destructive) {
+                Task {
+                    if await viewModel.leave() {
+                        dismiss()
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("You'll stop receiving updates and lose access to this group's shared tracks.")
+        }
+        .confirmationDialog(
+            "Delete this group?",
+            isPresented: $showDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Group", role: .destructive) {
+                Task {
+                    if await viewModel.delete() {
+                        dismiss()
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently removes the group for everyone. This action can't be undone.")
+        }
+    }
+
+    // MARK: - Toolbar menu
+
+    private var toolbarMenu: some View {
+        Menu {
+            Button {
+                Task { await viewModel.refresh() }
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .disabled(viewModel.isRefreshing)
+
+            if isOwner {
+                Button(role: .destructive) {
+                    showDeleteConfirm = true
+                } label: {
+                    Label("Delete Group", systemImage: "trash")
+                }
+            } else if viewModel.group != nil {
+                Button(role: .destructive) {
+                    showLeaveConfirm = true
+                } label: {
+                    Label("Leave Group", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
+        } label: {
+            if viewModel.isRefreshing {
+                ProgressView()
+            } else {
+                Image(systemName: "ellipsis.circle")
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+        }
+        .accessibilityLabel("Group actions")
+        .accessibilityHint("Opens menu with refresh and destructive actions")
     }
 
     private func tabTitle(_ tab: Tab) -> String {
@@ -96,23 +170,24 @@ struct GroupDetailView: View {
                 .textInputAutocapitalization(.never)
                 .padding()
                 .background(Color.white.opacity(0.05))
-                .cornerRadius(10)
-                .foregroundColor(.white)
+                .clipShape(.rect(cornerRadius: 10))
+                .foregroundStyle(.white)
 
             Button {
                 Task { await viewModel.addSongByUrl() }
             } label: {
                 if viewModel.isAddingSong {
                     ProgressView().tint(.white)
-                        .frame(width: 40, height: 40)
+                        .frame(width: 44, height: 44)
                 } else {
                     Image(systemName: "plus.circle.fill")
                         .font(.title2)
-                        .foregroundColor(.xomifyGreen)
-                        .frame(width: 40, height: 40)
+                        .foregroundStyle(Color.xomifyGreen)
+                        .frame(width: 44, height: 44)
                 }
             }
             .disabled(viewModel.isAddingSong || viewModel.addSongUrl.isEmpty)
+            .accessibilityLabel("Add track from URL")
         }
         .padding(.horizontal)
         .padding(.bottom, 8)
@@ -133,8 +208,8 @@ struct GroupDetailView: View {
                     .fontWeight(.medium)
                     .padding(.horizontal, 14).padding(.vertical, 8)
                     .background(Color.white.opacity(0.08))
-                    .foregroundColor(.white)
-                    .cornerRadius(16)
+                    .foregroundStyle(.white)
+                    .clipShape(.rect(cornerRadius: 16))
                 }
                 .buttonStyle(.plain)
                 .padding(.top, 4)
@@ -156,24 +231,24 @@ struct GroupDetailView: View {
                 Rectangle().fill(Color.gray.opacity(0.3))
             }
             .frame(width: 50, height: 50)
-            .cornerRadius(6)
+            .clipShape(.rect(cornerRadius: 6))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(track.trackName ?? "Unknown")
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .lineLimit(1)
                 if let artist = track.artistName {
                     Text(artist)
                         .font(.caption)
-                        .foregroundColor(.gray)
+                        .foregroundStyle(.gray)
                         .lineLimit(1)
                 }
                 if let by = track.addedBy {
                     Text("Added by \(by)")
                         .font(.caption2)
-                        .foregroundColor(.gray.opacity(0.8))
+                        .foregroundStyle(.gray.opacity(0.8))
                 }
             }
 
@@ -183,61 +258,55 @@ struct GroupDetailView: View {
                 Task { await viewModel.removeSong(track) }
             } label: {
                 Image(systemName: "trash")
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
+                    .frame(width: 44, height: 44)
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Remove \(track.trackName ?? "track")")
         }
         .padding(12)
         .background(Color.xomifyCard)
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 
     // MARK: - Members
 
     private var membersSection: some View {
         VStack(spacing: 0) {
-            addMemberBar
+            addMembersButton
 
             if viewModel.isLoading && viewModel.members.isEmpty {
                 ProgressView().tint(.xomifyGreen)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if viewModel.members.isEmpty {
                 emptyTab(icon: "person.2", title: "No members yet",
-                         message: "Add someone by their email above.")
+                         message: "Tap Add members to invite friends.")
             } else {
                 membersList
             }
         }
     }
 
-    private var addMemberBar: some View {
-        HStack(spacing: 8) {
-            TextField("Friend email", text: $viewModel.addMemberEmail)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .keyboardType(.emailAddress)
-                .padding()
-                .background(Color.white.opacity(0.05))
-                .cornerRadius(10)
-                .foregroundColor(.white)
-
-            Button {
-                Task { await viewModel.addMember() }
-            } label: {
-                if viewModel.isAddingMember {
-                    ProgressView().tint(.white)
-                        .frame(width: 40, height: 40)
-                } else {
-                    Image(systemName: "person.badge.plus")
-                        .font(.title3)
-                        .foregroundColor(.xomifyGreen)
-                        .frame(width: 40, height: 40)
-                }
+    private var addMembersButton: some View {
+        Button {
+            showingAddMembers = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "person.badge.plus")
+                Text("Add members")
             }
-            .disabled(viewModel.isAddingMember || viewModel.addMemberEmail.isEmpty)
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.vertical, 10)
+            .background(LinearGradient.xomifyGradient)
+            .foregroundStyle(.white)
+            .clipShape(.rect(cornerRadius: 22))
         }
         .padding(.horizontal)
         .padding(.bottom, 8)
+        .accessibilityLabel("Add members")
+        .accessibilityHint("Opens a picker to add friends to this group")
     }
 
     private var membersList: some View {
@@ -260,7 +329,7 @@ struct GroupDetailView: View {
                 Text(String(member.label.prefix(1)).uppercased())
                     .font(.subheadline)
                     .fontWeight(.bold)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -268,7 +337,7 @@ struct GroupDetailView: View {
                     Text(member.label)
                         .font(.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                         .lineLimit(1)
                     if member.isOwner == true {
                         Text("OWNER")
@@ -276,31 +345,35 @@ struct GroupDetailView: View {
                             .fontWeight(.semibold)
                             .padding(.horizontal, 6).padding(.vertical, 2)
                             .background(Color.xomifyPurple.opacity(0.2))
-                            .foregroundColor(.xomifyPurple)
-                            .cornerRadius(4)
+                            .foregroundStyle(Color.xomifyPurple)
+                            .clipShape(.rect(cornerRadius: 4))
+                            .accessibilityLabel("Owner")
                     }
                 }
                 Text(member.email)
                     .font(.caption2)
-                    .foregroundColor(.gray)
+                    .foregroundStyle(.gray)
                     .lineLimit(1)
             }
 
             Spacer()
 
-            if member.isOwner != true, viewModel.group?.ownerEmail == viewerEmail {
+            if member.isOwner != true, isOwner {
                 Button(role: .destructive) {
                     Task { await viewModel.removeMember(member) }
                 } label: {
                     Image(systemName: "person.badge.minus")
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
+                        .frame(width: 44, height: 44)
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel("Remove \(member.label)")
+                .accessibilityHint("Removes this member from the group")
             }
         }
         .padding(12)
         .background(Color.xomifyCard)
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
     }
 
     // MARK: - Empty helper
@@ -309,11 +382,11 @@ struct GroupDetailView: View {
         VStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 40))
-                .foregroundColor(.gray.opacity(0.5))
-            Text(title).font(.headline).foregroundColor(.white)
+                .foregroundStyle(Color.gray.opacity(0.5))
+            Text(title).font(.headline).foregroundStyle(.white)
             Text(message)
                 .font(.caption)
-                .foregroundColor(.gray)
+                .foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
         }
         .padding(40)

--- a/Xomify-iOS/Views/Groups/AddMemberSheet.swift
+++ b/Xomify-iOS/Views/Groups/AddMemberSheet.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// Sheet presented from `GroupDetailView` to add members via the friend
+/// picker. Also offers a "Add by email" disclosure fallback for adding
+/// people who aren't friends yet (keeps the old typed-email behavior).
+struct AddMemberSheet: View {
+
+    @Bindable var viewModel: GroupDetailViewModel
+    let onDismiss: () -> Void
+
+    @State private var selected: Set<String> = []
+    @State private var isAddingBatch = false
+    @State private var showByEmail = false
+
+    private var existingMemberEmails: Set<String> {
+        Set(viewModel.members.map { $0.email })
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+
+                VStack(spacing: 12) {
+                    header
+
+                    FriendPickerView(
+                        friends: viewModel.friends,
+                        excluding: existingMemberEmails,
+                        mode: .multi,
+                        isLoading: viewModel.isLoadingFriends,
+                        loadError: viewModel.friendsError,
+                        selected: $selected,
+                        onRetry: {
+                            Task { await viewModel.loadFriends() }
+                        }
+                    )
+                    .padding(.horizontal)
+
+                    byEmailDisclosure
+                        .padding(.horizontal)
+
+                    confirmButton
+                        .padding(.horizontal)
+                        .padding(.bottom, 8)
+                }
+                .padding(.top, 8)
+            }
+            .navigationTitle("Add Members")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { onDismiss() }
+                }
+            }
+            .tint(Color.xomifyGreen)
+            .task { await viewModel.loadFriends() }
+        }
+        .presentationDetents([.large])
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            if selected.isEmpty {
+                Text("Pick friends to add")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+            } else {
+                Text("\(selected.count) selected")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.xomifyGreen)
+            }
+            Spacer()
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - By-email fallback
+
+    private var byEmailDisclosure: some View {
+        DisclosureGroup(isExpanded: $showByEmail) {
+            HStack(spacing: 8) {
+                TextField("Friend email", text: $viewModel.addMemberEmail)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.emailAddress)
+                    .padding()
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(.rect(cornerRadius: 10))
+                    .foregroundStyle(.white)
+
+                Button {
+                    Task {
+                        await viewModel.addMember()
+                        if viewModel.errorMessage == nil {
+                            onDismiss()
+                        }
+                    }
+                } label: {
+                    if viewModel.isAddingMember {
+                        ProgressView().tint(.white)
+                            .frame(width: 44, height: 44)
+                    } else {
+                        Image(systemName: "person.badge.plus")
+                            .font(.title3)
+                            .foregroundStyle(Color.xomifyGreen)
+                            .frame(width: 44, height: 44)
+                    }
+                }
+                .disabled(viewModel.isAddingMember
+                          || viewModel.addMemberEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityLabel("Add by email")
+                .accessibilityHint("Adds the typed email as a member")
+            }
+            .padding(.top, 4)
+        } label: {
+            Text("Add by email")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.gray)
+        }
+        .tint(.gray)
+    }
+
+    // MARK: - Confirm
+
+    private var confirmButton: some View {
+        Button {
+            Task { await performAdd() }
+        } label: {
+            HStack(spacing: 8) {
+                if isAddingBatch {
+                    ProgressView().tint(.white)
+                } else {
+                    Image(systemName: "checkmark.circle.fill")
+                    Text(confirmLabel)
+                }
+            }
+            .font(.headline)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.vertical, 10)
+            .background(confirmBackground)
+            .foregroundStyle(.white)
+            .clipShape(.rect(cornerRadius: 22))
+        }
+        .disabled(selected.isEmpty || isAddingBatch)
+        .accessibilityLabel("Add selected members")
+        .accessibilityHint("Adds the selected friends to this group")
+    }
+
+    private var confirmLabel: String {
+        if selected.isEmpty { return "Add Members" }
+        if selected.count == 1 { return "Add 1 Member" }
+        return "Add \(selected.count) Members"
+    }
+
+    @ViewBuilder
+    private var confirmBackground: some View {
+        if selected.isEmpty {
+            Color.gray.opacity(0.3)
+        } else {
+            LinearGradient.xomifyGradient
+        }
+    }
+
+    private func performAdd() async {
+        let emails = Array(selected)
+        guard !emails.isEmpty else { return }
+        isAddingBatch = true
+        await viewModel.addMembers(emails)
+        isAddingBatch = false
+        // Dismiss when there's no fatal error; partial-success messages will
+        // be surfaced via the detail view's error banner.
+        onDismiss()
+    }
+}

--- a/Xomify-iOS/Views/Groups/FriendPickerView.swift
+++ b/Xomify-iOS/Views/Groups/FriendPickerView.swift
@@ -1,0 +1,304 @@
+import SwiftUI
+
+/// Reusable friend picker with search + selection. Used by the group-create
+/// flow (multi-select) and the add-member sheet (multi-select, with
+/// existing members excluded).
+///
+/// Rendered inline inside a parent sheet — owns no chrome of its own, just
+/// the search field, the rows, and the empty state. Parent is responsible
+/// for navigation / confirm / cancel buttons.
+struct FriendPickerView: View {
+
+    enum Mode {
+        case single
+        case multi
+    }
+
+    let friends: [Friend]
+    let excluding: Set<String>
+    let mode: Mode
+    let isLoading: Bool
+    let loadError: String?
+    @Binding var selected: Set<String>
+    let onRetry: (() -> Void)?
+
+    @State private var searchText: String = ""
+
+    init(
+        friends: [Friend],
+        excluding: Set<String> = [],
+        mode: Mode = .multi,
+        isLoading: Bool = false,
+        loadError: String? = nil,
+        selected: Binding<Set<String>>,
+        onRetry: (() -> Void)? = nil
+    ) {
+        self.friends = friends
+        self.excluding = excluding
+        self.mode = mode
+        self.isLoading = isLoading
+        self.loadError = loadError
+        self._selected = selected
+        self.onRetry = onRetry
+    }
+
+    // MARK: - Filtering
+
+    private var available: [Friend] {
+        friends.filter { !excluding.contains($0.targetEmail) }
+    }
+
+    private var filtered: [Friend] {
+        let q = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if q.isEmpty { return available }
+        return available.filter {
+            $0.label.lowercased().contains(q) ||
+            $0.targetEmail.lowercased().contains(q)
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 12) {
+            searchField
+
+            if isLoading {
+                loadingState
+            } else if let error = loadError {
+                errorState(error)
+            } else if available.isEmpty {
+                emptyState
+            } else if filtered.isEmpty {
+                noMatchesState
+            } else {
+                list
+            }
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.gray)
+            TextField("Search friends", text: $searchText)
+                .foregroundStyle(.white)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.gray)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding()
+        .background(Color.white.opacity(0.05))
+        .clipShape(.rect(cornerRadius: 10))
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                ForEach(filtered, id: \.targetEmail) { friend in
+                    row(for: friend)
+                }
+            }
+        }
+    }
+
+    private func row(for friend: Friend) -> some View {
+        let isSelected = selected.contains(friend.targetEmail)
+
+        return Button {
+            toggle(friend)
+        } label: {
+            HStack(spacing: 12) {
+                avatarCircle(label: friend.label)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(friend.label)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Text(friend.targetEmail)
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                selectionIcon(selected: isSelected)
+            }
+            .padding(12)
+            .background(Color.xomifyCard)
+            .clipShape(.rect(cornerRadius: 10))
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(friend.label))
+        .accessibilityValue(Text(isSelected ? "Selected" : "Not selected"))
+        .accessibilityHint(Text("Double tap to \(isSelected ? "deselect" : "select")"))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func selectionIcon(selected: Bool) -> some View {
+        Image(systemName: selected
+              ? (mode == .multi ? "checkmark.square.fill" : "largecircle.fill.circle")
+              : (mode == .multi ? "square" : "circle"))
+            .font(.title3)
+            .foregroundStyle(selected ? Color.xomifyGreen : Color.gray.opacity(0.6))
+            .frame(width: 32, height: 32)
+    }
+
+    private func avatarCircle(label: String) -> some View {
+        ZStack {
+            Circle()
+                .fill(LinearGradient.xomifyGradient)
+                .frame(width: 40, height: 40)
+            Text(String(label.prefix(1)).uppercased())
+                .font(.subheadline)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
+        }
+    }
+
+    // MARK: - States
+
+    private var loadingState: some View {
+        VStack(spacing: 10) {
+            ProgressView().tint(.xomifyGreen)
+            Text("Loading friends...")
+                .font(.caption)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, minHeight: 160)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32))
+                .foregroundStyle(Color.orange.opacity(0.7))
+            Text("Couldn't load friends")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+            if let onRetry {
+                Button("Try Again") {
+                    onRetry()
+                }
+                .buttonStyle(.bordered)
+                .tint(Color.xomifyPurple)
+            }
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, minHeight: 180)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "person.2")
+                .font(.system(size: 32))
+                .foregroundStyle(Color.gray.opacity(0.6))
+            Text("No friends yet")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+            Text("Add some from the Friends drawer entry, then come back here.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, minHeight: 180)
+    }
+
+    private var noMatchesState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 28))
+                .foregroundStyle(Color.gray.opacity(0.6))
+            Text("No friends match \"\(searchText)\"")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity, minHeight: 120)
+    }
+
+    // MARK: - Actions
+
+    private func toggle(_ friend: Friend) {
+        let key = friend.targetEmail
+        switch mode {
+        case .multi:
+            if selected.contains(key) {
+                selected.remove(key)
+            } else {
+                selected.insert(key)
+            }
+        case .single:
+            if selected.contains(key) {
+                selected.removeAll()
+            } else {
+                selected = [key]
+            }
+        }
+    }
+}
+
+#Preview {
+    struct Host: View {
+        @State private var selected: Set<String> = []
+
+        var body: some View {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+                FriendPickerView(
+                    friends: [
+                        Friend(
+                            email: "me@example.com",
+                            friendEmail: "alex@example.com",
+                            displayName: "Alex",
+                            avatar: nil,
+                            status: "accepted",
+                            direction: nil,
+                            createdAt: nil,
+                            mutualCount: nil
+                        ),
+                        Friend(
+                            email: "me@example.com",
+                            friendEmail: "sam@example.com",
+                            displayName: "Sam",
+                            avatar: nil,
+                            status: "accepted",
+                            direction: nil,
+                            createdAt: nil,
+                            mutualCount: nil
+                        )
+                    ],
+                    excluding: [],
+                    mode: .multi,
+                    selected: $selected
+                )
+                .padding()
+            }
+        }
+    }
+    return Host()
+}

--- a/Xomify-iOS/Views/GroupsView.swift
+++ b/Xomify-iOS/Views/GroupsView.swift
@@ -25,24 +25,55 @@ struct GroupsView: View {
                     Image(systemName: "plus")
                 }
                 .disabled(isLoadingUser)
+                .accessibilityLabel("Create group")
             }
         }
         .task { await loadUserAndData() }
+        .onAppear {
+            // Return from GroupDetailView (e.g. after delete/leave) should
+            // re-fetch the list so stale rows don't linger.
+            guard !isLoadingUser, let email = userEmail, !email.isEmpty else { return }
+            Task { await viewModel.refresh() }
+        }
         .sheet(isPresented: $showingCreate) {
             CreateGroupSheet(
-                onCreate: { name, desc in
+                viewModel: viewModel,
+                onCreate: { name, memberEmails, desc in
                     Task {
-                        if let group = await viewModel.create(name: name, description: desc) {
-                            _ = group
-                        }
+                        _ = await viewModel.create(
+                            name: name,
+                            memberEmails: memberEmails,
+                            description: desc
+                        )
                         showingCreate = false
                     }
                 },
-                onCancel: { showingCreate = false },
-                isCreating: viewModel.isCreating
+                onCancel: { showingCreate = false }
             )
         }
+        .overlay(alignment: .top) { errorBanner }
         .tint(Color.xomifyGreen)
+    }
+
+    // MARK: - Banners
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let error = viewModel.errorMessage, !viewModel.isEmpty {
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.red)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color.red.opacity(0.15))
+        } else if let info = viewModel.infoMessage {
+            Text(info)
+                .font(.caption)
+                .foregroundStyle(Color.xomifyGreen)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color.xomifyGreen.opacity(0.12))
+        }
     }
 
     @ViewBuilder
@@ -79,53 +110,91 @@ struct GroupsView: View {
     }
 
     private func groupRow(_ group: XomifyGroup) -> some View {
-        HStack(spacing: 12) {
+        let isOwner = group.ownerEmail == viewModel.userEmail
+        let memberCount = group.memberCount ?? 0
+        let trackCount = group.trackCount ?? 0
+
+        return HStack(spacing: 12) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(LinearGradient.xomifyGradient)
                     .frame(width: 50, height: 50)
                 Image(systemName: "person.3.fill")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(group.name)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(group.name)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    if isOwner {
+                        ownerBadge
+                    }
+                }
                 if let desc = group.description, !desc.isEmpty {
                     Text(desc)
                         .font(.caption)
-                        .foregroundColor(.gray)
+                        .foregroundStyle(.gray)
                         .lineLimit(2)
                 }
                 HStack(spacing: 8) {
-                    Label("\(group.memberCount ?? 0)", systemImage: "person.2")
-                    Label("\(group.trackCount ?? 0)", systemImage: "music.note")
+                    Label("\(memberCount)", systemImage: "person.2")
+                    Label("\(trackCount)", systemImage: "music.note")
                 }
                 .font(.caption2)
-                .foregroundColor(.gray)
+                .foregroundStyle(.gray)
                 .padding(.top, 2)
             }
             Spacer()
 
             Image(systemName: "chevron.right")
-                .foregroundColor(.gray)
+                .foregroundStyle(.gray)
         }
         .padding(12)
         .background(Color.xomifyCard)
-        .cornerRadius(10)
+        .clipShape(.rect(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(accessibilityLabel(
+            group: group, isOwner: isOwner,
+            memberCount: memberCount, trackCount: trackCount
+        )))
+    }
+
+    private var ownerBadge: some View {
+        Text("OWNER")
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color.xomifyPurple.opacity(0.2))
+            .foregroundStyle(Color.xomifyPurple)
+            .clipShape(.rect(cornerRadius: 4))
+            .accessibilityLabel("Owner")
+    }
+
+    private func accessibilityLabel(
+        group: XomifyGroup,
+        isOwner: Bool,
+        memberCount: Int,
+        trackCount: Int
+    ) -> String {
+        var parts: [String] = [group.name]
+        if isOwner { parts.append("owner") }
+        parts.append("\(memberCount) member\(memberCount == 1 ? "" : "s")")
+        parts.append("\(trackCount) track\(trackCount == 1 ? "" : "s")")
+        return parts.joined(separator: ", ")
     }
 
     private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "person.3")
                 .font(.system(size: 50))
-                .foregroundColor(.gray.opacity(0.5))
-            Text("No Groups Yet").font(.headline).foregroundColor(.white)
+                .foregroundStyle(Color.gray.opacity(0.5))
+            Text("No Groups Yet").font(.headline).foregroundStyle(.white)
             Text("Create a group to share and discover music with friends.")
-                .font(.caption).foregroundColor(.gray)
+                .font(.caption).foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
             Button {
                 showingCreate = true
@@ -135,8 +204,8 @@ struct GroupsView: View {
                     .fontWeight(.semibold)
                     .padding(.horizontal, 20).padding(.vertical, 10)
                     .background(LinearGradient.xomifyGradient)
-                    .foregroundColor(.white)
-                    .cornerRadius(20)
+                    .foregroundStyle(.white)
+                    .clipShape(.rect(cornerRadius: 20))
             }
         }
         .padding(.horizontal, 40)
@@ -147,9 +216,9 @@ struct GroupsView: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 50))
-                .foregroundColor(.orange.opacity(0.7))
-            Text("Error").font(.headline).foregroundColor(.white)
-            Text(message).font(.caption).foregroundColor(.gray)
+                .foregroundStyle(Color.orange.opacity(0.7))
+            Text("Error").font(.headline).foregroundStyle(.white)
+            Text(message).font(.caption).foregroundStyle(.gray)
                 .multilineTextAlignment(.center)
             Button {
                 Task { await loadUserAndData() }
@@ -159,8 +228,8 @@ struct GroupsView: View {
                     .fontWeight(.medium)
                     .padding(.horizontal, 24).padding(.vertical, 10)
                     .background(Color.xomifyPurple)
-                    .foregroundColor(.white)
-                    .cornerRadius(20)
+                    .foregroundStyle(.white)
+                    .clipShape(.rect(cornerRadius: 20))
             }
         }
         .padding(.horizontal, 40)
@@ -187,73 +256,185 @@ struct GroupsView: View {
     }
 }
 
-// MARK: - Create sheet
+// MARK: - Create sheet (two-step: name/description → friend picker)
 
 private struct CreateGroupSheet: View {
-    let onCreate: (String, String?) -> Void
-    let onCancel: () -> Void
-    let isCreating: Bool
 
+    @Bindable var viewModel: GroupsViewModel
+    let onCreate: (_ name: String, _ memberEmails: [String], _ description: String?) -> Void
+    let onCancel: () -> Void
+
+    private enum Step {
+        case details
+        case members
+    }
+
+    @State private var step: Step = .details
     @State private var name: String = ""
     @State private var description: String = ""
+    @State private var selected: Set<String> = []
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Name").font(.caption).foregroundColor(.gray)
-                    TextField("My Group", text: $name)
-                        .padding()
-                        .background(Color.white.opacity(0.05))
-                        .cornerRadius(10)
-                        .foregroundColor(.white)
-                }
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Description (optional)").font(.caption).foregroundColor(.gray)
-                    TextField("What's this group about?", text: $description, axis: .vertical)
-                        .lineLimit(3, reservesSpace: true)
-                        .padding()
-                        .background(Color.white.opacity(0.05))
-                        .cornerRadius(10)
-                        .foregroundColor(.white)
+                switch step {
+                case .details: detailsStep
+                case .members: membersStep
                 }
-
-                Spacer()
-
-                Button {
-                    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let desc = description.trimmingCharacters(in: .whitespacesAndNewlines)
-                    onCreate(trimmed, desc.isEmpty ? nil : desc)
-                } label: {
-                    HStack(spacing: 8) {
-                        if isCreating {
-                            ProgressView().tint(.white)
-                        } else {
-                            Image(systemName: "plus.circle.fill")
-                            Text("Create Group")
-                        }
-                    }
-                    .font(.headline)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(LinearGradient.xomifyGradient)
-                    .foregroundColor(.white)
-                    .cornerRadius(25)
-                }
-                .disabled(isCreating || name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-            .padding()
-            .background(Color.xomifyDark.ignoresSafeArea())
-            .navigationTitle("New Group")
+            .navigationTitle(step == .details ? "New Group" : "Add Members")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel", action: onCancel)
+                    if step == .details {
+                        Button("Cancel", action: onCancel)
+                    } else {
+                        Button("Back") { step = .details }
+                    }
                 }
             }
+            .tint(Color.xomifyGreen)
         }
-        .presentationDetents([.medium])
+        .presentationDetents(step == .details ? [.medium] : [.large])
+    }
+
+    // MARK: - Step 1
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedDescription: String? {
+        let t = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
+    }
+
+    private var detailsStep: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Name").font(.caption).foregroundStyle(.gray)
+                TextField("My Group", text: $name)
+                    .padding()
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(.rect(cornerRadius: 10))
+                    .foregroundStyle(.white)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Description (optional)").font(.caption).foregroundStyle(.gray)
+                TextField("What's this group about?", text: $description, axis: .vertical)
+                    .lineLimit(3, reservesSpace: true)
+                    .padding()
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(.rect(cornerRadius: 10))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer()
+
+            VStack(spacing: 10) {
+                Button {
+                    step = .members
+                    Task { await viewModel.loadFriends() }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "person.2.badge.plus")
+                        Text("Pick Members")
+                    }
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .padding(.vertical, 10)
+                    .background(LinearGradient.xomifyGradient)
+                    .foregroundStyle(.white)
+                    .clipShape(.rect(cornerRadius: 22))
+                }
+                .disabled(trimmedName.isEmpty)
+
+                Button {
+                    onCreate(trimmedName, [], trimmedDescription)
+                } label: {
+                    HStack(spacing: 8) {
+                        if viewModel.isCreating {
+                            ProgressView().tint(.white)
+                        } else {
+                            Text("Create without members")
+                        }
+                    }
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .frame(maxWidth: .infinity, minHeight: 40)
+                    .foregroundStyle(.white.opacity(0.8))
+                }
+                .disabled(trimmedName.isEmpty || viewModel.isCreating)
+                .accessibilityHint("Creates the group with no members")
+            }
+        }
+        .padding()
+    }
+
+    // MARK: - Step 2
+
+    private var membersStep: some View {
+        VStack(spacing: 12) {
+            HStack {
+                if selected.isEmpty {
+                    Text("Pick friends to add")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                } else {
+                    Text("\(selected.count) selected")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.xomifyGreen)
+                }
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            FriendPickerView(
+                friends: viewModel.friends,
+                excluding: [],
+                mode: .multi,
+                isLoading: viewModel.isLoadingFriends,
+                loadError: viewModel.friendsError,
+                selected: $selected,
+                onRetry: { Task { await viewModel.loadFriends() } }
+            )
+            .padding(.horizontal)
+
+            Button {
+                onCreate(trimmedName, Array(selected), trimmedDescription)
+            } label: {
+                HStack(spacing: 8) {
+                    if viewModel.isCreating {
+                        ProgressView().tint(.white)
+                    } else {
+                        Image(systemName: "plus.circle.fill")
+                        Text(confirmLabel)
+                    }
+                }
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .padding(.vertical, 10)
+                .background(LinearGradient.xomifyGradient)
+                .foregroundStyle(.white)
+                .clipShape(.rect(cornerRadius: 22))
+            }
+            .disabled(viewModel.isCreating || trimmedName.isEmpty)
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+        .padding(.top, 8)
+    }
+
+    private var confirmLabel: String {
+        switch selected.count {
+        case 0: return "Create Group"
+        case 1: return "Create with 1 Member"
+        default: return "Create with \(selected.count) Members"
+        }
     }
 }
 

--- a/docs/features/ios-groups-management/EXECUTION_LOG.md
+++ b/docs/features/ios-groups-management/EXECUTION_LOG.md
@@ -1,0 +1,33 @@
+# Execution Log: ios-groups-management
+
+**Started:** 2026-04-22
+**Branch:** `feat/ios-groups-management`
+**Base:** `master` @ `3630446`
+
+## Progress
+
+- [x] 1. Create branch `feat/ios-groups-management` off latest master.
+- [x] 2. Create `Xomify-iOS/Views/Groups/FriendPickerView.swift`.
+- [x] 3. Create `Xomify-iOS/Views/Groups/AddMemberSheet.swift`.
+- [x] 4. Extend `GroupsViewModel` (friends, loadFriends, create w/ memberEmails, delete).
+- [x] 5. Extend `GroupDetailViewModel` (friends, loadFriends, addMembers, leave, delete).
+- [x] 6. Modify `GroupsView.swift` (OWNER badge, two-step CreateGroupSheet, info banner).
+- [x] 7. Modify `GroupDetailView.swift` (toolbar menu, leave/delete dialogs, AddMemberSheet).
+- [x] 8. Build-verify (clean `xcodebuild ... clean build` = **BUILD SUCCEEDED**, no warnings in touched files).
+- [ ] 9. Commit.
+- [ ] 10. Push branch + open PR against master.
+
+## Build result
+
+- Command: `xcodebuild -project Xomify-iOS.xcodeproj -scheme Xomify-iOS -sdk iphonesimulator clean build`
+- Result: `** BUILD SUCCEEDED **`
+- Warnings in this PR's touched files: 0 (all existing warnings come from `XomifyService.swift` untouched code — pre-existing Swift 6 `@MainActor`-isolated conformance notices unrelated to scope).
+- Incremental rebuild: 1.93s real
+
+## Deviations from plan
+
+- **`GroupsViewModel.create` signature**: plan said replace the description-only signature. Implemented as `create(name:memberEmails:description:)` with `memberEmails` defaulted to `[]` and `description` defaulted to `nil`. Keeps a single call-site compatible with the one existing caller (`CreateGroupSheet.onCreate`).
+- **Toolbar chrome**: plan suggested a `Menu` replacing the refresh-only toolbar. Implemented as a `Menu` with `ellipsis.circle` label containing Refresh + destructive action. The `ProgressView` still shows during refresh so the UX doesn't regress.
+- **Info banner**: added `infoMessage` to `GroupsViewModel` (plan mentioned partial-success UX under Open Questions) and rendered it on `GroupsView` in green-tinted style, matching the red error banner pattern.
+- **CreateGroupSheet two-step**: kept on a single `NavigationStack`; step switching uses a local `@State enum` instead of nested `NavigationLink`. Keeps presentation detents adjustable (`.medium` → `.large` when picker is active).
+- **Return-from-detail refresh**: added `.onAppear` on `GroupsView` to trigger `viewModel.refresh()` so a deleted/left group's row disappears when popping back. Risk called out in plan.

--- a/docs/features/ios-groups-management/PLAN.md
+++ b/docs/features/ios-groups-management/PLAN.md
@@ -1,0 +1,315 @@
+# Plan: Xomify Social Feed — ios-groups-management
+
+**Epic**: [xomify-social-feed](../xomify-social-feed/PLAN.md)
+**Sub-feature ID**: 6 (`ios-groups-management`)
+**Status**: Ready
+**Created**: 2026-04-22
+**Last updated**: 2026-04-22
+**Scope size**: M
+**Repo(s) touched**: `xomify-ios`
+**Depends on**: 2 (`ios-nav-shell`) — merged
+
+---
+
+## Summary
+
+Polish the drawer-resident Groups screen into a first-class management surface: pick members from the accepted-friends graph (instead of typing raw emails), surface an OWNER badge on the list, add destructive owner/non-owner actions (delete vs leave) on the detail screen, and hard-gate remove-member + delete-group on ownership. The Groups view already exists from previous work — this sub-feature refines UX, wires to the friends picker, and closes the loop on the epic's "no iOS UI for shared-queue" boundary by keeping the existing tracks tab untouched.
+
+## One-liner (from epic)
+
+> Drawer-resident Groups screen: list / create / add-member / remove-member. Wires to existing `groups_*` lambdas.
+
+---
+
+## Critical decisions inherited from epic (do not re-litigate)
+
+- **Groups = filter layer on iOS** (epic decision #7). Existing `groups_add_song` / `groups_song_status` / tracks tab **stays** — already shipped — but no new shared-queue surfaces get added in this PR.
+- **No new backend work.** Every endpoint this PR needs is already live and already wired in `XomifyService`.
+- **Lives in the drawer**, not the tab bar. Drawer destination `.groups` already routes to `GroupsView()` (see `DrawerView.swift:126`).
+- **MVVM constraint**: views never touch `XomifyService` directly — go through a VM. Already honored by `GroupsViewModel` / `GroupDetailViewModel`.
+
+---
+
+## Investigation findings
+
+Verified against the tree under `Xomify-iOS/` on `master` (post-nav-shell merge):
+
+- **Drawer wiring is live**: `Xomify-iOS/Views/Shell/DrawerView.swift:126` — `case .groups: GroupsView()` inside `.navigationDestination(for: DrawerDestination.self)`. No shell-level change needed. `DrawerDestination.groups` already exists in `NavigationStore.swift`.
+- **GroupsView already exists** at `Xomify-iOS/Views/GroupsView.swift` — list + create sheet + navigation to detail. Uses `GroupsViewModel`. Shows member count + track count but **does not display an owner badge** on the list row.
+- **GroupDetailView already exists** at `Xomify-iOS/Views/GroupDetailView.swift` — segmented Tracks / Members tabs, member add via typed email, owner-only remove button on members. **No leave-group / delete-group actions on the screen**; VM only has leave in the list VM (`GroupsViewModel.leave`).
+- **GroupsViewModel** at `Xomify-iOS/ViewModels/GroupsViewModel.swift` — `load`, `refresh`, `create`, `leave`. **Missing**: `delete` (owner), friends list for picker.
+- **GroupDetailViewModel** at `Xomify-iOS/ViewModels/GroupDetailViewModel.swift` — `load`, `refresh`, `addMember`, `removeMember`, plus song CRUD (out of scope for this PR). **Missing**: `leave`, `delete`, friends list for picker.
+- **XomifyService** is already an `actor` at `Xomify-iOS/Services/XomifyService.swift` and **has every endpoint we need**: `listGroups`, `createGroup`, `getGroupInfo`, `addMember`, `removeMember`, `leaveGroup`, `removeGroup` (delete), plus `getAllFriends` for the picker. Also has `updateGroup` if we want rename in the future.
+- **Models** are complete at `Xomify-iOS/Models/SocialModels.swift`: `XomifyGroup` (has `ownerEmail`), `GroupMember` (has `isOwner`), `GroupsListResponse`, `GroupInfo`, `GroupCreateResponse`, `SuccessResponse`, and `Friend` / `FriendsAllResponse` for the picker.
+- **Project layout**: `PBXFileSystemSynchronizedRootGroup` — adding `.swift` files under `Xomify-iOS/` needs no pbxproj edits.
+- **Build scheme**: `Xomify-iOS` against `Xomify-iOS.xcodeproj`.
+
+### Backend endpoint shapes — no mismatches
+
+Every endpoint the epic assumed exists and matches the service call. The epic spec listed `GET /groups/detail`; the actual path is `GET /groups/info`. Already reflected in `XomifyService.getGroupInfo`. The epic spec listed `DELETE /groups/delete`; the actual call is `POST /groups/remove`. Already reflected in `XomifyService.removeGroup`. **No backend PR required.**
+
+---
+
+## Approach
+
+Minimum-delta refinement. The surfaces already exist — we add (a) friend-picker sheets that replace the typed-email flows, (b) an owner badge on the list, (c) `delete` to `GroupsViewModel`, and (d) `leave` / `delete` toolbar actions to `GroupDetailView` with `.confirmationDialog`s. The friends list for pickers is loaded lazily on sheet open via `xomify.getAllFriends(email:)` → `.accepted`.
+
+**Optimistic UI** for member add / remove on detail: mutate `members` locally first, roll back on throw. Create-group stays pessimistic (we need the server's generated `groupId` back). Leave / delete are pessimistic — we wait on success before navigating out.
+
+---
+
+## Target screens
+
+| Screen | Route | Status |
+|--------|-------|--------|
+| `GroupsListView` (`GroupsView.swift`) | Drawer `.groups` destination | **Exists** — add owner badge on rows. |
+| `GroupDetailView` | Pushed from list | **Exists** — add leave + delete toolbar actions. |
+| `CreateGroupSheet` | Modal from `GroupsView` + | **Exists** — extend with friend-picker step (name first, then pick members). |
+| `AddMemberSheet` (new) | Modal from `GroupDetailView` `person.badge.plus` | **New** — replaces inline typed-email row on the Members tab. |
+| `FriendPickerView` (new, shared) | Used by both sheets | **New** — multi-select (create) or single-select (add) friend list with search + exclusion set. |
+
+The existing typed-email `addMemberBar` stays as a fallback for the edge case of adding a non-friend by email — hidden behind a disclosure ("Add someone who isn't a friend yet"). Default path is the picker.
+
+---
+
+## ViewModels
+
+### `GroupsViewModel` — extend
+
+Add:
+
+- `friends: [Friend] = []` — accepted friends cache for the create sheet's picker.
+- `isLoadingFriends: Bool` / `friendsError: String?`.
+- `func loadFriends() async` — calls `xomify.getAllFriends(email:).accepted ?? []`. Cache so re-opening the sheet is instant.
+- `@discardableResult func create(name:String, memberEmails:[String]) async -> XomifyGroup?` — replaces the description-only signature. Under the hood: create group, then fan-out-add each picked member email with `xomify.addMember`. If adds partially fail, surface "Group created, N of M members added — try re-adding from the group."
+- `@discardableResult func delete(_ group: XomifyGroup) async -> Bool` — calls `xomify.removeGroup`; on success removes from `groups` and returns `true`. Owner-only gate done by the caller (view).
+
+Keep: `load`, `refresh`, `leave` (used on detail screen too).
+
+### `GroupDetailViewModel` — extend
+
+Add:
+
+- `friends: [Friend] = []` (accepted friends for the add-member picker).
+- `func loadFriends() async`.
+- `func addMembers(_ emails: [String]) async` — loops `xomify.addMember` with optimistic local `members` insert + rollback per-failure. Clears picker on success.
+- `@discardableResult func leave() async -> Bool` — calls `xomify.leaveGroup`; returns `true` on success so the view can `dismiss()`.
+- `@discardableResult func delete() async -> Bool` — calls `xomify.removeGroup` (owner-only; caller verifies `group?.ownerEmail == userEmail` first).
+
+Keep: `load`, `refresh`, `addMember` (single), `removeMember`. Song methods untouched.
+
+**Note on concurrency**: both VMs stay `@Observable` + `@MainActor`. They already are. No changes to the service `actor`.
+
+---
+
+## Service layer
+
+**No changes required.** Every call we need is already exposed on `XomifyService`:
+
+- `listGroups(email:)` → `GroupsListResponse`
+- `createGroup(email:, name:, description:)` → `GroupCreateResponse`
+- `getGroupInfo(groupId:, email:)` → `GroupInfo`
+- `addMember(email:, groupId:, memberEmail:)` → `SuccessResponse`
+- `removeMember(email:, groupId:, memberEmail:)` → `SuccessResponse`
+- `leaveGroup(email:, groupId:)` → `SuccessResponse`
+- `removeGroup(email:, groupId:)` → `SuccessResponse` (maps to backend `POST /groups/remove` — functional "delete")
+- `getAllFriends(email:)` → `FriendsAllResponse` (accepted bucket feeds the picker)
+
+No new models. All shapes verified in `Xomify-iOS/Models/SocialModels.swift`.
+
+---
+
+## Affected Files / Components
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `Xomify-iOS/Views/Groups/FriendPickerView.swift` | Reusable multi/single-select friend picker with search. Generic over selection mode. |
+| `Xomify-iOS/Views/Groups/AddMemberSheet.swift` | Sheet shown from `GroupDetailView`; hosts `FriendPickerView` (excluding current members) + a confirm button. |
+
+### Modified files
+
+| File | Change | Why |
+|------|--------|-----|
+| `Xomify-iOS/Views/GroupsView.swift` | Show OWNER badge in `groupRow` when `group.ownerEmail == viewModel.userEmail`. Extend `CreateGroupSheet` with a second step: name → pick friends (multi-select). Replace current onCreate signature with `(name, selectedEmails, description?)`. | Close owner-affordance gap + swap email-typing for friend picker. |
+| `Xomify-iOS/Views/GroupDetailView.swift` | Add toolbar `Menu` with "Leave Group" (non-owner) or "Delete Group" (owner), each gated by `.confirmationDialog`. Replace inline `addMemberBar` with a button that presents `AddMemberSheet`. Keep typed-email row behind a "Add by email" disclosure row inside the sheet. | Destructive-action parity + picker-first UX. |
+| `Xomify-iOS/ViewModels/GroupsViewModel.swift` | Add `friends`, `loadFriends()`, `delete(_:)`, extend `create` to accept `memberEmails`. | See ViewModel section. |
+| `Xomify-iOS/ViewModels/GroupDetailViewModel.swift` | Add `friends`, `loadFriends()`, `addMembers([String])`, `leave()`, `delete()`. | See ViewModel section. |
+
+### Not touched
+
+- `Xomify-iOS/Services/XomifyService.swift` — zero changes.
+- `Xomify-iOS/Models/SocialModels.swift` — zero changes.
+- `Xomify-iOS/Views/Shell/*` — zero changes. Drawer already routes `.groups → GroupsView()`.
+- `Xomify-iOS/Views/GroupDetailView.swift` **Tracks tab** — zero changes. Epic boundary.
+
+No backend changes. No Angular changes.
+
+---
+
+## Drawer wiring confirmation
+
+`DrawerView.swift` already has:
+
+```swift
+case .groups:
+    GroupsView()
+```
+
+inside `.navigationDestination(for: DrawerDestination.self)`. Drawer owns its own `NavigationStack(path: $navStore.drawerPath)`, so pushing `GroupDetailView` from the list via a `NavigationLink` works inside the drawer's stack. **No MainShell, HeaderBar, or NavigationStore edits.**
+
+---
+
+## Implementation Steps
+
+- [ ] **1. Branch**
+  - [ ] `git checkout -b feat/ios-groups-management` off `master`.
+- [ ] **2. FriendPickerView (shared component)**
+  - [ ] Create `Xomify-iOS/Views/Groups/FriendPickerView.swift`.
+  - [ ] API: `init(friends: [Friend], excluding: Set<String> = [], selectionMode: Mode, onConfirm: (Set<String>) -> Void, onCancel: () -> Void)`.
+  - [ ] `enum Mode { case single, multi }`.
+  - [ ] Body: search field (filters by `label` / `targetEmail`) + `List { ... Toggle / Button rows }` + confirm button.
+  - [ ] Empty state: "No friends yet. Add some from the Friends drawer entry."
+  - [ ] Respect `.claude/rules/ios.md`: `foregroundStyle`, `Color.xomifyDark`, no force unwraps.
+- [ ] **3. GroupsViewModel extensions**
+  - [ ] Add `friends`, `isLoadingFriends`, `friendsError`.
+  - [ ] Add `loadFriends()` calling `xomify.getAllFriends(email:)` — populate `friends` from the `accepted` bucket.
+  - [ ] Replace `create(name:description:)` with `create(name:memberEmails:description:)`. Compile-check callsites (one: `GroupsView.CreateGroupSheet.onCreate`).
+  - [ ] Add `delete(_:)` calling `xomify.removeGroup`; remove from `groups` on success.
+- [ ] **4. CreateGroupSheet rework**
+  - [ ] Two-step flow inside the same sheet: Step 1 = name + description; Step 2 = pick friends (embed `FriendPickerView` in `.multi` mode). "Back" returns to step 1.
+  - [ ] Confirm button on step 2 calls `onCreate(name, selectedEmails, description)`.
+  - [ ] Skip-step-2 affordance: "Create without members" button on step 1 that bypasses the picker with an empty set. Useful when friend list is empty.
+  - [ ] On `.task`: `await viewModel.loadFriends()`.
+- [ ] **5. GroupsView list row OWNER badge**
+  - [ ] In `groupRow`, when `group.ownerEmail == viewModel.userEmail`, render the same OWNER capsule already used in `GroupDetailView.memberRow` (match style: `Color.xomifyPurple.opacity(0.2)` / `foregroundColor(.xomifyPurple)`, font `.caption2` semibold).
+  - [ ] VoiceOver label on the row announces "Group Name, owner, N members, M tracks" when owned.
+- [ ] **6. GroupDetailViewModel extensions**
+  - [ ] Add `friends`, `loadFriends()`.
+  - [ ] Add `addMembers(_ emails: [String])` — optimistic inserts (append skeleton `GroupMember(email:)` with `isOwner=false`), call `xomify.addMember` per email, on failure remove the skeleton and surface the error. On complete success do a `refresh()` to get server-canonical display names / joinedAt.
+  - [ ] Add `leave()` / `delete()` — pessimistic, return `Bool`.
+- [ ] **7. AddMemberSheet**
+  - [ ] Create `Xomify-iOS/Views/Groups/AddMemberSheet.swift`.
+  - [ ] Content: `FriendPickerView` in `.multi` mode with `excluding: Set(viewModel.members.map { $0.email })`.
+  - [ ] Below picker: disclosure group "Add by email" — the old `TextField` + `person.badge.plus` button as a fallback. Keeps the existing `viewModel.addMember()` call path.
+  - [ ] Confirm calls `viewModel.addMembers(Array(selected))`.
+- [ ] **8. GroupDetailView destructive actions**
+  - [ ] Replace the refresh-only toolbar with a `Menu`:
+    - `Button("Refresh", systemImage: "arrow.clockwise") { Task { await viewModel.refresh() } }`.
+    - If `viewerEmail == group?.ownerEmail`: `Button(role: .destructive) { showDeleteConfirm = true } label: { Label("Delete Group", systemImage: "trash") }`.
+    - Else: `Button(role: .destructive) { showLeaveConfirm = true } label: { Label("Leave Group", systemImage: "rectangle.portrait.and.arrow.right") }`.
+  - [ ] Two `.confirmationDialog` modifiers. Destructive button text: "Delete Group" / "Leave Group". Include a `Button("Cancel", role: .cancel) {}` in each.
+  - [ ] On success: call `dismiss` via `@Environment(\.dismiss)` so the user pops back to `GroupsView`. If delete, also ensure `GroupsViewModel` gets told to refresh — simplest: `.task(id: navStore.drawerPath)` on `GroupsView` already reloads on return. If not, add an explicit `viewModel.refresh()` in `onAppear`.
+  - [ ] Replace the inline `addMemberBar` on the Members tab with a single "Add members" button that toggles `showingAddMemberSheet`.
+- [ ] **9. Accessibility pass**
+  - [ ] All destructive buttons: `.accessibilityLabel("Leave group")` / `.accessibilityLabel("Delete group")`, `.accessibilityHint("Opens a confirmation dialog")`.
+  - [ ] Remove-member trash icon: `.accessibilityLabel("Remove <member label>")`, `.accessibilityHint("Removes this member from the group")`.
+  - [ ] All action buttons ≥ 44×44pt (SwiftUI `Button` defaults are fine; verify trash and plus icons expand tap area).
+  - [ ] Picker rows expose `.accessibilityAddTraits(.isButton)` and announce selected state.
+- [ ] **10. Error UX**
+  - [ ] Continue using the existing `overlay(alignment: .top) { if let error = viewModel.errorMessage ... }` red banner pattern already in `GroupDetailView`. Extend `GroupsView` to show the same banner (currently only `errorState` full-screen exists — add an inline banner for non-fatal errors like partial-create failures).
+  - [ ] Each VM action sets `errorMessage` on throw; no silent swallows. Existing pattern already honors this.
+- [ ] **11. Build**
+  - [ ] `xcodebuild -project Xomify-iOS.xcodeproj -scheme Xomify-iOS -sdk iphonesimulator clean build`. Resolve any strict-concurrency warnings introduced by the new code.
+- [ ] **12. Simulator smoke (manual, Dom to run)**
+  - [ ] Sign in → open drawer → Groups.
+  - [ ] Create group: typed name + picked 1 friend → verify OWNER badge shows on the new row.
+  - [ ] Open new group → Members tab → Add members → pick another friend → confirm. Verify appears in list.
+  - [ ] As owner: remove a member via the member-row trash. Confirm.
+  - [ ] Open toolbar menu → Delete Group → confirm → verify list excludes the group on return.
+  - [ ] Create a second group, add self only, switch Spotify accounts or simulate a non-owner (alt: have the member-side account run the flow) → toolbar shows **Leave** not **Delete**.
+  - [ ] Verify "Add by email" fallback still works for typing a non-friend email.
+- [ ] **13. PR**
+  - [ ] Commit: `#<issue> feat(ios): groups management — friend picker, owner badge, leave/delete`.
+  - [ ] PR title: `feat(ios): groups management — friend picker, owner badge, leave/delete`.
+  - [ ] Body: `Closes #<issue>`, 2 screenshots (list with OWNER badge, detail with Delete menu), smoke checklist above.
+  - [ ] Request `code-reviewer` agent pass.
+
+---
+
+## Accessibility
+
+- **Destructive actions**: every leave / delete / remove control has a `.accessibilityLabel`, `.accessibilityHint`, and goes through a `.confirmationDialog`. No single-tap destructive paths.
+- **Owner badge**: `.accessibilityLabel("Owner")` on the capsule; owner state is also announced in the parent row label.
+- **Picker rows**: `.accessibilityValue("Selected")` / `"Not selected"` when in multi-select mode.
+- **Touch targets**: 44×44pt minimum on every tappable control. SwiftUI `Button` + SF Symbol default padding verified with Accessibility Inspector during smoke.
+- **Dynamic Type**: all screens already use `.font(.caption)` / `.font(.subheadline)` — test at `.accessibility3`. Owner badge may wrap; that's fine.
+- **VoiceOver row announcement**: group list row uses `.accessibilityElement(children: .combine)` + a custom label ("Group Name, owner, 4 members").
+
+---
+
+## Build / test commands
+
+```bash
+# Clean build
+xcodebuild -project Xomify-iOS.xcodeproj \
+           -scheme Xomify-iOS \
+           -sdk iphonesimulator \
+           clean build
+
+# Smoke run
+open -a Simulator
+xcrun simctl boot "iPhone 15" 2>/dev/null || true
+xcodebuild -project Xomify-iOS.xcodeproj \
+           -scheme Xomify-iOS \
+           -sdk iphonesimulator \
+           -destination 'platform=iOS Simulator,name=iPhone 15' \
+           build
+```
+
+`.claude/CLAUDE.md` says `echo "no tests configured"` — no XCTest target. VM logic (friend-picker filter, delete, addMembers rollback) is small enough that manual smoke covers it. If the `ios-engineer` agent wants to add a minimal XCTest target in this PR, flag for Dom's approval first — don't expand scope.
+
+---
+
+## PR shape
+
+- **Branch**: `feat/ios-groups-management`
+- **Commit**: `#<issue-number> feat(ios): groups management — friend picker, owner badge, leave/delete`
+- **PR title**: `feat(ios): groups management — friend picker, owner badge, leave/delete`
+- **PR description**: `Closes #<issue-number>`, screenshots (list with OWNER badge, detail menu open, add-member picker), the simulator-smoke checklist above.
+- **Reviewer**: `code-reviewer` agent.
+- **Merge gate**: green build + manual smoke pass.
+
+---
+
+## Out of Scope
+
+- **Invite-a-friend CTA** — that's `ios-friends-management` (#7). Do not put an Invite button on the Groups screens.
+- **Groups-as-shared-queue UI** — the existing Tracks tab in `GroupDetailView` already exists and stays. We don't add new shared-queue entry points, and we don't remove the existing ones either. Epic decision #7.
+- **Feed-side group filter chips** — that's `ios-feed` (#5), consuming `listGroups`.
+- **Group rename / edit description** — `updateGroup` exists on the service but no UI is planned here. Defer.
+- **Group avatar / cover image** — no backend support; defer.
+- **Push notification on member add** — not backend-supported; defer.
+- **XCTest scaffolding** — project has none; adding one is out of scope.
+- **Drawer / NavigationStore changes** — already done in #2.
+
+---
+
+## Risks / Tradeoffs
+
+- **Backend shape mismatch risk**: none found. Epic spec mentioned `GET /groups/detail` and `DELETE /groups/delete` but actual endpoints are `GET /groups/info` and `POST /groups/remove`, and these are already correctly wired in `XomifyService`. **No backend PR needed.**
+- **Optimistic add-member rollback complexity**: looping `addMember` per picked friend means partial-failure state. Mitigation: accept partial success, surface the count ("N of M added"), and drive a `refresh()` to get the canonical list. Worse UX than atomic batch but matches the current single-member backend shape.
+- **Pessimistic vs optimistic on create-and-add-members**: accepted pessimistic for create-group call (need `groupId`) + optimistic for post-create adds. Risk: group appears without all members if a network blip hits mid-fan-out. Mitigation: explicit toast + refresh button.
+- **Drawer `NavigationStack` vs sheet presentation**: sheets on a push-stack inside the drawer can fight dismiss gestures on small devices. Mitigation: use `.sheet(isPresented:)` on the leaf view (`GroupDetailView`), not on the drawer root — already the pattern in the existing code.
+- **Non-friend email fallback**: keeping the typed-email path risks letting owners add random emails. Accepted — mirrors the current behavior; backend already validates membership rules.
+- **Removing a member who is the last non-owner**: no server-side guardrail we rely on. Accepted — owners can shrink their group to just themselves by design.
+- **Delete-group navigation race**: after `delete()` success we need to `dismiss()` and have the list reload. Risk: stale row flashes before refresh. Mitigation: `GroupsView` calls `viewModel.refresh()` in `.onAppear` on return from detail.
+
+---
+
+## Open Questions
+
+- [ ] **Confirm smoke-test account pair**: do we have two Spotify dev accounts ready to test the owner vs non-owner branch end-to-end, or do we stub a second `ownerEmail` for the smoke? Either works — flag before step 12.
+- [ ] **Disclosure wording for the non-friend typed-email fallback**: "Add by email" vs "Add someone not in your friends list"? Minor copy call. Default to the shorter.
+- [ ] **Should `GroupsView.create` take the description field through the picker flow, or drop description entirely?** Current `CreateGroupSheet` has a description field. Recommend **keep it** in step 1, since the backend supports it and it's already wired. Free UX sugar.
+- [ ] **Partial-success toast UX**: full-screen alert or inline banner for "3 of 5 members added"? Recommend the existing top-banner pattern used by `GroupDetailView` — consistent and non-blocking.
+
+---
+
+## Skills / Agents to Use
+
+- **ios-engineer agent**: primary implementer. Knows `@Observable`, modern SwiftUI, MVVM, strict concurrency, and already has context on the navigation shell from sub-feature #2.
+- **ios-standards skill**: invoke during step 2 (`FriendPickerView`) + step 6 (VM extensions) to double-check `@Observable` + modern SwiftUI idioms and reject any `ObservableObject` / `@Published` drift.
+- **code-reviewer agent**: single mandatory pre-merge review. Focus: concurrency warnings, owner-gate correctness (`viewerEmail == group.ownerEmail` checks), destructive-action `.confirmationDialog` coverage, accessibility labels.
+- **test-writer agent**: not required this PR — no XCTest target exists. If Dom approves adding one, pair on `GroupsViewModel.create` + `GroupDetailViewModel.addMembers` rollback tests only.


### PR DESCRIPTION
Polish-work refinement of the drawer-resident Groups screen. Part of the **[xomify-social-feed](../../docs/features/xomify-social-feed/PLAN.md)** epic, sub-feature **#6 ([ios-groups-management](../../docs/features/ios-groups-management/PLAN.md))**.

> **Scope note — polish vs greenfield:** The Groups surface, `GroupsViewModel`/`GroupDetailViewModel`, and every lambda call were already shipped. This PR does **not** build the screen from scratch — it layers UX polish on top: a friend picker replacing raw-email entry, an OWNER badge on the list, and destructive action parity (leave / delete) on the detail screen. Zero service/model changes.

## What changed

**New files**
- `Xomify-iOS/Views/Groups/FriendPickerView.swift` — reusable multi/single-select picker with search, exclusion set, and empty/error/no-match states.
- `Xomify-iOS/Views/Groups/AddMemberSheet.swift` — sheet-hosted picker for `GroupDetailView`, with an "Add by email" disclosure fallback for non-friend invites.

**Modified**
- `Xomify-iOS/Views/GroupsView.swift` — OWNER capsule on list rows, two-step `CreateGroupSheet` (details → friend picker), info banner for partial-success creates, refresh-on-reappear so deleted/left groups don't linger.
- `Xomify-iOS/Views/GroupDetailView.swift` — toolbar `Menu` with Refresh + Leave / Delete (owner-gated). Both destructive actions go through `.confirmationDialog`. Members tab's inline typed-email bar is replaced by an "Add members" button that presents `AddMemberSheet`.
- `Xomify-iOS/ViewModels/GroupsViewModel.swift` — `friends` + `loadFriends()`, `create(name:memberEmails:description:)` with fan-out `addMember`, `delete(_:)`, `infoMessage` for partial-success UX.
- `Xomify-iOS/ViewModels/GroupDetailViewModel.swift` — `friends` + `loadFriends()`, batched `addMembers([String])` with optimistic inserts and per-email rollback, `leave()` / `delete()` returning `Bool`.

**Not touched** (per epic boundary)
- `XomifyService.swift` — every needed endpoint already wired.
- `SocialModels.swift` — `XomifyGroup.ownerEmail`, `GroupMember.isOwner`, `Friend`, `FriendsAllResponse` already present.
- Nav shell / `DrawerView` routing — `.groups → GroupsView()` already live from `ios-nav-shell`.
- `GroupDetailView` Tracks tab — epic decision #7 keeps the existing shared-queue surface untouched.

## Why it matters

- Picker-first flow means adding members no longer requires memorizing emails — the graph of accepted friends becomes the default input.
- OWNER badge on the list answers "is this mine?" without drilling in.
- Leave / Delete parity on detail closes the destructive-action gap — previously only the **list** had a `leave` path and **no** `delete` anywhere on iOS.
- Owner gating is enforced at the view layer (`viewerEmail == group.ownerEmail`) so the Delete action is only wired for owners.

## Build

```
xcodebuild -project Xomify-iOS.xcodeproj -scheme Xomify-iOS -sdk iphonesimulator clean build
** BUILD SUCCEEDED **
```

Zero warnings / errors in files touched by this PR. Pre-existing Swift 6 `@MainActor` isolation notices in `XomifyService.swift` are untouched and out of scope.

## Smoke plan (to run in sim)

- [ ] Sign in → drawer → Groups.
- [ ] Create group: name + description (step 1) → pick 1 friend (step 2) → confirm. OWNER badge appears on new row.
- [ ] Open group → Members tab → "Add members" → pick a friend → confirm. Member appears (optimistic) then refreshes with canonical `displayName`.
- [ ] Members tab → trash on a member → removes (optimistic).
- [ ] Toolbar menu → "Delete Group" → dialog → confirm. Navigates back; row no longer in list.
- [ ] Non-owner account: menu shows "Leave Group" (not Delete). Dialog → confirm → back to list, row gone.
- [ ] "Add by email" disclosure still lets you type a non-friend email as a fallback.

## Accessibility

- Destructive actions use `.confirmationDialog` (no single-tap destruction).
- OWNER badge announces "Owner"; rows combine into "Group Name, owner, N members, M tracks".
- Picker rows: `.accessibilityValue("Selected" / "Not selected")`, `.accessibilityAddTraits(.isButton)`.
- 44×44pt touch targets on all icon buttons (trash, person.badge.minus, plus).

## Links

- Epic plan: `docs/features/xomify-social-feed/PLAN.md`
- Sub-feature plan: `docs/features/ios-groups-management/PLAN.md`
- Execution log: `docs/features/ios-groups-management/EXECUTION_LOG.md`