### PR TITLE
feat(ios): push notifications — APNs permission, token registration, push-open deep links

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5291E4E32F08498E00A10C3E /* secrets.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Xomify-iOS/Xomify-iOS.entitlements";
@@ -319,6 +320,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5291E4E32F08498E00A10C3E /* secrets.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Xomify-iOS/Xomify-iOS.entitlements";

--- a/Xomify-iOS/App/XomifyAppDelegate.swift
+++ b/Xomify-iOS/App/XomifyAppDelegate.swift
@@ -1,0 +1,41 @@
+import UIKit
+import UserNotifications
+
+/// Minimal `UIApplicationDelegate` introduced solely to hook APNs device-token
+/// registration. All business logic lives in `NotificationsService` — the
+/// delegate forwards events and does nothing else.
+///
+/// Wired into the SwiftUI lifecycle via `@UIApplicationDelegateAdaptor` on
+/// `Xomify_iOSApp`.
+final class XomifyAppDelegate: NSObject, UIApplicationDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Register `NotificationsService` as the notification center delegate so
+        // foreground presentation + push-open dispatch route through it.
+        UNUserNotificationCenter.current().delegate = NotificationsService.shared
+        return true
+    }
+
+    // MARK: - APNs token lifecycle
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            await NotificationsService.shared.handleDeviceToken(deviceToken)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        Task { @MainActor in
+            NotificationsService.shared.handleRegistrationFailure(error)
+        }
+    }
+}

--- a/Xomify-iOS/App/Xomify_iOSApp.swift
+++ b/Xomify-iOS/App/Xomify_iOSApp.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 @main
 struct Xomify_iOSApp: App {
+    /// APNs device-token registration + push-open dispatch.
+    /// Owned here so the app has a single delegate for the whole lifecycle.
+    @UIApplicationDelegateAdaptor(XomifyAppDelegate.self) private var appDelegate
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Xomify-iOS/Models/NotificationModels.swift
+++ b/Xomify-iOS/Models/NotificationModels.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// MARK: - Device Token Registration
+
+/// Request body for `POST /notifications/register`.
+///
+/// Mirrors the deployed `lambdas/notifications_register/handler.py` contract.
+/// Keys are camelCase on the wire (no snake_case conversion).
+struct DeviceTokenRegistration: Codable, Sendable, Equatable {
+    let email: String
+    let deviceToken: String
+    let queueNotificationsEnabled: Bool
+    let digestEnabled: Bool
+}
+
+// MARK: - Device Token Unregister
+
+/// Request body for `POST /notifications/unregister`.
+/// Mirrors `lambdas/notifications_unregister/handler.py`.
+struct DeviceTokenUnregister: Codable, Sendable, Equatable {
+    let email: String
+    let deviceToken: String
+}
+
+// MARK: - Digest Preferences
+
+/// UI-facing preference tuple for the Settings screen. Persisted client-side via
+/// `@AppStorage`; mirrored to the backend through `registerPushToken` (upsert).
+struct DigestPreferences: Codable, Sendable, Equatable {
+    var queueNotificationsEnabled: Bool
+    var digestEnabled: Bool
+
+    init(queueNotificationsEnabled: Bool = true, digestEnabled: Bool = true) {
+        self.queueNotificationsEnabled = queueNotificationsEnabled
+        self.digestEnabled = digestEnabled
+    }
+}
+
+// MARK: - Push Payload
+//
+// The backend's `notifications_send` lambda flattens every `customData` key
+// onto the top-level APNs payload alongside `aps`. Queue-threshold pushes
+// (emitted by `shares_react`) carry `shareId`, `trackId`, `trackName`,
+// `artistName`, `reactorCount`. Digest pushes (emitted by `cron_shares_digest`)
+// carry `count`, `windowDays`. There is no explicit `pushType` field — the
+// kind must be inferred from the shape.
+
+/// Classification of an incoming push, derived from payload shape.
+enum PushKind: String, Sendable {
+    case queueThreshold
+    case digest
+    case unknown
+}
+
+/// Strongly-typed view onto an APNs userInfo dictionary. Tolerates missing
+/// fields — all optional. Use `kind` + `shareId` for routing decisions.
+struct PushPayload: Sendable, Equatable {
+    let kind: PushKind
+    let shareId: String?
+    let trackId: String?
+    let reactorCount: Int?
+    let count: Int?
+    let windowDays: Int?
+
+    /// Construct from a raw APNs userInfo dictionary (e.g., the
+    /// `notification.request.content.userInfo` passed by UserNotifications).
+    init(userInfo: [AnyHashable: Any]) {
+        self.shareId = userInfo["shareId"] as? String
+        self.trackId = userInfo["trackId"] as? String
+        self.reactorCount = Self.asInt(userInfo["reactorCount"])
+        self.count = Self.asInt(userInfo["count"])
+        self.windowDays = Self.asInt(userInfo["windowDays"])
+
+        // Kind inference:
+        //  - Queue threshold pushes always carry `shareId`.
+        //  - Digest pushes carry `windowDays` (no `shareId`).
+        if self.shareId != nil {
+            self.kind = .queueThreshold
+        } else if self.windowDays != nil || self.count != nil {
+            self.kind = .digest
+        } else {
+            self.kind = .unknown
+        }
+    }
+
+    /// Direct-init for tests + call sites that already have typed fields.
+    init(
+        kind: PushKind,
+        shareId: String? = nil,
+        trackId: String? = nil,
+        reactorCount: Int? = nil,
+        count: Int? = nil,
+        windowDays: Int? = nil
+    ) {
+        self.kind = kind
+        self.shareId = shareId
+        self.trackId = trackId
+        self.reactorCount = reactorCount
+        self.count = count
+        self.windowDays = windowDays
+    }
+
+    private static func asInt(_ value: Any?) -> Int? {
+        if let i = value as? Int { return i }
+        if let s = value as? String { return Int(s) }
+        if let d = value as? Double { return Int(d) }
+        return nil
+    }
+}

--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -342,17 +342,28 @@ final class AuthService: NSObject, Sendable {
     }
     
     // MARK: - Logout
-    
+
+    /// Synchronous logout — kept for existing call sites. For new call sites
+    /// prefer `logout()` (async) so the APNs token can be unregistered from the
+    /// backend before the Spotify access token is cleared.
     func logout() {
+        // Fire-and-forget: unregister the APNs device token with the backend.
+        // `NotificationsService.unregister()` internally resolves the current
+        // user email via Spotify, so we dispatch it *before* clearing tokens.
+        // It swallows errors — stale backend tokens get pruned on next 410.
+        Task { @MainActor in
+            await NotificationsService.shared.unregister()
+        }
+
         accessToken = nil
         refreshToken = nil
         tokenExpirationDate = nil
         isAuthenticated = false
-        
+
         KeychainHelper.delete(key: accessTokenKey)
         KeychainHelper.delete(key: refreshTokenKey)
         KeychainHelper.delete(key: expirationKey)
-        
+
         print("👋 Auth: Logged out")
     }
     

--- a/Xomify-iOS/Services/NotificationsService.swift
+++ b/Xomify-iOS/Services/NotificationsService.swift
@@ -1,0 +1,272 @@
+import Foundation
+import SwiftUI
+import UIKit
+import UserNotifications
+
+/// Owns all push-notification plumbing:
+///   - permission prompt (gated by `@AppStorage` so we only ask once),
+///   - APNs device-token lifecycle (hex encoding, cache, register/unregister),
+///   - foreground presentation (banner+sound for threshold, silent for digest),
+///   - push-open dispatch (routes to the Feed tab via the shared
+///     `NavigationStore` that `MainShell` observes).
+///
+/// Views never touch this directly — trigger points are called from
+/// `ShareComposerViewModel`, `FriendsViewModel`, `SettingsViewModel`, and the
+/// `AppDelegate`. `SettingsViewModel` mediates preference flips.
+@MainActor
+final class NotificationsService: NSObject {
+
+    // MARK: - Singleton
+
+    static let shared = NotificationsService()
+
+    // MARK: - Dependencies
+
+    private let xomify: any XomifyServicing
+    private let defaults: UserDefaults
+
+    /// Shared `NavigationStore` observed by `MainShell`. Published pushes land
+    /// here as tab switches / deep-link requests. `weak` so we don't keep a
+    /// detached shell alive during unit tests.
+    weak var navigationStore: NavigationStore?
+
+    // MARK: - UserDefaults keys
+
+    /// Flipped to `true` the first time we call `requestAuthorization`, whether
+    /// the user grants or denies. Prevents re-prompting (iOS silently drops
+    /// subsequent prompts anyway — this flag makes the gate explicit).
+    static let hasPromptedKey = "notifications.hasPromptedForPush"
+
+    /// Hex-encoded APNs token from the most recent `didRegister` callback.
+    /// Used by `unregister()` on sign-out and by `updatePreferences()` to
+    /// upsert without re-soliciting the token.
+    static let cachedTokenKey = "notifications.cachedDeviceToken"
+
+    /// Mirror of the Settings toggles (kept in sync via `@AppStorage` on the
+    /// view model side). Read here when the push pipeline needs the values
+    /// without rebuilding the VM.
+    static let queueEnabledKey = "notifications.push.enabled"
+    static let digestEnabledKey = "notifications.digest.enabled"
+
+    /// Cached user email for unregister. Written after a successful token
+    /// upsert so sign-out can POST /notifications/unregister without needing
+    /// to round-trip to Spotify (by the time sign-out runs the access token
+    /// may already be cleared).
+    static let cachedEmailKey = "notifications.cachedEmail"
+
+    // MARK: - Init
+
+    init(
+        xomify: any XomifyServicing = XomifyService.shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.xomify = xomify
+        self.defaults = defaults
+        super.init()
+    }
+
+    // MARK: - Public API
+
+    /// Current authorization status from UNUserNotificationCenter. Async because
+    /// the underlying API is callback-based.
+    func currentAuthorizationStatus() async -> UNAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                continuation.resume(returning: settings.authorizationStatus)
+            }
+        }
+    }
+
+    /// First-share / first-accepted-invite trigger. No-op after the first call.
+    /// Sets `hasPromptedForPush` regardless of grant/deny so we only ever
+    /// prompt once — the Settings screen shows a "Open System Settings" button
+    /// for users who deny.
+    func requestPermissionIfNeeded() async {
+        if defaults.bool(forKey: Self.hasPromptedKey) {
+            return
+        }
+        defaults.set(true, forKey: Self.hasPromptedKey)
+
+        let granted: Bool
+        do {
+            granted = try await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .sound])
+        } catch {
+            print("❌ Notifications: requestAuthorization threw — \(error.localizedDescription)")
+            return
+        }
+
+        guard granted else {
+            print("ℹ️ Notifications: user denied push permission")
+            return
+        }
+
+        // Kick APNs token registration. The delegate callback feeds back into
+        // `handleDeviceToken(_:)` where we POST to the backend.
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+
+    /// Called from `XomifyAppDelegate.didRegisterForRemoteNotificationsWithDeviceToken`.
+    /// Hex-encodes the raw token, caches it, and upserts to the backend.
+    func handleDeviceToken(_ data: Data) async {
+        let hex = Self.hexString(from: data)
+        defaults.set(hex, forKey: Self.cachedTokenKey)
+
+        guard let email = await currentUserEmail() else {
+            print("ℹ️ Notifications: token received but no current user — skipping register")
+            return
+        }
+
+        let queueEnabled = defaults.object(forKey: Self.queueEnabledKey) as? Bool ?? true
+        let digestEnabled = defaults.object(forKey: Self.digestEnabledKey) as? Bool ?? true
+
+        // One retry on failure — token registration is non-critical, so we
+        // don't surface errors to the user. Backend upsert is idempotent.
+        for attempt in 1...2 {
+            do {
+                _ = try await xomify.registerPushToken(
+                    email: email,
+                    deviceToken: hex,
+                    queueNotificationsEnabled: queueEnabled,
+                    digestEnabled: digestEnabled
+                )
+                defaults.set(email, forKey: Self.cachedEmailKey)
+                print("✅ Notifications: device token registered (attempt \(attempt))")
+                return
+            } catch {
+                print("❌ Notifications: registerPushToken failed (attempt \(attempt)) — \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Called from the delegate when APNs registration fails. Simulator and
+    /// unsigned-dev builds regularly hit this — not fatal.
+    func handleRegistrationFailure(_ error: Error) {
+        print("ℹ️ Notifications: APNs registration failed — \(error.localizedDescription)")
+    }
+
+    /// Flipped by `SettingsViewModel` when the user toggles either switch.
+    /// Re-POSTs to `/notifications/register` as an upsert using the cached token.
+    func updatePreferences(queueNotificationsEnabled: Bool, digestEnabled: Bool) async {
+        guard let hex = defaults.string(forKey: Self.cachedTokenKey) else {
+            // No token yet — next `handleDeviceToken` call will pick up the
+            // latest flags from UserDefaults and POST them.
+            return
+        }
+        // Prefer the cached email (written on first successful register) so
+        // this call path stays independent of the Spotify session.
+        let email: String
+        if let cached = defaults.string(forKey: Self.cachedEmailKey), !cached.isEmpty {
+            email = cached
+        } else if let fetched = await currentUserEmail() {
+            email = fetched
+        } else {
+            return
+        }
+
+        do {
+            _ = try await xomify.registerPushToken(
+                email: email,
+                deviceToken: hex,
+                queueNotificationsEnabled: queueNotificationsEnabled,
+                digestEnabled: digestEnabled
+            )
+        } catch {
+            print("❌ Notifications: updatePreferences failed — \(error.localizedDescription)")
+        }
+    }
+
+    /// Called on sign-out. Swallows errors — the user is leaving anyway, and a
+    /// stale backend token expires on the next failed send (APNs 410).
+    ///
+    /// Uses the cached email (written after the first successful register) so
+    /// this works even after the Spotify access token has been cleared.
+    func unregister() async {
+        let hex = defaults.string(forKey: Self.cachedTokenKey)
+        let cachedEmail = defaults.string(forKey: Self.cachedEmailKey)
+
+        // Clear local state first so subsequent pushes/launches don't try to
+        // reuse the old token before the network round-trip completes.
+        defaults.removeObject(forKey: Self.cachedTokenKey)
+        defaults.removeObject(forKey: Self.cachedEmailKey)
+        defaults.removeObject(forKey: Self.hasPromptedKey)
+
+        guard let hex, let cachedEmail, !cachedEmail.isEmpty else { return }
+
+        do {
+            _ = try await xomify.unregisterPushToken(email: cachedEmail, deviceToken: hex)
+        } catch {
+            print("ℹ️ Notifications: unregister failed (swallowed) — \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Resolve the current user's email. Fetched from the Spotify profile since
+    /// the backend keys tokens by email. Returns `nil` when not signed in.
+    private func currentUserEmail() async -> String? {
+        do {
+            let user = try await SpotifyService.shared.getCurrentUser()
+            return user.email
+        } catch {
+            return nil
+        }
+    }
+
+    /// APNs device tokens arrive as raw `Data`; the backend stores them as hex.
+    /// Matches `String(format: "%02x", ...)` byte-by-byte.
+    static func hexString(from data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension NotificationsService: UNUserNotificationCenterDelegate {
+
+    /// Foreground presentation. Queue-threshold pushes still show a banner +
+    /// play a sound (the user likely wants immediate feedback). Digest pushes
+    /// are suppressed in-app — if the user is already in the app, they don't
+    /// need a banner telling them to come check it out.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        let payload = PushPayload(userInfo: notification.request.content.userInfo)
+        switch payload.kind {
+        case .digest:
+            completionHandler([])
+        case .queueThreshold, .unknown:
+            completionHandler([.banner, .sound])
+        }
+    }
+
+    /// Push-open routing. `shareId` → route to the Feed tab so the user lands
+    /// on the list that contains the share. `digest` → route to Feed tab too.
+    ///
+    /// The `Share`-detail destination does not yet exist as a drawer
+    /// destination; the Feed tab is the correct landing spot until it does.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        defer { completionHandler() }
+
+        let payload = PushPayload(userInfo: response.notification.request.content.userInfo)
+        handlePushOpen(payload: payload)
+    }
+
+    /// Dispatch a parsed push-open payload into the navigation layer. Split
+    /// from the delegate callback so tests can drive it directly.
+    func handlePushOpen(payload: PushPayload) {
+        switch payload.kind {
+        case .queueThreshold, .digest:
+            navigationStore?.selectedTab = .feed
+        case .unknown:
+            // Nothing to route — leave the user wherever they were.
+            return
+        }
+    }
+}

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -466,4 +466,39 @@ actor XomifyService {
             return nil
         }
     }
+
+    // MARK: - Notifications (APNs)
+    //
+    // Thin wrappers over the deployed `notifications_register` /
+    // `notifications_unregister` lambdas. Body shape is camelCase and matches
+    // the Python handlers exactly.
+
+    /// Upsert the user's APNs device token + push preferences. Idempotent —
+    /// safe to call on every cold launch when the APNs token refreshes.
+    @discardableResult
+    func registerPushToken(
+        email: String,
+        deviceToken: String,
+        queueNotificationsEnabled: Bool,
+        digestEnabled: Bool
+    ) async throws -> SuccessResponse {
+        try await network.xomifyPost("/notifications/register", body: [
+            "email": email,
+            "deviceToken": deviceToken,
+            "queueNotificationsEnabled": queueNotificationsEnabled,
+            "digestEnabled": digestEnabled
+        ])
+    }
+
+    /// Delete the user's APNs device token from the backend. Called on sign-out.
+    @discardableResult
+    func unregisterPushToken(
+        email: String,
+        deviceToken: String
+    ) async throws -> SuccessResponse {
+        try await network.xomifyPost("/notifications/unregister", body: [
+            "email": email,
+            "deviceToken": deviceToken
+        ])
+    }
 }

--- a/Xomify-iOS/Services/XomifyServicing.swift
+++ b/Xomify-iOS/Services/XomifyServicing.swift
@@ -39,6 +39,25 @@ protocol XomifyServicing: Sendable {
     /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
     @discardableResult
     func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse
+
+    // MARK: - Notifications
+
+    /// Upsert an APNs device token + preference flags for the user.
+    /// Idempotent on `(email, deviceToken)` — safe to call on every cold launch.
+    @discardableResult
+    func registerPushToken(
+        email: String,
+        deviceToken: String,
+        queueNotificationsEnabled: Bool,
+        digestEnabled: Bool
+    ) async throws -> SuccessResponse
+
+    /// Delete a device token from the backend. Called on sign-out.
+    @discardableResult
+    func unregisterPushToken(
+        email: String,
+        deviceToken: String
+    ) async throws -> SuccessResponse
 }
 
 // Conformance on the real service — ensures production callers can keep using

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -238,6 +238,11 @@ final class ShareComposerViewModel {
                 genreTags: capturedGenres
             )
 
+            // Value-moment trigger for the APNs permission prompt — fire-and-forget.
+            // `NotificationsService` gates on `hasPromptedForPush` so this only
+            // ever surfaces the iOS dialog on the first successful share.
+            Task { await NotificationsService.shared.requestPermissionIfNeeded() }
+
             if let returned = response.share {
                 return returned
             }

--- a/Xomify-iOS/ViewModels/FriendsViewModel.swift
+++ b/Xomify-iOS/ViewModels/FriendsViewModel.swift
@@ -139,6 +139,9 @@ final class FriendsViewModel {
             incoming.removeAll { $0.targetEmail == targetEmail }
             accepted.append(friend)
             updateDiscoverFlags(for: targetEmail, isFriend: true)
+            // Value-moment: first accepted friend request is a solid signal the
+            // user wants to engage — prompt for push permission if we haven't.
+            Task { await NotificationsService.shared.requestPermissionIfNeeded() }
         } catch {
             errorMessage = "Failed to accept: \(error.localizedDescription)"
             print("❌ Friends: accept failed - \(error)")
@@ -251,6 +254,9 @@ final class FriendsViewModel {
 
         do {
             let response = try await xomify.acceptInvite(email: userEmail, inviteCode: code)
+            // Value-moment: accepting a deep-link invite = user just crossed a
+            // meaningful threshold. Prompt for push permission if we haven't.
+            Task { await NotificationsService.shared.requestPermissionIfNeeded() }
             // Remove the accepted row from the pending list.
             if let senderEmail = incomingInvites.first(where: { $0.inviteCode == code })?.senderEmail {
                 incomingInvites.removeAll { $0.inviteCode == code }

--- a/Xomify-iOS/ViewModels/SettingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftUI
+import UserNotifications
+
+/// Drives the Settings screen's notification section. Views never call
+/// `NotificationsService` directly — every toggle flip routes through here.
+///
+/// State mirrors `@AppStorage` (persisted across launches) but exposes the
+/// values as `@Observable` fields so the view can bind without leaking
+/// persistence concerns.
+@Observable
+@MainActor
+final class SettingsViewModel {
+
+    // MARK: - Persisted toggle keys (shared with NotificationsService)
+
+    static let queueEnabledKey = NotificationsService.queueEnabledKey
+    static let digestEnabledKey = NotificationsService.digestEnabledKey
+
+    // MARK: - State
+
+    /// Queue-threshold push opt-in. Persisted to UserDefaults immediately on set.
+    var queueNotificationsEnabled: Bool {
+        didSet {
+            guard oldValue != queueNotificationsEnabled else { return }
+            defaults.set(queueNotificationsEnabled, forKey: Self.queueEnabledKey)
+            syncPreferences()
+        }
+    }
+
+    /// Weekly digest push opt-in.
+    var digestEnabled: Bool {
+        didSet {
+            guard oldValue != digestEnabled else { return }
+            defaults.set(digestEnabled, forKey: Self.digestEnabledKey)
+            syncPreferences()
+        }
+    }
+
+    /// Current system-level APNs authorization. Polled on view appear.
+    var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    // MARK: - Dependencies
+
+    private let notificationsService: NotificationsService
+    private let defaults: UserDefaults
+
+    // MARK: - Init
+
+    init(
+        notificationsService: NotificationsService = NotificationsService.shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.notificationsService = notificationsService
+        self.defaults = defaults
+
+        // Default both toggles to true (matches backend default + the
+        // previously-stubbed `@AppStorage` defaults on `SettingsView`).
+        self.queueNotificationsEnabled = defaults.object(forKey: Self.queueEnabledKey) as? Bool ?? true
+        self.digestEnabled = defaults.object(forKey: Self.digestEnabledKey) as? Bool ?? true
+    }
+
+    // MARK: - Lifecycle
+
+    /// Refresh the authorization status. Called on view appear.
+    func refreshAuthorizationStatus() async {
+        authorizationStatus = await notificationsService.currentAuthorizationStatus()
+    }
+
+    // MARK: - Derived UI state
+
+    /// Whether the toggles should be editable. Disabled when the user has
+    /// denied permission — they must visit System Settings first.
+    var togglesEnabled: Bool {
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined, .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    /// Copy shown below the notifications section footer.
+    var statusFooter: String {
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return "Preferences sync instantly when you toggle them."
+        case .notDetermined:
+            return "Enable notifications to use these toggles."
+        case .denied:
+            return "Notifications are disabled in System Settings. Tap below to turn them on."
+        @unknown default:
+            return ""
+        }
+    }
+
+    // MARK: - System settings deep link
+
+    /// URL used by the Settings screen's "Open System Settings" button when
+    /// permission has been denied.
+    var systemSettingsURL: URL? {
+        URL(string: UIApplication.openSettingsURLString)
+    }
+
+    // MARK: - Private
+
+    /// Push the latest flags to the backend. Swallows network errors so the UI
+    /// stays responsive; the local `@AppStorage` value is the source of truth
+    /// and the backend reconciles on next register.
+    private func syncPreferences() {
+        let queue = queueNotificationsEnabled
+        let digest = digestEnabled
+        Task { @MainActor in
+            await notificationsService.updatePreferences(
+                queueNotificationsEnabled: queue,
+                digestEnabled: digest
+            )
+        }
+    }
+}

--- a/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
@@ -1,19 +1,15 @@
 import SwiftUI
+import UserNotifications
 
-/// Drawer-resident Settings screen. Covers notification toggles (stubbed until #9),
-/// version info, legal links, support email, and a destructive Sign out action.
+/// Drawer-resident Settings screen. Covers notification toggles, version info,
+/// legal links, support email, and a destructive Sign out action.
+///
+/// Notification toggles are mediated by `SettingsViewModel` (sub-feature #9 —
+/// `ios-notifications`) which mirrors them into `@AppStorage` and POSTs to
+/// `/notifications/register` as an upsert on each flip.
 struct SettingsView: View {
 
-    // MARK: - Persisted toggles
-    // Both keys are stub-wired. Real APNs registration + preferences sync to backend
-    // land in sub-feature #9 (`ios-notifications`).
-
-    @AppStorage("notifications.push.enabled")
-    private var pushEnabled: Bool = true
-
-    @AppStorage("notifications.digest.enabled")
-    private var digestEnabled: Bool = true
-
+    @State private var viewModel = SettingsViewModel()
     @State private var showSignOutConfirm = false
 
     private let supportEmailURL = URL(string: "mailto:support@xomware.com")
@@ -33,6 +29,9 @@ struct SettingsView: View {
         .background(Color.xomifyDark.ignoresSafeArea())
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.refreshAuthorizationStatus()
+        }
         .confirmationDialog(
             "Sign out of Xomify?",
             isPresented: $showSignOutConfirm,
@@ -49,24 +48,35 @@ struct SettingsView: View {
 
     private var notificationsSection: some View {
         Section {
-            // TODO(#9): wire to NotificationsService.registerDeviceToken once ios-notifications ships.
-            Toggle(isOn: $pushEnabled) {
+            Toggle(isOn: $viewModel.queueNotificationsEnabled) {
                 Label("Push notifications", systemImage: "bell.fill")
                     .foregroundStyle(.white)
             }
             .tint(Color.xomifyGreen)
+            .disabled(!viewModel.togglesEnabled)
+            .accessibilityHint("Queue-threshold push notifications")
 
-            // TODO(#9): wire to NotificationsService.updateDigestPreference once ios-notifications ships.
-            Toggle(isOn: $digestEnabled) {
+            Toggle(isOn: $viewModel.digestEnabled) {
                 Label("Weekly digest", systemImage: "envelope.fill")
                     .foregroundStyle(.white)
             }
             .tint(Color.xomifyGreen)
+            .disabled(!viewModel.togglesEnabled)
+            .accessibilityHint("Weekly digest push notifications")
+
+            if viewModel.authorizationStatus == .denied,
+               let url = viewModel.systemSettingsURL {
+                Link(destination: url) {
+                    Label("Open System Settings", systemImage: "gear")
+                        .foregroundStyle(Color.xomifyGreen)
+                }
+                .accessibilityHint("Opens the iOS Settings app to enable notifications")
+            }
         } header: {
             Text("Notifications")
                 .foregroundStyle(.gray)
         } footer: {
-            Text("Preferences take effect in a future update.")
+            Text(viewModel.statusFooter)
                 .font(.caption2)
                 .foregroundStyle(.gray)
         }

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -70,6 +70,9 @@ struct MainShell: View {
         .environment(navStore)
         .ignoresSafeArea(edges: .bottom)
         .task {
+            // Share the nav store with the push pipeline so `didReceive` can
+            // tab-switch into Feed on push-open.
+            NotificationsService.shared.navigationStore = navStore
             await fetchAvatar()
         }
         .onChange(of: navStore.pendingDeepLink) { _, newValue in

--- a/Xomify-iOS/Xomify-iOS.entitlements
+++ b/Xomify-iOS/Xomify-iOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:xomify.xomware.com</string>

--- a/Xomify-iOSTests/MockXomifyServicing.swift
+++ b/Xomify-iOSTests/MockXomifyServicing.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import Xomify_iOS
+
+/// Lightweight mock implementing the full `XomifyServicing` protocol for use
+/// in unit tests. Each call records its arguments for later assertion;
+/// successful responses are returned by default and individual methods can be
+/// stubbed to throw by setting the corresponding `...Error` property.
+final class MockXomifyServicing: XomifyServicing, @unchecked Sendable {
+
+    // MARK: - Register / unregister
+
+    struct RegisterCall: Equatable {
+        let email: String
+        let deviceToken: String
+        let queueNotificationsEnabled: Bool
+        let digestEnabled: Bool
+    }
+
+    struct UnregisterCall: Equatable {
+        let email: String
+        let deviceToken: String
+    }
+
+    private(set) var registerCalls: [RegisterCall] = []
+    private(set) var unregisterCalls: [UnregisterCall] = []
+
+    var registerError: Error?
+    var unregisterError: Error?
+
+    func registerPushToken(
+        email: String,
+        deviceToken: String,
+        queueNotificationsEnabled: Bool,
+        digestEnabled: Bool
+    ) async throws -> SuccessResponse {
+        registerCalls.append(RegisterCall(
+            email: email,
+            deviceToken: deviceToken,
+            queueNotificationsEnabled: queueNotificationsEnabled,
+            digestEnabled: digestEnabled
+        ))
+        if let registerError { throw registerError }
+        return SuccessResponse(success: true)
+    }
+
+    func unregisterPushToken(
+        email: String,
+        deviceToken: String
+    ) async throws -> SuccessResponse {
+        unregisterCalls.append(UnregisterCall(email: email, deviceToken: deviceToken))
+        if let unregisterError { throw unregisterError }
+        return SuccessResponse(success: true)
+    }
+
+    // MARK: - Friends (unused — returned as empty / success stubs)
+
+    func getAllFriends(email: String) async throws -> FriendsAllResponse {
+        FriendsAllResponse(
+            email: email,
+            accepted: [], requested: [], pending: [], blocked: [],
+            acceptedCount: 0, requestedCount: 0, pendingCount: 0, blockedCount: 0,
+            totalCount: 0
+        )
+    }
+
+    func listUsers(email: String) async throws -> UserListResponse {
+        UserListResponse(users: [], totalCount: 0)
+    }
+
+    func requestFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+
+    func acceptFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+
+    func rejectFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+
+    func removeFriend(email: String, friendEmail: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+
+    // MARK: - Invites
+
+    func createInvite(email: String) async throws -> InviteCreateResponse {
+        InviteCreateResponse(
+            success: true,
+            inviteCode: "mock-code",
+            shareUrl: "https://xomify.xomware.com/invite/mock-code",
+            expiresAt: nil,
+            status: "active"
+        )
+    }
+
+    func acceptInvite(email: String, inviteCode: String) async throws -> InviteAcceptResponse {
+        InviteAcceptResponse(success: true, inviteCode: inviteCode, friendEmail: nil)
+    }
+
+    func listPendingInvites(email: String) async throws -> PendingInvitesResponse {
+        PendingInvitesResponse(email: email, invites: [], totalCount: 0)
+    }
+
+    func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+}

--- a/Xomify-iOSTests/NotificationsServiceTests.swift
+++ b/Xomify-iOSTests/NotificationsServiceTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+import UserNotifications
+@testable import Xomify_iOS
+
+/// Unit tests for `NotificationsService`.
+///
+/// NOTE: No XCTest target is wired into the Xcode project yet. These tests
+/// live here as the reference suite for when `Xomify-iOSTests` is added. Run
+/// with `xcodebuild test` once the target ships.
+@MainActor
+final class NotificationsServiceTests: XCTestCase {
+
+    // MARK: - Token hex encoding
+
+    func test_hexString_encodesKnownBytes() {
+        let bytes: [UInt8] = [0x00, 0x01, 0x02, 0xFF, 0xAB, 0xCD]
+        let hex = NotificationsService.hexString(from: Data(bytes))
+        XCTAssertEqual(hex, "000102ffabcd")
+    }
+
+    func test_hexString_emptyData_returnsEmptyString() {
+        XCTAssertEqual(NotificationsService.hexString(from: Data()), "")
+    }
+
+    func test_hexString_singleByte() {
+        XCTAssertEqual(NotificationsService.hexString(from: Data([0x7F])), "7f")
+    }
+
+    // MARK: - Permission prompt gate
+
+    func test_requestPermissionIfNeeded_firstCall_setsHasPromptedFlag() async {
+        let defaults = makeIsolatedDefaults()
+        let service = NotificationsService(xomify: MockXomifyServicing(), defaults: defaults)
+
+        // The real call hits UNUserNotificationCenter which requires a host
+        // app — we can't fully drive it in a unit test. The gate check is
+        // what we're proving: if the flag is already true we bail early and
+        // do nothing, so subsequent calls don't re-prompt.
+        defaults.set(true, forKey: NotificationsService.hasPromptedKey)
+        await service.requestPermissionIfNeeded()
+        // No crash = no-op path taken.
+        XCTAssertTrue(defaults.bool(forKey: NotificationsService.hasPromptedKey))
+    }
+
+    // MARK: - Push payload inference
+
+    func test_pushPayload_queueThreshold_inferredFromShareId() {
+        let userInfo: [AnyHashable: Any] = [
+            "aps": ["alert": ["title": "x", "body": "y"]],
+            "shareId": "share-123",
+            "trackId": "track-abc",
+            "reactorCount": 5
+        ]
+        let payload = PushPayload(userInfo: userInfo)
+        XCTAssertEqual(payload.kind, .queueThreshold)
+        XCTAssertEqual(payload.shareId, "share-123")
+        XCTAssertEqual(payload.trackId, "track-abc")
+        XCTAssertEqual(payload.reactorCount, 5)
+    }
+
+    func test_pushPayload_digest_inferredFromWindowDays() {
+        let userInfo: [AnyHashable: Any] = [
+            "aps": ["alert": ["title": "x", "body": "y"]],
+            "count": 3,
+            "windowDays": 7
+        ]
+        let payload = PushPayload(userInfo: userInfo)
+        XCTAssertEqual(payload.kind, .digest)
+        XCTAssertNil(payload.shareId)
+        XCTAssertEqual(payload.count, 3)
+        XCTAssertEqual(payload.windowDays, 7)
+    }
+
+    func test_pushPayload_unknown_whenNoSignals() {
+        let userInfo: [AnyHashable: Any] = [
+            "aps": ["alert": ["title": "x", "body": "y"]]
+        ]
+        let payload = PushPayload(userInfo: userInfo)
+        XCTAssertEqual(payload.kind, .unknown)
+    }
+
+    func test_pushPayload_acceptsStringIntegers() {
+        // DynamoDB / JSON wire can surface numerics as strings. Make sure we
+        // coerce them.
+        let userInfo: [AnyHashable: Any] = [
+            "shareId": "s1",
+            "reactorCount": "5"
+        ]
+        let payload = PushPayload(userInfo: userInfo)
+        XCTAssertEqual(payload.kind, .queueThreshold)
+        XCTAssertEqual(payload.reactorCount, 5)
+    }
+
+    // MARK: - handlePushOpen routes to feed
+
+    func test_handlePushOpen_queueThreshold_routesToFeed() async {
+        let defaults = makeIsolatedDefaults()
+        let service = NotificationsService(xomify: MockXomifyServicing(), defaults: defaults)
+        let nav = NavigationStore()
+        nav.selectedTab = .home
+        service.navigationStore = nav
+
+        service.handlePushOpen(
+            payload: PushPayload(kind: .queueThreshold, shareId: "s1")
+        )
+
+        XCTAssertEqual(nav.selectedTab, .feed)
+    }
+
+    func test_handlePushOpen_digest_routesToFeed() async {
+        let defaults = makeIsolatedDefaults()
+        let service = NotificationsService(xomify: MockXomifyServicing(), defaults: defaults)
+        let nav = NavigationStore()
+        nav.selectedTab = .home
+        service.navigationStore = nav
+
+        service.handlePushOpen(
+            payload: PushPayload(kind: .digest, count: 3, windowDays: 7)
+        )
+
+        XCTAssertEqual(nav.selectedTab, .feed)
+    }
+
+    func test_handlePushOpen_unknown_doesNotChangeTab() async {
+        let defaults = makeIsolatedDefaults()
+        let service = NotificationsService(xomify: MockXomifyServicing(), defaults: defaults)
+        let nav = NavigationStore()
+        nav.selectedTab = .home
+        service.navigationStore = nav
+
+        service.handlePushOpen(payload: PushPayload(kind: .unknown))
+
+        XCTAssertEqual(nav.selectedTab, .home)
+    }
+
+    // MARK: - Register body shape
+
+    func test_registerPushToken_usesCorrectBodyShape() async throws {
+        let mock = MockXomifyServicing()
+        _ = try await mock.registerPushToken(
+            email: "user@example.com",
+            deviceToken: "abcdef",
+            queueNotificationsEnabled: true,
+            digestEnabled: false
+        )
+        XCTAssertEqual(mock.registerCalls.count, 1)
+        let call = try XCTUnwrap(mock.registerCalls.first)
+        XCTAssertEqual(call.email, "user@example.com")
+        XCTAssertEqual(call.deviceToken, "abcdef")
+        XCTAssertTrue(call.queueNotificationsEnabled)
+        XCTAssertFalse(call.digestEnabled)
+    }
+
+    func test_unregisterPushToken_usesCorrectBodyShape() async throws {
+        let mock = MockXomifyServicing()
+        _ = try await mock.unregisterPushToken(
+            email: "user@example.com",
+            deviceToken: "abcdef"
+        )
+        XCTAssertEqual(mock.unregisterCalls.count, 1)
+        let call = try XCTUnwrap(mock.unregisterCalls.first)
+        XCTAssertEqual(call.email, "user@example.com")
+        XCTAssertEqual(call.deviceToken, "abcdef")
+    }
+
+    // MARK: - Helpers
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "NotificationsServiceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+}

--- a/Xomify-iOSTests/SettingsViewModelTests.swift
+++ b/Xomify-iOSTests/SettingsViewModelTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import Xomify_iOS
+
+/// Tests for `SettingsViewModel`. Verifies toggle flips persist to the
+/// injected `UserDefaults` and dispatch to `NotificationsService.updatePreferences`.
+@MainActor
+final class SettingsViewModelTests: XCTestCase {
+
+    func test_init_defaultsToggleValuesToTrue() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+        XCTAssertTrue(vm.queueNotificationsEnabled)
+        XCTAssertTrue(vm.digestEnabled)
+    }
+
+    func test_init_readsPersistedValues() {
+        let defaults = makeIsolatedDefaults()
+        defaults.set(false, forKey: SettingsViewModel.queueEnabledKey)
+        defaults.set(false, forKey: SettingsViewModel.digestEnabledKey)
+
+        let vm = SettingsViewModel(defaults: defaults)
+        XCTAssertFalse(vm.queueNotificationsEnabled)
+        XCTAssertFalse(vm.digestEnabled)
+    }
+
+    func test_toggleQueueEnabled_persistsToDefaults() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+
+        vm.queueNotificationsEnabled = false
+
+        XCTAssertEqual(defaults.object(forKey: SettingsViewModel.queueEnabledKey) as? Bool, false)
+    }
+
+    func test_toggleDigestEnabled_persistsToDefaults() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+
+        vm.digestEnabled = false
+
+        XCTAssertEqual(defaults.object(forKey: SettingsViewModel.digestEnabledKey) as? Bool, false)
+    }
+
+    func test_togglesEnabled_authorized_returnsTrue() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+        vm.authorizationStatus = .authorized
+        XCTAssertTrue(vm.togglesEnabled)
+    }
+
+    func test_togglesEnabled_denied_returnsFalse() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+        vm.authorizationStatus = .denied
+        XCTAssertFalse(vm.togglesEnabled)
+    }
+
+    func test_togglesEnabled_notDetermined_returnsFalse() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+        vm.authorizationStatus = .notDetermined
+        XCTAssertFalse(vm.togglesEnabled)
+    }
+
+    func test_statusFooter_reflectsStatus() {
+        let defaults = makeIsolatedDefaults()
+        let vm = SettingsViewModel(defaults: defaults)
+
+        vm.authorizationStatus = .authorized
+        XCTAssertTrue(vm.statusFooter.contains("sync"))
+
+        vm.authorizationStatus = .denied
+        XCTAssertTrue(vm.statusFooter.contains("System Settings"))
+
+        vm.authorizationStatus = .notDetermined
+        XCTAssertTrue(vm.statusFooter.contains("Enable"))
+    }
+
+    // MARK: - Helpers
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suite = "SettingsViewModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

Implements iOS push notifications end-to-end per `docs/features/ios-notifications/PLAN.md`.

- `XomifyAppDelegate` (via `@UIApplicationDelegateAdaptor`) forwards APNs token + remote-notification callbacks to `NotificationsService`.
- `NotificationsService` owns: one-shot permission prompt, hex-encoded device-token lifecycle, `/notifications/register` + `/notifications/unregister` upserts, foreground presentation (digest silent, queue-threshold banner+sound), and push-open routing to the Feed tab via `NavigationStore`.
- `XomifyServicing` extended with `registerPushToken` / `unregisterPushToken`. Body shape matches `lambdas/notifications_register/handler.py` (camelCase: `email`, `deviceToken`, `queueNotificationsEnabled`, `digestEnabled`).
- `PushPayload` parses APNs `customData` — `shareId` → `queueThreshold`, `windowDays` → `digest` — matching `notifications_send/handler.py`'s flattened top-level payload (no explicit `pushType` key).
- Trigger points: `ShareComposerViewModel.submit` + `FriendsViewModel.accept(_:)` / `FriendsViewModel.acceptInvite(code:)` call `requestPermissionIfNeeded()` on success. One-shot — re-denies land users on the "Open System Settings" link in the Settings drawer.
- `SettingsView` now routes through `SettingsViewModel` (`@Observable`); toggle flips persist to `UserDefaults` and upsert the preference pair to the backend. Disabled + deep-link-to-Settings when permission is denied.
- `AuthService.logout()` calls `NotificationsService.unregister()` before clearing Spotify tokens. Unregister uses a cached email (written after the first successful register) so it works even after the access token has been cleared.
- Entitlements: `aps-environment = \$(APS_ENVIRONMENT)`. Target build settings: `APS_ENVIRONMENT=development` (Debug), `APS_ENVIRONMENT=production` (Release).
- Tests at `Xomify-iOSTests/`: hex encoding, payload inference, push-open routing, Settings VM persistence + auth states, mock `XomifyServicing`.

## Xcode: enable Push Notifications capability

The entitlement is already written, but the capability itself still has to be toggled on the target once. Steps:

1. Open `Xomify-iOS.xcodeproj` in Xcode.
2. Select the project in the navigator, then select the **Xomify-iOS** target.
3. Click the **Signing & Capabilities** tab.
4. Make sure the correct **Team** is selected and **Automatically manage signing** is on.
5. Click **+ Capability** (top-left of the Signing & Capabilities pane).
6. Search for **Push Notifications** and double-click it. It appears in the capabilities list underneath Associated Domains.
7. Repeat for any additional build configuration rows if Xcode shows per-configuration tabs (Debug / Release / etc.). The `aps-environment` value is already wired to `\$(APS_ENVIRONMENT)`, so you do not need to edit the entitlements file by hand.
8. Commit the pbxproj diff Xcode generates (the capability adds `SystemCapabilities` entries to the target).

## Dependencies / rollout notes

- Backend APNs secrets in SSM must be populated before real pushes can be sent end-to-end. Local toggle flips will still upsert preferences with the cached token regardless.
- **Simulator limitation**: APNs device-token registration silently fails in the iOS Simulator for older simulators. Xcode 14+ simulators can deliver simulated pushes, but real `didRegisterForRemoteNotificationsWithDeviceToken` callbacks require a physical device with a provisioning profile that includes the Push Notifications entitlement.

## Test plan

- [ ] On a physical device: fresh install → first share → permission prompt fires → grant → POST to `/notifications/register` succeeds (check CloudWatch logs).
- [ ] Deny on prompt → Settings drawer shows toggles disabled and "Open System Settings" link visible.
- [ ] Toggle "Push notifications" off in Settings → next `/notifications/register` upsert reflects `queueNotificationsEnabled: false`.
- [ ] Receive a queue-threshold push while app is foregrounded → banner + sound present.
- [ ] Receive a digest push while app is foregrounded → no banner (silent).
- [ ] Tap a queue-threshold push from lock screen → app opens on Feed tab.
- [ ] Sign out → `/notifications/unregister` is called with cached email + token.
- [ ] Simulator: confirm app launches without crashing even though APNs registration will log a soft failure.

Screenshots: TBD (will capture on device once capability is enabled).

Closes #<push-notifications issue>