### PR TITLE
feat(ios): enable reactions flag

### DIFF
--- a/Xomify-iOS/Services/FeatureFlags.swift
+++ b/Xomify-iOS/Services/FeatureFlags.swift
@@ -6,8 +6,7 @@ import Foundation
 /// remote-config or A/B testing — this is deliberately dumb and grep-able.
 enum FeatureFlags {
 
-    /// Reactions UI on share cards. Wired to the eventual `/shares/react`
-    /// endpoint that sub-feature 4 (`backend-interactions-and-notifications`)
-    /// is building. Keep `false` until that endpoint is deployed.
-    static let reactionsEnabled: Bool = false
+    /// Reactions UI on share cards. Wired to `/shares/react` from
+    /// `backend-interactions-and-notifications` (PR #131, shipped).
+    static let reactionsEnabled: Bool = true
 }


### PR DESCRIPTION
## Summary
- Flips `FeatureFlags.reactionsEnabled` from `false` → `true`
- `/shares/react` is live as of backend PR #131 (merged), so the star-rating UI on share cards can now light up.

## Test plan
- [ ] Build Debug + Release locally
- [ ] Tap a share card, confirm the rating control is visible and a tap round-trips through `/shares/react`