### PR TITLE
feat(ios): friends management — invites, remove-friend, deep links

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				"Xomify-iOS.entitlements",
 			);
 			target = 5291E4C52F0822CF00A10C3E /* Xomify-iOS */;
 		};
@@ -284,6 +285,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Xomify-iOS/Xomify-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
@@ -319,6 +321,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Xomify-iOS/Xomify-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;

--- a/Xomify-iOS/App/Xomify_iOSApp.swift
+++ b/Xomify-iOS/App/Xomify_iOSApp.swift
@@ -6,6 +6,20 @@ struct Xomify_iOSApp: App {
         WindowGroup {
             ContentView()
                 .preferredColorScheme(.dark) // Force dark mode for Xomify branding
+                .onOpenURL { url in
+                    // Route deep links. Invite URLs (Universal Links and custom
+                    // scheme) are stashed on `InviteCoordinator`; the Friends
+                    // screen picks them up once it loads.
+                    InviteCoordinator.shared.handle(url)
+                }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    // Universal Link handoff — the user tapped a Safari/Messages
+                    // link that resolved to us. Extract the URL and delegate to
+                    // the same coordinator path.
+                    if let url = activity.webpageURL {
+                        InviteCoordinator.shared.handle(url)
+                    }
+                }
         }
     }
 }

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -217,6 +217,61 @@ struct InviteAcceptResponse: Codable, Sendable {
     let friendEmail: String?
 }
 
+// MARK: - Pending Invite
+
+/// A single deep-link invite that has been sent to the current user and is
+/// awaiting their accept/decline action. Distinct from `Friend` which represents
+/// an accepted social connection or an in-app friend request.
+struct PendingInvite: Codable, Sendable, Identifiable, Hashable {
+    let inviteCode: String
+    let senderEmail: String
+    let senderDisplayName: String?
+    let senderAvatar: String?
+    let createdAt: String?
+    let expiresAt: String?
+
+    var id: String { inviteCode }
+
+    /// Human-facing sender label.
+    var label: String {
+        if let name = senderDisplayName, !name.isEmpty { return name }
+        return senderEmail
+    }
+
+    /// Parse createdAt into a Date (best-effort).
+    var createdAtDate: Date? {
+        guard let createdAt else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        if let date = formatter.date(from: createdAt) {
+            return date
+        }
+        return ISO8601DateFormatter().date(from: createdAt)
+    }
+
+    /// Short relative time string ("3h ago", "just now").
+    var relativeTime: String {
+        guard let date = createdAtDate else { return "" }
+        let interval = Date().timeIntervalSince(date)
+        if interval < 60 { return "just now" }
+        if interval < 3_600 { return "\(Int(interval / 60))m ago" }
+        if interval < 86_400 { return "\(Int(interval / 3_600))h ago" }
+        if interval < 604_800 { return "\(Int(interval / 86_400))d ago" }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+/// Response for `GET /invites/pending?email=...`.
+struct PendingInvitesResponse: Codable, Sendable {
+    let email: String?
+    let invites: [PendingInvite]?
+    let totalCount: Int?
+}
+
 // MARK: - Friends
 
 /// A single friend / friend-request row in any bucket.

--- a/Xomify-iOS/Services/InviteCoordinator.swift
+++ b/Xomify-iOS/Services/InviteCoordinator.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Parses Universal Link and custom-scheme invite URLs and stashes the code
+/// so the Friends screen can consume it once the user is authenticated.
+///
+/// Accepted shapes:
+///   - Universal Link: `https://xomify.xomware.com/invite/<code>`
+///   - Custom scheme:  `xomify://invite/<code>`
+///
+/// Any invite code captured here is "pending" until the Friends screen sees it
+/// and either auto-accepts (if authenticated) or waits for login. After the
+/// code is handed off, callers clear `pendingInviteCode` via `consume()`.
+@Observable
+@MainActor
+final class InviteCoordinator {
+
+    /// Shared singleton — matches the rest of the app's `.shared` service pattern.
+    static let shared = InviteCoordinator()
+
+    /// Host for Universal Link-style invite URLs.
+    static let universalLinkHost = "xomify.xomware.com"
+
+    /// Custom URL scheme (shared with Spotify OAuth callback, disambiguated by path).
+    static let customScheme = "xomify"
+
+    /// Captured invite code from the most recent deep link. Cleared via `consume()`
+    /// once the Friends screen has handled it.
+    private(set) var pendingInviteCode: String?
+
+    private init() {}
+
+    /// Parse an incoming URL and, if it's an invite link, capture the code.
+    /// Safe to call with any URL — non-invite URLs are ignored.
+    /// - Returns: `true` if the URL was recognized as an invite link.
+    @discardableResult
+    func handle(_ url: URL) -> Bool {
+        guard let code = Self.extractInviteCode(from: url) else {
+            return false
+        }
+        pendingInviteCode = code
+        print("🔗 InviteCoordinator: captured invite code \(code.prefix(6))… from \(url.absoluteString)")
+        return true
+    }
+
+    /// Pull the pending code (if any) and clear it. Intended for a one-shot
+    /// consumer: once Friends has auto-acted on it, we don't want to re-act on
+    /// a re-render.
+    func consume() -> String? {
+        defer { pendingInviteCode = nil }
+        return pendingInviteCode
+    }
+
+    // MARK: - Parsing
+
+    /// Extract an invite code from a deep-link URL, if the URL matches one of
+    /// our known shapes. Returns `nil` for unrelated URLs.
+    ///
+    /// Accepts:
+    ///   - `https://xomify.xomware.com/invite/<code>` (Universal Link)
+    ///   - `xomify://invite/<code>` (custom scheme)
+    static func extractInviteCode(from url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let scheme = components.scheme?.lowercased()
+        let host = components.host?.lowercased()
+
+        // Universal Link shape — path starts with /invite/<code>
+        if scheme == "https", host == universalLinkHost {
+            return inviteCode(fromPath: components.path)
+        }
+
+        // Custom scheme shape — xomify://invite/<code>
+        // Note: for custom schemes `host` is typically the authority, so the
+        // <code> might land in `host` or in `path` depending on URL shape.
+        // We accept both `xomify://invite/<code>` (host=invite, path=/<code>)
+        // and `xomify:///invite/<code>` (empty host, path=/invite/<code>).
+        if scheme == customScheme {
+            if host == "invite" {
+                let trimmed = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            if host?.isEmpty ?? true {
+                return inviteCode(fromPath: components.path)
+            }
+        }
+
+        return nil
+    }
+
+    /// Given a path like `/invite/<code>` (or `/invite/<code>/`), return `<code>`.
+    private static func inviteCode(fromPath path: String) -> String? {
+        let parts = path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard parts.count >= 2, parts[0].lowercased() == "invite" else { return nil }
+        let code = parts[1]
+        return code.isEmpty ? nil : code
+    }
+}

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -121,6 +121,24 @@ actor XomifyService {
         ])
     }
 
+    /// List deep-link invites awaiting accept/decline for this user.
+    /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
+    /// Until the backend ships, this will raise a server error; the UI renders
+    /// an empty state against that failure.
+    func listPendingInvites(email: String) async throws -> PendingInvitesResponse {
+        try await network.xomifyGet("/invites/pending", queryParams: ["email": email])
+    }
+
+    /// Decline a deep-link invite.
+    /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
+    @discardableResult
+    func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse {
+        try await network.xomifyPost("/invites/decline", body: [
+            "email": email,
+            "inviteCode": inviteCode
+        ])
+    }
+
     // MARK: - Friends
 
     /// Send a friend request.

--- a/Xomify-iOS/Services/XomifyServicing.swift
+++ b/Xomify-iOS/Services/XomifyServicing.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Protocol surface for `FriendsViewModel` (and related screens) to interact with
+/// the Xomify backend. Extracted to enable mocking in unit tests without having
+/// to stub the full `XomifyService` actor.
+///
+/// Only the operations exercised by Friends / Invites flows are included here —
+/// keep this surface tight and expand incrementally as other screens adopt it.
+protocol XomifyServicing: Sendable {
+
+    // MARK: - Friends
+
+    func getAllFriends(email: String) async throws -> FriendsAllResponse
+    func listUsers(email: String) async throws -> UserListResponse
+
+    @discardableResult
+    func requestFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+
+    @discardableResult
+    func acceptFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+
+    @discardableResult
+    func rejectFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+
+    @discardableResult
+    func removeFriend(email: String, friendEmail: String) async throws -> SuccessResponse
+
+    // MARK: - Invites
+
+    func createInvite(email: String) async throws -> InviteCreateResponse
+
+    func acceptInvite(email: String, inviteCode: String) async throws -> InviteAcceptResponse
+
+    /// List deep-link invites sent to this user and awaiting accept/decline.
+    /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
+    func listPendingInvites(email: String) async throws -> PendingInvitesResponse
+
+    /// Decline a deep-link invite.
+    /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
+    @discardableResult
+    func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse
+}
+
+// Conformance on the real service — ensures production callers can keep using
+// the existing singleton while tests inject a mock.
+extension XomifyService: XomifyServicing {}

--- a/Xomify-iOS/ViewModels/FriendsViewModel.swift
+++ b/Xomify-iOS/ViewModels/FriendsViewModel.swift
@@ -1,7 +1,12 @@
 import Foundation
 
-/// ViewModel for the Friends screen. Three buckets: accepted friends, requests
-/// (incoming + outgoing), and a discovery list of all other users.
+/// ViewModel for the Friends screen. Four buckets:
+/// - accepted friends,
+/// - requests (incoming + outgoing in-app friend requests),
+/// - discovery list of other users,
+/// - incoming deep-link invites awaiting accept/decline.
+///
+/// Also owns invite-mint state for the "Invite a Friend" CTA.
 @Observable
 @MainActor
 final class FriendsViewModel {
@@ -15,14 +20,31 @@ final class FriendsViewModel {
     var outgoing: [Friend] = []   // requested (me -> others)
     var discover: [SearchResult] = []
 
+    /// Deep-link invites the user has received. Sourced from the backend
+    /// `/invites/pending` endpoint once it lands; renders as an empty list
+    /// until then.
+    var incomingInvites: [PendingInvite] = []
+
     var isLoading = false
     var isRefreshing = false
     var errorMessage: String?
 
-    /// Actions currently in flight, keyed by target email. Prevents double-taps.
+    // Invite-mint state for the Invite-a-Friend CTA.
+    var isMintingInvite = false
+    var lastMintedInvite: URL?
+    var inviteMintError: String?
+
+    /// Actions currently in flight, keyed by target email or invite code.
+    /// Prevents double-taps.
     var inFlight: Set<String> = []
 
-    private let xomify = XomifyService.shared
+    private let xomify: any XomifyServicing
+
+    // MARK: - Init
+
+    init(xomify: any XomifyServicing = XomifyService.shared) {
+        self.xomify = xomify
+    }
 
     // MARK: - Load
 
@@ -39,19 +61,35 @@ final class FriendsViewModel {
 
         async let friendsBucket = xomify.getAllFriends(email: email)
         async let allUsers = xomify.listUsers(email: email)
+        async let pendingInvites = loadPendingInvitesResult(email: email)
 
         do {
-            let (friendsResp, usersResp) = try await (friendsBucket, allUsers)
+            let (friendsResp, usersResp, invitesResp) = try await (friendsBucket, allUsers, pendingInvites)
             accepted = friendsResp.accepted ?? []
             incoming = friendsResp.pending ?? []
             outgoing = friendsResp.requested ?? []
             discover = (usersResp.users ?? []).filter { $0.email != email }
+            incomingInvites = invitesResp
         } catch {
             errorMessage = error.localizedDescription
             print("❌ Friends: load failed - \(error)")
         }
 
         isLoading = false
+    }
+
+    /// Defensive wrapper around `listPendingInvites` — the backend endpoint is
+    /// pending, so any error is swallowed here to avoid nuking the whole load.
+    /// Returns an empty list on failure.
+    private func loadPendingInvitesResult(email: String) async -> [PendingInvite] {
+        do {
+            let response = try await xomify.listPendingInvites(email: email)
+            return response.invites ?? []
+        } catch {
+            // Endpoint not yet deployed — render an empty list. Not a fatal error.
+            print("ℹ️ Friends: listPendingInvites unavailable - \(error.localizedDescription)")
+            return []
+        }
     }
 
     func refresh() async {
@@ -61,7 +99,7 @@ final class FriendsViewModel {
         isRefreshing = false
     }
 
-    // MARK: - Actions
+    // MARK: - Friend actions
 
     func request(_ target: SearchResult) async {
         let targetEmail = target.email
@@ -153,6 +191,117 @@ final class FriendsViewModel {
         } catch {
             errorMessage = "Failed to remove: \(error.localizedDescription)"
             print("❌ Friends: remove failed - \(error)")
+        }
+    }
+
+    // MARK: - Invite mint
+
+    /// Mint a fresh invite code + share URL for the current user. Updates
+    /// `lastMintedInvite` on success, which the view observes to present the
+    /// iOS share sheet.
+    func mintInvite() async {
+        guard !userEmail.isEmpty else {
+            inviteMintError = "Please log in first"
+            return
+        }
+        guard !isMintingInvite else { return }
+        isMintingInvite = true
+        inviteMintError = nil
+        lastMintedInvite = nil
+
+        do {
+            let response = try await xomify.createInvite(email: userEmail)
+            guard let shareUrl = response.shareUrl, let url = URL(string: shareUrl) else {
+                inviteMintError = "Invite minted but URL was missing"
+                isMintingInvite = false
+                return
+            }
+            lastMintedInvite = url
+        } catch {
+            inviteMintError = "Failed to create invite: \(error.localizedDescription)"
+            print("❌ Friends: mintInvite failed - \(error)")
+        }
+
+        isMintingInvite = false
+    }
+
+    /// Clear the last minted invite — call after the share sheet has been
+    /// dismissed so the sheet can re-present cleanly on a future mint.
+    func clearMintedInvite() {
+        lastMintedInvite = nil
+    }
+
+    // MARK: - Incoming invite actions
+
+    /// Accept an incoming deep-link invite by code.
+    func acceptInvite(_ invite: PendingInvite) async {
+        await acceptInvite(code: invite.inviteCode)
+    }
+
+    /// Accept a deep-link invite by its raw code. Used by both the in-app
+    /// Invites list and the Universal-Link-triggered auto-accept flow.
+    func acceptInvite(code: String) async {
+        guard !userEmail.isEmpty else {
+            errorMessage = "Please log in first"
+            return
+        }
+        guard !inFlight.contains(code) else { return }
+        inFlight.insert(code)
+        defer { inFlight.remove(code) }
+
+        do {
+            let response = try await xomify.acceptInvite(email: userEmail, inviteCode: code)
+            // Remove the accepted row from the pending list.
+            if let senderEmail = incomingInvites.first(where: { $0.inviteCode == code })?.senderEmail {
+                incomingInvites.removeAll { $0.inviteCode == code }
+                // Optimistically promote the sender to accepted if we can
+                // reflect the friendship without a full refetch.
+                if let friendEmail = response.friendEmail ?? Optional(senderEmail) {
+                    let exists = accepted.contains { $0.targetEmail == friendEmail }
+                    if !exists {
+                        accepted.append(Friend(
+                            email: userEmail,
+                            friendEmail: friendEmail,
+                            displayName: nil,
+                            avatar: nil,
+                            status: "accepted",
+                            direction: "incoming",
+                            createdAt: ISO8601DateFormatter().string(from: Date()),
+                            mutualCount: nil
+                        ))
+                    }
+                }
+            } else {
+                // Code came from a deep link — we may have no row to remove,
+                // that's fine; just trigger a refresh to resync state.
+                await refresh()
+            }
+        } catch {
+            errorMessage = "Failed to accept invite: \(error.localizedDescription)"
+            print("❌ Friends: acceptInvite failed - \(error)")
+        }
+    }
+
+    /// Decline an incoming deep-link invite.
+    func declineInvite(_ invite: PendingInvite) async {
+        let code = invite.inviteCode
+        guard !inFlight.contains(code) else { return }
+        inFlight.insert(code)
+        defer { inFlight.remove(code) }
+
+        // Optimistic removal — restore on failure.
+        let snapshot = incomingInvites
+        incomingInvites.removeAll { $0.inviteCode == code }
+
+        do {
+            _ = try await xomify.declineInvite(email: userEmail, inviteCode: code)
+        } catch {
+            // Restore the row and surface the error — but only if the failure
+            // wasn't "endpoint missing" (404/5xx). We still clear client-side
+            // because the row has no other way out; flag via errorMessage.
+            incomingInvites = snapshot.filter { $0.inviteCode != code }
+            errorMessage = "Decline not yet supported: \(error.localizedDescription)"
+            print("ℹ️ Friends: declineInvite failed - \(error)")
         }
     }
 

--- a/Xomify-iOS/Views/FriendsView.swift
+++ b/Xomify-iOS/Views/FriendsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Friends screen: three segmented tabs (Friends / Requests / Find).
+/// Friends screen: four segmented tabs (Friends / Requests / Invites / Find).
 struct FriendsView: View {
 
     @State private var viewModel = FriendsViewModel()
@@ -9,11 +9,19 @@ struct FriendsView: View {
     @State private var selectedTab: Tab = .friends
     @State private var searchText: String = ""
 
+    /// Friend queued for removal; drives the confirmation dialog.
+    @State private var friendPendingRemoval: Friend?
+
+    /// Whether the iOS share sheet is currently presented for a minted invite.
+    @State private var isShareSheetPresented: Bool = false
+
     private let spotifyService = SpotifyService.shared
+    private let inviteCoordinator = InviteCoordinator.shared
 
     enum Tab: String, CaseIterable, Identifiable {
         case friends = "Friends"
         case requests = "Requests"
+        case invites = "Invites"
         case find = "Find"
         var id: String { rawValue }
     }
@@ -30,22 +38,84 @@ struct FriendsView: View {
         }
         .navigationTitle("Friends")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    Task { await viewModel.refresh() }
-                } label: {
-                    if viewModel.isRefreshing {
-                        ProgressView()
-                    } else {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                }
-                .disabled(viewModel.isRefreshing || isLoadingUser)
-            }
-        }
+        .toolbar { toolbarContent }
         .task { await loadUserAndData() }
         .tint(Color.xomifyGreen)
+        .confirmationDialog(
+            removalConfirmationTitle,
+            isPresented: Binding(
+                get: { friendPendingRemoval != nil },
+                set: { if !$0 { friendPendingRemoval = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: friendPendingRemoval
+        ) { friend in
+            Button("Remove", role: .destructive) {
+                Task {
+                    await viewModel.remove(friend)
+                    friendPendingRemoval = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                friendPendingRemoval = nil
+            }
+        } message: { friend in
+            Text("\(friend.label) will no longer be your friend on Xomify.")
+        }
+        .sheet(isPresented: $isShareSheetPresented, onDismiss: {
+            viewModel.clearMintedInvite()
+        }) {
+            if let url = viewModel.lastMintedInvite {
+                InviteShareSheet(url: url)
+                    .presentationDetents([.medium])
+            }
+        }
+        .onChange(of: viewModel.lastMintedInvite) { _, new in
+            // Auto-present the share sheet as soon as the mint lands.
+            isShareSheetPresented = new != nil
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                Task { await viewModel.mintInvite() }
+            } label: {
+                if viewModel.isMintingInvite {
+                    ProgressView()
+                } else {
+                    Label("Invite a Friend", systemImage: "person.badge.plus")
+                        .labelStyle(.titleAndIcon)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                }
+            }
+            .accessibilityLabel("Invite a friend")
+            .disabled(viewModel.isMintingInvite || isLoadingUser)
+        }
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                Task { await viewModel.refresh() }
+            } label: {
+                if viewModel.isRefreshing {
+                    ProgressView()
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .accessibilityLabel("Refresh")
+            .disabled(viewModel.isRefreshing || isLoadingUser)
+        }
+    }
+
+    private var removalConfirmationTitle: String {
+        if let friend = friendPendingRemoval {
+            return "Remove \(friend.label)?"
+        }
+        return "Remove friend?"
     }
 
     // MARK: - Tab picker
@@ -67,6 +137,9 @@ struct FriendsView: View {
         case .requests:
             let total = viewModel.incoming.count + viewModel.outgoing.count
             return total == 0 ? "Requests" : "Requests (\(total))"
+        case .invites:
+            let total = viewModel.incomingInvites.count
+            return total == 0 ? "Invites" : "Invites (\(total))"
         case .find:
             return "Find"
         }
@@ -76,22 +149,23 @@ struct FriendsView: View {
 
     private var searchField: some View {
         HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass").foregroundColor(.gray)
+            Image(systemName: "magnifyingglass").foregroundStyle(Color.gray)
             TextField("Search by name or email", text: $searchText)
-                .foregroundColor(.white)
+                .foregroundStyle(Color.white)
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
             if !searchText.isEmpty {
                 Button {
                     searchText = ""
                 } label: {
-                    Image(systemName: "xmark.circle.fill").foregroundColor(.gray)
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(Color.gray)
                 }
+                .accessibilityLabel("Clear search")
             }
         }
         .padding()
         .background(Color.white.opacity(0.05))
-        .cornerRadius(10)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         .padding(.horizontal)
     }
 
@@ -101,12 +175,16 @@ struct FriendsView: View {
     private var content: some View {
         if isLoadingUser || viewModel.isLoading {
             loadingState
-        } else if let error = viewModel.errorMessage, viewModel.accepted.isEmpty, viewModel.discover.isEmpty {
+        } else if let error = viewModel.errorMessage,
+                  viewModel.accepted.isEmpty,
+                  viewModel.discover.isEmpty,
+                  viewModel.incomingInvites.isEmpty {
             errorState(error)
         } else {
             switch selectedTab {
             case .friends:  friendsList
             case .requests: requestsList
+            case .invites:  invitesList
             case .find:     findList
             }
         }
@@ -115,7 +193,7 @@ struct FriendsView: View {
     private var loadingState: some View {
         VStack(spacing: 12) {
             ProgressView().tint(.xomifyGreen)
-            Text("Loading...").font(.caption).foregroundColor(.gray)
+            Text("Loading...").font(.caption).foregroundStyle(Color.gray)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -124,9 +202,9 @@ struct FriendsView: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 50))
-                .foregroundColor(.orange.opacity(0.7))
-            Text("Error").font(.headline).foregroundColor(.white)
-            Text(message).font(.caption).foregroundColor(.gray)
+                .foregroundStyle(Color.orange.opacity(0.7))
+            Text("Error").font(.headline).foregroundStyle(Color.white)
+            Text(message).font(.caption).foregroundStyle(Color.gray)
                 .multilineTextAlignment(.center)
             Button {
                 Task { await loadUserAndData() }
@@ -136,8 +214,8 @@ struct FriendsView: View {
                     .fontWeight(.medium)
                     .padding(.horizontal, 24).padding(.vertical, 10)
                     .background(Color.xomifyPurple)
-                    .foregroundColor(.white)
-                    .cornerRadius(20)
+                    .foregroundStyle(Color.white)
+                    .clipShape(Capsule())
             }
         }
         .padding(.horizontal, 40)
@@ -154,7 +232,7 @@ struct FriendsView: View {
         Group {
             if filteredFriends.isEmpty {
                 emptyTab(icon: "person.2", title: "No Friends Yet",
-                         message: "Invite a friend from the Invites page to get started.")
+                         message: "Tap Invite a Friend in the top bar to share a link, or use Find to add existing users.")
             } else {
                 ScrollView {
                     LazyVStack(spacing: 8) {
@@ -165,12 +243,14 @@ struct FriendsView: View {
                                 friendRow(friend, trailing: {
                                     AnyView(
                                         Button(role: .destructive) {
-                                            Task { await viewModel.remove(friend) }
+                                            friendPendingRemoval = friend
                                         } label: {
                                             Image(systemName: "person.badge.minus")
-                                                .foregroundColor(.red)
+                                                .foregroundStyle(Color.red)
+                                                .frame(minWidth: 44, minHeight: 44)
                                         }
                                         .buttonStyle(.borderless)
+                                        .accessibilityLabel("Remove \(friend.label)")
                                     )
                                 })
                             }
@@ -215,10 +295,11 @@ struct FriendsView: View {
                                                     .fontWeight(.semibold)
                                                     .padding(.horizontal, 12).padding(.vertical, 6)
                                                     .background(Color.xomifyGreen)
-                                                    .foregroundColor(.black)
-                                                    .cornerRadius(12)
+                                                    .foregroundStyle(Color.black)
+                                                    .clipShape(Capsule())
                                             }
                                             .buttonStyle(.plain)
+                                            .accessibilityLabel("Accept \(friend.label)")
 
                                             Button {
                                                 Task { await viewModel.reject(friend) }
@@ -228,10 +309,11 @@ struct FriendsView: View {
                                                     .fontWeight(.semibold)
                                                     .padding(.horizontal, 12).padding(.vertical, 6)
                                                     .background(Color.white.opacity(0.1))
-                                                    .foregroundColor(.white)
-                                                    .cornerRadius(12)
+                                                    .foregroundStyle(Color.white)
+                                                    .clipShape(Capsule())
                                             }
                                             .buttonStyle(.plain)
+                                            .accessibilityLabel("Reject \(friend.label)")
                                         }
                                     )
                                 })
@@ -251,10 +333,11 @@ struct FriendsView: View {
                                                 .fontWeight(.semibold)
                                                 .padding(.horizontal, 12).padding(.vertical, 6)
                                                 .background(Color.white.opacity(0.1))
-                                                .foregroundColor(.white)
-                                                .cornerRadius(12)
+                                                .foregroundStyle(Color.white)
+                                                .clipShape(Capsule())
                                         }
                                         .buttonStyle(.plain)
+                                        .accessibilityLabel("Cancel request to \(friend.label)")
                                     )
                                 })
                             }
@@ -264,6 +347,90 @@ struct FriendsView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Invites tab
+
+    private var filteredInvites: [PendingInvite] {
+        filter(viewModel.incomingInvites, by: searchText) { $0.label + " " + $0.senderEmail }
+    }
+
+    private var invitesList: some View {
+        Group {
+            if filteredInvites.isEmpty {
+                emptyTab(icon: "envelope.badge", title: "No Invites",
+                         message: "Deep-link invites from other users appear here.")
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(filteredInvites) { invite in
+                            inviteRow(invite)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+
+    private func inviteRow(_ invite: PendingInvite) -> some View {
+        HStack(spacing: 12) {
+            avatarCircle(label: invite.label)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(invite.label)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(Color.white)
+                    .lineLimit(1)
+                Text(invite.senderEmail)
+                    .font(.caption2)
+                    .foregroundStyle(Color.gray)
+                    .lineLimit(1)
+                if !invite.relativeTime.isEmpty {
+                    Text(invite.relativeTime)
+                        .font(.caption2)
+                        .foregroundStyle(Color.gray.opacity(0.7))
+                }
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Button {
+                    Task { await viewModel.acceptInvite(invite) }
+                } label: {
+                    Text("Accept")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 12).padding(.vertical, 6)
+                        .background(Color.xomifyGreen)
+                        .foregroundStyle(Color.black)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Accept invite from \(invite.label)")
+                .disabled(viewModel.inFlight.contains(invite.inviteCode))
+
+                Button {
+                    Task { await viewModel.declineInvite(invite) }
+                } label: {
+                    Text("Decline")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 12).padding(.vertical, 6)
+                        .background(Color.white.opacity(0.1))
+                        .foregroundStyle(Color.white)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Decline invite from \(invite.label)")
+                .disabled(viewModel.inFlight.contains(invite.inviteCode))
+            }
+        }
+        .padding(12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     // MARK: - Find tab
@@ -298,11 +465,11 @@ struct FriendsView: View {
                 Text(user.label)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundStyle(Color.white)
                     .lineLimit(1)
                 Text(user.email)
                     .font(.caption2)
-                    .foregroundColor(.gray)
+                    .foregroundStyle(Color.gray)
                     .lineLimit(1)
             }
 
@@ -324,16 +491,17 @@ struct FriendsView: View {
                     .fontWeight(.semibold)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                     .background(Color.xomifyPurple)
-                    .foregroundColor(.white)
-                    .cornerRadius(12)
+                    .foregroundStyle(Color.white)
+                    .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Add \(user.label)")
                 .disabled(viewModel.inFlight.contains(user.email))
             }
         }
         .padding(12)
         .background(Color.xomifyCard)
-        .cornerRadius(10)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     // MARK: - Row builders
@@ -346,11 +514,11 @@ struct FriendsView: View {
                 Text(friend.label)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundStyle(Color.white)
                     .lineLimit(1)
                 Text(friend.targetEmail)
                     .font(.caption2)
-                    .foregroundColor(.gray)
+                    .foregroundStyle(Color.gray)
                     .lineLimit(1)
             }
 
@@ -360,7 +528,7 @@ struct FriendsView: View {
         }
         .padding(12)
         .background(Color.xomifyCard)
-        .cornerRadius(10)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private func avatarCircle(label: String) -> some View {
@@ -371,7 +539,7 @@ struct FriendsView: View {
             Text(String(label.prefix(1)).uppercased())
                 .font(.subheadline)
                 .fontWeight(.bold)
-                .foregroundColor(.white)
+                .foregroundStyle(Color.white)
         }
     }
 
@@ -381,15 +549,15 @@ struct FriendsView: View {
             .fontWeight(.semibold)
             .padding(.horizontal, 10).padding(.vertical, 4)
             .background(color.opacity(0.2))
-            .foregroundColor(color)
-            .cornerRadius(10)
+            .foregroundStyle(color)
+            .clipShape(Capsule())
     }
 
     private func sectionHeader(_ text: String) -> some View {
         Text(text)
             .font(.caption)
             .fontWeight(.semibold)
-            .foregroundColor(.gray)
+            .foregroundStyle(Color.gray)
             .padding(.top, 4)
     }
 
@@ -397,11 +565,11 @@ struct FriendsView: View {
         VStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 40))
-                .foregroundColor(.gray.opacity(0.5))
-            Text(title).font(.headline).foregroundColor(.white)
+                .foregroundStyle(Color.gray.opacity(0.5))
+            Text(title).font(.headline).foregroundStyle(Color.white)
             Text(message)
                 .font(.caption)
-                .foregroundColor(.gray)
+                .foregroundStyle(Color.gray)
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 40)
@@ -429,10 +597,79 @@ struct FriendsView: View {
             }
             userEmail = email
             await viewModel.load(email: email)
+            // If a deep-link invite was captured before we finished auth, route
+            // into the Invites tab and auto-accept.
+            if let pendingCode = inviteCoordinator.consume() {
+                selectedTab = .invites
+                await viewModel.acceptInvite(code: pendingCode)
+            }
         } catch {
             viewModel.errorMessage = "Failed to load profile: \(error.localizedDescription)"
         }
         isLoadingUser = false
+    }
+}
+
+// MARK: - Invite share sheet
+
+/// Small wrapper that presents a `ShareLink`-style share sheet for a minted
+/// invite URL. Kept separate so the sheet can be driven by `@State` on the
+/// parent view.
+private struct InviteShareSheet: View {
+    let url: URL
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "link")
+                .font(.system(size: 40))
+                .foregroundStyle(Color.xomifyGreen)
+                .padding(.top, 24)
+
+            Text("Invite a Friend")
+                .font(.title3)
+                .fontWeight(.bold)
+                .foregroundStyle(Color.white)
+
+            Text("Send this link to anyone you want to add as a friend on Xomify.")
+                .font(.subheadline)
+                .foregroundStyle(Color.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            Text(url.absoluteString)
+                .font(.caption)
+                .foregroundStyle(Color.white)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.xomifyCard)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .textSelection(.enabled)
+                .padding(.horizontal, 24)
+
+            ShareLink(
+                item: url,
+                subject: Text("Join me on Xomify"),
+                message: Text("Accept my invite to connect on Xomify: \(url.absoluteString)")
+            ) {
+                HStack(spacing: 8) {
+                    Image(systemName: "square.and.arrow.up")
+                    Text("Share")
+                }
+                .font(.headline)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(LinearGradient.xomifyGradient)
+                .foregroundStyle(Color.white)
+                .clipShape(Capsule())
+            }
+            .padding(.horizontal, 24)
+            .accessibilityLabel("Share invite link")
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.xomifyDark)
     }
 }
 

--- a/Xomify-iOS/Xomify-iOS.entitlements
+++ b/Xomify-iOS/Xomify-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:xomify.xomware.com</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Ships sub-feature #30 of the social-feed epic: hardens the drawer Friends screen with an Invite-a-Friend share flow, an Invites tab for inbound deep-link invites, a confirmation gate before removing a friend, and Universal Link + custom-scheme deep-link handling.

- Invite CTA mints via `XomifyService.createInvite` and shares through a `ShareLink` sheet
- Fourth `Invites` tab lists inbound deep-link invites (accept / decline)
- Remove-friend is gated behind a `.confirmationDialog`
- `InviteCoordinator` parses `https://xomify.xomware.com/invite/<code>` and `xomify://invite/<code>` and hands off to `FriendsView` once the user is authenticated
- `XomifyServicing` protocol extraction so the VM can be unit-tested against a mock

Closes #30

## Required follow-up before this works end-to-end

### 1. Host the AASA file

Universal Links will NOT activate until `https://xomify.xomware.com/.well-known/apple-app-site-association` serves the following JSON as `Content-Type: application/json` (no `.json` extension on the URL path, no redirects):

```json
{
  "applinks": {
    "details": [
      {
        "appIDs": ["A3HMLDS2AL.com.Xomware.Xomify"],
        "components": [
          {
            "/": "/invite/*",
            "comment": "Matches invite deep links"
          }
        ]
      }
    ]
  }
}
```

Notes:
- `A3HMLDS2AL` is the Team ID pulled from `DEVELOPMENT_TEAM` in `project.pbxproj`. Bundle ID is `com.Xomware.Xomify`.
- Until this is live, invite links tapped in Messages / Safari will open in-browser. The custom-scheme fallback (`xomify://invite/<code>`) works regardless; that's the path the first TestFlight invitees will actually exercise.
- Verify post-deploy with `xcrun swcutil dl -d xomify.xomware.com` and Apple's AASA validator: https://branch.io/resources/aasa-validator/.

### 2. Merge backend PR #131

Backend PR https://github.com/Xomware/xomify-backend/pull/131 ships `GET /invites/pending` and `POST /invites/decline`. This PR's `XomifyService.listPendingInvites` and `declineInvite` point at the real URLs already — they degrade gracefully (empty Invites tab, error toast on decline) while #131 is unmerged.

### 3. Screenshots

TBD — will attach before merge once the AASA is live so the end-to-end deep-link handoff is captured too.

## Test plan

- [ ] Open drawer → Friends. Confirm four tabs render: Friends / Requests / Invites / Find.
- [ ] Tap "Invite a Friend" in the toolbar. Confirm spinner → share sheet with a `https://xomify.xomware.com/invite/<code>` URL.
- [ ] Paste the URL into Messages to self, tap it. Expect: app opens on the Invites tab and auto-accepts (Universal Link path, after AASA goes live).
- [ ] While app is backgrounded, open `xomify://invite/<code>` from Safari. Expect: same Invites tab + auto-accept (custom-scheme path).
- [ ] With backend PR #131 merged: confirm inbound invites list populates; Decline removes locally and on the server.
- [ ] With backend PR #131 NOT merged: confirm Invites tab renders empty state without a visible error.
- [ ] On Friends tab, tap remove on a friend row. Expect `.confirmationDialog` with "Remove" + "Cancel"; only "Remove" triggers the API call.

## Out of scope

- AASA hosting — sits in `xomify-frontend` / AWS S3, not this repo.
- `invites_pending` / `invites_decline` lambdas — shipping in backend PR #131.
- Invite landing page for users without the app installed — tracked separately.