### PR TITLE
ci: auto-bump TestFlight marketing version from commit count

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -45,8 +45,14 @@ jobs:
       - name: Compute version and build number
         id: version
         run: |
-          MARKETING_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
-          MARKETING_VERSION=${MARKETING_VERSION:-1.0.0}
+          # Marketing version: 1.0.<master-commit-count>. Prefers the latest vX.Y.Z tag when one exists.
+          TAGGED_VERSION=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//' || true)
+          if [ -n "$TAGGED_VERSION" ]; then
+            MARKETING_VERSION="$TAGGED_VERSION"
+          else
+            COMMIT_COUNT=$(git rev-list --count HEAD)
+            MARKETING_VERSION="1.0.${COMMIT_COUNT}"
+          fi
           BUILD_NUMBER=$(date +%Y%m%d%H%M)
           echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Every TestFlight build was shipping as 1.0.0 because no \`vX.Y.Z\` tags exist and the workflow fell through to the default.
- Switch to \`1.0.<commit-count-on-master>\` as the fallback — auto-increments on every merge with no manual tagging required.
- Explicit \`vX.Y.Z\` tags still win when we want to pin a version.

## Test plan
- [ ] Merge to master, confirm next deploy run prints a non-1.0.0 marketing version in the "Compute version and build number" step.
- [ ] Confirm TestFlight lists the new version under builds for com.Xomware.Xomify.