### PR TITLE
fix(ios): align stale backend routes causing Wrapped/Profile 403s

### DIFF
--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -233,17 +233,18 @@ final class AuthService: NSObject, Sendable {
         
         print("📤 Auth: Saving refresh token to Xomify backend...")
         
-        let url = URL(string: "\(xomifyApiUrl)/user/user-table")!
+        let url = URL(string: "\(xomifyApiUrl)/user/update")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(xomifyApiToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+
         let body: [String: Any] = [
             "email": userProfile.email,
             "userId": userProfile.id,
             "displayName": userProfile.displayName ?? userProfile.email,
-            "refreshToken": refresh
+            "refreshToken": refresh,
+            "avatar": userProfile.images?.first?.url ?? ""
         ]
         
         do {
@@ -428,12 +429,18 @@ private struct SpotifyUserProfile: Codable {
     let id: String
     let email: String
     let displayName: String?
-    
+    let images: [SpotifyImage]?
+
     enum CodingKeys: String, CodingKey {
         case id
         case email
         case displayName = "display_name"
+        case images
     }
+}
+
+private struct SpotifyImage: Codable {
+    let url: String
 }
 
 // MARK: - Auth Errors

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -15,24 +15,24 @@ actor XomifyService {
     
     /// Get user enrollment status and wraps
     func getUserData(email: String) async throws -> WrappedDataResponse {
-        try await network.xomifyGet("/wrapped/data", queryParams: ["email": email])
+        try await network.xomifyGet("/wrapped/all", queryParams: ["email": email])
     }
-    
+
     /// Get user table data
     func getUserTableData(email: String) async throws -> XomifyUser {
-        try await network.xomifyGet("/user/user-table", queryParams: ["email": email])
+        try await network.xomifyGet("/user/data", queryParams: ["email": email])
     }
-    
+
     /// Enroll or update user enrollments
     func updateEnrollments(
         email: String,
         activeWrapped: Bool,
         activeReleaseRadar: Bool
     ) async throws {
-        let _: EmptyResponse = try await network.xomifyPost("/user/user-table", body: [
+        let _: EmptyResponse = try await network.xomifyPost("/user/update", body: [
             "email": email,
-            "activeWrapped": activeWrapped,
-            "activeReleaseRadar": activeReleaseRadar
+            "wrappedEnrolled": activeWrapped,
+            "releaseRadarEnrolled": activeReleaseRadar
         ])
     }
     
@@ -54,9 +54,9 @@ actor XomifyService {
     
     // MARK: - Wrapped
     
-    /// Get all wraps from wrapped/data endpoint
+    /// Get all wraps
     func getWraps(email: String) async throws -> [MonthlyWrap] {
-        let response: WrappedDataResponse = try await network.xomifyGet("/wrapped/data", queryParams: ["email": email])
+        let response: WrappedDataResponse = try await network.xomifyGet("/wrapped/all", queryParams: ["email": email])
         return response.wraps ?? []
     }
     


### PR DESCRIPTION
## Summary
- iOS was calling `/wrapped/data`, `/user/user-table` (GET), `/user/user-table` (POST) — routes that were renamed during the backend single-lambda refactor. API Gateway returns 403 "Missing Authentication Token" for any route that doesn't exist, which is exactly what was showing up on the Wrapped, Profile, and enrollment screens in TestFlight today.
- Re-pointed to the live routes (`/wrapped/all`, `/user/data`, `/user/update`) and updated the `user/update` request body to match the new contract (`wrappedEnrolled` / `releaseRadarEnrolled` instead of `active*`, plus the required `avatar` field on refresh-token updates).
- Verified against API Gateway (`wkuh988iah`) — only the three old paths were stale; all other `/friends/*`, `/groups/*`, `/ratings/*`, `/release-radar/*`, `/shares/*`, `/invites/*`, `/notifications/*` paths already matched.

## Test plan
- [ ] Install TestFlight build, log in, confirm profile enrollment state loads correctly (not stuck "not enrolled")
- [ ] Wrapped tab: no more 403, wraps render
- [ ] Release Radar tab: loads history without 403 (was cascading from the enrollment check)
- [ ] Toggle a wrapped enrollment off/on → hits `/user/update` with the new field names, persists
- [ ] Re-login → refresh token save still succeeds (avatar now populated from Spotify `/me.images`)