### PR TITLE
chore(ci): fetch TestFlight config from SSM, not GH secrets

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -24,13 +24,32 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
 
-      - name: Write secrets.xcconfig
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Fetch app config from SSM and write secrets.xcconfig
         run: |
+          set -euo pipefail
+
+          SPOTIFY_CLIENT_ID=$(aws ssm get-parameter --name /xomify/spotify/CLIENT_ID --with-decryption --query 'Parameter.Value' --output text)
+          SPOTIFY_CLIENT_SECRET=$(aws ssm get-parameter --name /xomify/spotify/CLIENT_SECRET --with-decryption --query 'Parameter.Value' --output text)
+          XOMIFY_API_ID=$(aws ssm get-parameter --name /xomify/api/API_ID --with-decryption --query 'Parameter.Value' --output text)
+          XOMIFY_API_TOKEN=$(aws ssm get-parameter --name /xomify/api/API_AUTH_TOKEN --with-decryption --query 'Parameter.Value' --output text)
+
+          echo "::add-mask::$SPOTIFY_CLIENT_ID"
+          echo "::add-mask::$SPOTIFY_CLIENT_SECRET"
+          echo "::add-mask::$XOMIFY_API_ID"
+          echo "::add-mask::$XOMIFY_API_TOKEN"
+
           cat > secrets.xcconfig << XCCONFIG
-          SPOTIFY_CLIENT_ID = ${{ secrets.SPOTIFY_CLIENT_ID }}
-          SPOTIFY_CLIENT_SECRET = ${{ secrets.SPOTIFY_CLIENT_SECRET }}
-          XOMIFY_API_ID = ${{ secrets.XOMIFY_API_ID }}
-          XOMIFY_API_TOKEN = ${{ secrets.XOMIFY_API_TOKEN }}
+          SPOTIFY_CLIENT_ID = $SPOTIFY_CLIENT_ID
+          SPOTIFY_CLIENT_SECRET = $SPOTIFY_CLIENT_SECRET
+          XOMIFY_API_ID = $XOMIFY_API_ID
+          XOMIFY_API_TOKEN = $XOMIFY_API_TOKEN
           XCCONFIG
 
       - name: Write App Store Connect API key


### PR DESCRIPTION
## Why
Today the iOS app 403'd on every API call. Root cause: \`XOMIFY_API_TOKEN\` in the iOS repo secrets diverged from \`/xomify/api/API_AUTH_TOKEN\` in SSM (someone pasted the wrong value). The web frontend pulls that param from SSM at build time and stayed correct; iOS was reading a stale GH secret and shipping it into \`secrets.xcconfig\`.

This PR deletes the GH-secret-based flow and mirrors the xomify-frontend pattern: AWS creds → \`aws ssm get-parameter\` → write \`secrets.xcconfig\`.

## Change
- Adds \`aws-actions/configure-aws-credentials\` step (requires \`AWS_ACCESS_KEY_ID\` + \`AWS_SECRET_ACCESS_KEY\` repo secrets — see below).
- Replaces the old \`Write secrets.xcconfig\` step with an SSM-fetch + write step. All 4 values get \`::add-mask::\`'d so they don't leak in logs.
- Fetches: \`/xomify/spotify/CLIENT_ID\`, \`/xomify/spotify/CLIENT_SECRET\`, \`/xomify/api/API_ID\`, \`/xomify/api/API_AUTH_TOKEN\`.

Apple-specific secrets (\`ASC_*\`, \`APPLE_TEAM_ID\`) stay as GH repo secrets — they're Apple-account-scoped and don't live in AWS.

## Action required BEFORE merge
1. Add AWS creds to this repo's secrets: https://github.com/Xomware/xomify-ios/settings/secrets/actions
   - \`AWS_ACCESS_KEY_ID\`
   - \`AWS_SECRET_ACCESS_KEY\`
   Same pair used by xomify-frontend — reuse those values.
2. The IAM user/role behind those keys needs \`ssm:GetParameter\` on the 4 param paths above. The xomify-frontend key already has this, so reusing it should just work.

## Post-merge verification
- Run workflow on master → TestFlight build should succeed and upload.
- Install new TestFlight, confirm no 403s on API calls.
- Once verified, delete these now-unused repo secrets: \`SPOTIFY_CLIENT_ID\`, \`SPOTIFY_CLIENT_SECRET\`, \`XOMIFY_API_ID\`, \`XOMIFY_API_TOKEN\`.

## Follow-up (not this PR)
Bug-report today showed that the API token desync has been invisible to monitoring. Consider: the iOS app should surface 401/403 responses distinctly in the UI (generic "something went wrong" currently hides auth failures), and CloudWatch could alarm on authorizer deny spikes.