### PR TITLE
feat(ios): sidebar-only IA + Settings carve-out

### DIFF
--- a/Xomify-iOS/Navigation/NavigationStore.swift
+++ b/Xomify-iOS/Navigation/NavigationStore.swift
@@ -1,40 +1,19 @@
 import SwiftUI
 
-// MARK: - ShellTab
+// MARK: - SidebarDestination
 
-enum ShellTab: Hashable, CaseIterable {
-    case home, feed, releases, builder
-
-    var label: String {
-        switch self {
-        case .home:     "Home"
-        case .feed:     "Feed"
-        case .releases: "Releases"
-        case .builder:  "Builder"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .home:     "house.fill"
-        case .feed:     "sparkles"
-        case .releases: "antenna.radiowaves.left.and.right"
-        case .builder:  "music.note.list"
-        }
-    }
-}
-
-// MARK: - DrawerDestination
-
-enum DrawerDestination: Hashable {
-    case profile
-    case stats
-    case following
-    case friends
+/// All top-level destinations reachable from the sidebar drawer.
+/// This is the sole primary-navigation enum — `ShellTab` has been removed.
+enum SidebarDestination: Hashable {
+    case feed
+    case wrapped
+    case releaseRadar
+    case ratings
     case groups
-    case ratingsHistory
+    case friends
+    case profile
     case settings
-    case helpAbout
+    case builder
 }
 
 // MARK: - NavigationStore
@@ -42,19 +21,23 @@ enum DrawerDestination: Hashable {
 @Observable
 @MainActor
 final class NavigationStore {
-    var selectedTab: ShellTab = .home
+
+    /// The currently visible full-screen destination. Defaults to Feed on cold launch.
+    var currentDestination: SidebarDestination = .feed
+
     var isDrawerOpen: Bool = false
-    var drawerPath: [DrawerDestination] = []
 
-    // MARK: - Feed integration (ios-feed)
+    // MARK: - Feed integration
 
-    /// Toggled by the Feed tab's FAB and by composer dismissal.
+    /// Toggled by the Feed screen's FAB and by composer dismissal.
     var composerSheetPresented: Bool = false
 
-    /// Set by the Feed empty-state CTAs. `MainShell` observes this, opens the
-    /// drawer, and consumes the value via `consumePendingDeepLink()` on the
-    /// next runloop so the drawer animation and path push don't race.
-    var pendingDeepLink: DrawerDestination?
+    /// Set by the Feed empty-state CTAs. `MainShell` observes this and calls
+    /// `consumePendingDeepLink()` on the next runloop so the drawer animation
+    /// and destination switch don't race.
+    var pendingDeepLink: SidebarDestination?
+
+    // MARK: - Drawer control
 
     func openDrawer() {
         withAnimation(.easeInOut(duration: 0.25)) {
@@ -65,28 +48,32 @@ final class NavigationStore {
     func closeDrawer() {
         withAnimation(.easeInOut(duration: 0.25)) {
             isDrawerOpen = false
-            drawerPath.removeAll()
         }
     }
 
-    func navigate(to destination: DrawerDestination) {
-        drawerPath.append(destination)
+    /// Select a sidebar destination. Sets `currentDestination` and closes the
+    /// drawer in a single animation block so the dismiss + content swap happen
+    /// together without an intermediate flash.
+    func select(_ destination: SidebarDestination) {
+        withAnimation(.easeInOut(duration: 0.25)) {
+            currentDestination = destination
+            isDrawerOpen = false
+        }
     }
 
-    // MARK: - Deep link intent
+    // MARK: - Deep-link intent
 
-    /// Request a drawer deep link. The observer (`MainShell`) is responsible
-    /// for opening the drawer and pushing the destination on the path.
-    func requestDeepLink(_ destination: DrawerDestination) {
+    /// Request a navigation deep link. The observer (`MainShell`) is responsible
+    /// for consuming it via `consumePendingDeepLink()` on the next runloop.
+    func requestDeepLink(_ destination: SidebarDestination) {
         pendingDeepLink = destination
     }
 
-    /// Consume the pending deep link, opening the drawer + pushing the
-    /// destination. No-op when no link is pending.
+    /// Consume the pending deep link, switching to the destination.
+    /// No-op when no link is pending.
     func consumePendingDeepLink() {
         guard let destination = pendingDeepLink else { return }
         pendingDeepLink = nil
-        openDrawer()
-        drawerPath.append(destination)
+        select(destination)
     }
 }

--- a/Xomify-iOS/Services/NotificationsService.swift
+++ b/Xomify-iOS/Services/NotificationsService.swift
@@ -263,7 +263,7 @@ extension NotificationsService: UNUserNotificationCenterDelegate {
     func handlePushOpen(payload: PushPayload) {
         switch payload.kind {
         case .queueThreshold, .digest:
-            navigationStore?.selectedTab = .feed
+            navigationStore?.select(.feed)
         case .unknown:
             // Nothing to route — leave the user wherever they were.
             return

--- a/Xomify-iOS/ViewModels/ProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/ProfileViewModel.swift
@@ -1,158 +1,49 @@
 import Foundation
 
-/// ViewModel for the Profile/Home screen
+/// ViewModel for the Profile screen.
+/// Scope: identity (name, email, avatar) + social counts (followers, following).
+/// Settings items (enrollment, account details, logout) live in `SettingsViewModel`.
 @Observable
 @MainActor
 final class ProfileViewModel {
-    
+
     // MARK: - Properties
-    
+
     var user: SpotifyUser?
-    var xomifyUser: XomifyUser?
     var isLoading = false
     var errorMessage: String?
-    
-    // Counts
+
+    /// Number of artists the user follows on Spotify.
     var followingCount = 0
-    var playlistCount = 0
-    
-    // Enrollment states
-    var isWrappedEnrolled = false
-    var isReleaseRadarEnrolled = false
-    var isUpdatingEnrollment = false
-    
+
     private let spotifyService = SpotifyService.shared
-    private let xomifyService = XomifyService.shared
-    private let authService = AuthService.shared
-    
+
     // MARK: - Computed
-    
-    var displayName: String {
-        user?.displayName ?? "User"
-    }
-    
-    var email: String {
-        user?.email ?? ""
-    }
-    
-    var profileImageUrl: URL? {
-        user?.profileImageUrl
-    }
-    
-    var accountType: String {
-        user?.product?.capitalized ?? "Free"
-    }
-    
-    var isPremium: Bool {
-        user?.product?.lowercased() == "premium"
-    }
-    
-    var country: String {
-        user?.country ?? ""
-    }
-    
-    var followersCount: Int {
-        user?.followers?.total ?? 0
-    }
-    
-    var userId: String {
-        user?.id ?? ""
-    }
-    
-    var spotifyProfileUrl: URL? {
-        if let urlString = user?.externalUrls?["spotify"] {
-            return URL(string: urlString)
-        }
-        return nil
-    }
-    
+
+    var displayName: String  { user?.displayName ?? "User" }
+    var email: String        { user?.email ?? "" }
+    var profileImageUrl: URL? { user?.profileImageUrl }
+    var followersCount: Int  { user?.followers?.total ?? 0 }
+
     // MARK: - Actions
-    
+
     func loadProfile() async {
         guard !isLoading else { return }
-        
         isLoading = true
         errorMessage = nil
-        
+
         do {
-            // Load Spotify user
             user = try await spotifyService.getCurrentUser()
-            
-            // Load following count
+
             let followedArtists = try await spotifyService.getFollowedArtists()
             followingCount = followedArtists.count
-            
-            // Load Xomify enrollment status
-            if let email = user?.email {
-                await loadXomifyStatus(email: email)
-            }
-            
-            print("✅ Profile: Loaded - \(displayName), following \(followingCount) artists")
+
+            print("✅ Profile: loaded — \(displayName), following \(followingCount) artists")
         } catch {
             errorMessage = error.localizedDescription
-            print("❌ Profile: Error loading profile - \(error)")
+            print("❌ Profile: error loading — \(error)")
         }
-        
+
         isLoading = false
-    }
-    
-    private func loadXomifyStatus(email: String) async {
-        do {
-            let userData = try await xomifyService.getUserData(email: email)
-            isWrappedEnrolled = userData.activeWrapped
-            isReleaseRadarEnrolled = userData.activeReleaseRadar
-            print("✅ Profile: Loaded enrollment - Wrapped: \(isWrappedEnrolled), ReleaseRadar: \(isReleaseRadarEnrolled)")
-        } catch {
-            // User might not exist yet in Xomify - that's OK
-            print("⚠️ Profile: Could not load Xomify status - \(error)")
-            isWrappedEnrolled = false
-            isReleaseRadarEnrolled = false
-        }
-    }
-    
-    func toggleWrappedEnrollment() async {
-        guard !isUpdatingEnrollment, let email = user?.email else { return }
-        
-        isUpdatingEnrollment = true
-        let newValue = !isWrappedEnrolled
-        
-        do {
-            try await xomifyService.updateEnrollments(
-                email: email,
-                activeWrapped: newValue,
-                activeReleaseRadar: isReleaseRadarEnrolled
-            )
-            isWrappedEnrolled = newValue
-            print("✅ Profile: Updated Wrapped enrollment to \(newValue)")
-        } catch {
-            print("❌ Profile: Failed to update Wrapped enrollment - \(error)")
-        }
-        
-        isUpdatingEnrollment = false
-    }
-    
-    func toggleReleaseRadarEnrollment() async {
-        guard !isUpdatingEnrollment, let email = user?.email else { return }
-        
-        isUpdatingEnrollment = true
-        let newValue = !isReleaseRadarEnrolled
-        
-        do {
-            try await xomifyService.updateEnrollments(
-                email: email,
-                activeWrapped: isWrappedEnrolled,
-                activeReleaseRadar: newValue
-            )
-            isReleaseRadarEnrolled = newValue
-            print("✅ Profile: Updated Release Radar enrollment to \(newValue)")
-        } catch {
-            print("❌ Profile: Failed to update Release Radar enrollment - \(error)")
-        }
-        
-        isUpdatingEnrollment = false
-    }
-    
-    func logout() {
-        authService.logout()
     }
 }

--- a/Xomify-iOS/ViewModels/SettingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/SettingsViewModel.swift
@@ -2,29 +2,33 @@ import Foundation
 import SwiftUI
 import UserNotifications
 
-/// Drives the Settings screen's notification section. Views never call
-/// `NotificationsService` directly — every toggle flip routes through here.
+/// Drives the Settings screen.
 ///
-/// State mirrors `@AppStorage` (persisted across launches) but exposes the
-/// values as `@Observable` fields so the view can bind without leaking
-/// persistence concerns.
+/// Owns:
+///  - Push-notification toggles (persisted to `UserDefaults` via `NotificationsService`).
+///  - Xomify feature-enrollment toggles (Wrapped, Release Radar).
+///  - Spotify account read-outs (country, subscription, user ID, profile URL).
+///  - Sign-out action.
+///
+/// Views never touch `NotificationsService`, `XomifyService`, or `AuthService` directly —
+/// every side-effect routes through this VM.
 @Observable
 @MainActor
 final class SettingsViewModel {
 
-    // MARK: - Persisted toggle keys (shared with NotificationsService)
+    // MARK: - Persisted notification toggle keys (shared with NotificationsService)
 
     static let queueEnabledKey = NotificationsService.queueEnabledKey
     static let digestEnabledKey = NotificationsService.digestEnabledKey
 
-    // MARK: - State
+    // MARK: - Notification state
 
-    /// Queue-threshold push opt-in. Persisted to UserDefaults immediately on set.
+    /// Queue-threshold push opt-in. Persisted to `UserDefaults` immediately on set.
     var queueNotificationsEnabled: Bool {
         didSet {
             guard oldValue != queueNotificationsEnabled else { return }
             defaults.set(queueNotificationsEnabled, forKey: Self.queueEnabledKey)
-            syncPreferences()
+            syncNotificationPreferences()
         }
     }
 
@@ -33,44 +37,41 @@ final class SettingsViewModel {
         didSet {
             guard oldValue != digestEnabled else { return }
             defaults.set(digestEnabled, forKey: Self.digestEnabledKey)
-            syncPreferences()
+            syncNotificationPreferences()
         }
     }
 
-    /// Current system-level APNs authorization. Polled on view appear.
+    /// Current system-level APNs authorization. Refreshed on view appear.
     var authorizationStatus: UNAuthorizationStatus = .notDetermined
 
-    // MARK: - Dependencies
+    // MARK: - Enrollment state
 
-    private let notificationsService: NotificationsService
-    private let defaults: UserDefaults
+    var isWrappedEnrolled: Bool = false
+    var isReleaseRadarEnrolled: Bool = false
+    var isUpdatingEnrollment: Bool = false
 
-    // MARK: - Init
+    // MARK: - Account state
 
-    init(
-        notificationsService: NotificationsService = NotificationsService.shared,
-        defaults: UserDefaults = .standard
-    ) {
-        self.notificationsService = notificationsService
-        self.defaults = defaults
+    /// The signed-in Spotify user. Populated by `load()`.
+    private var user: SpotifyUser?
 
-        // Default both toggles to true (matches backend default + the
-        // previously-stubbed `@AppStorage` defaults on `SettingsView`).
-        self.queueNotificationsEnabled = defaults.object(forKey: Self.queueEnabledKey) as? Bool ?? true
-        self.digestEnabled = defaults.object(forKey: Self.digestEnabledKey) as? Bool ?? true
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    var displayName: String { user?.displayName ?? "" }
+    var country: String { user?.country ?? "" }
+    var accountType: String { user?.product?.capitalized ?? "Free" }
+    var userId: String { user?.id ?? "" }
+    var spotifyProfileUrl: URL? {
+        guard let urlString = user?.externalUrls?["spotify"] else { return nil }
+        return URL(string: urlString)
     }
+    var userEmail: String { user?.email ?? "" }
 
-    // MARK: - Lifecycle
+    // MARK: - Derived notification UI state
 
-    /// Refresh the authorization status. Called on view appear.
-    func refreshAuthorizationStatus() async {
-        authorizationStatus = await notificationsService.currentAuthorizationStatus()
-    }
-
-    // MARK: - Derived UI state
-
-    /// Whether the toggles should be editable. Disabled when the user has
-    /// denied permission — they must visit System Settings first.
+    /// Whether the notification toggles are editable. Disabled when the user
+    /// has denied permission — they must visit System Settings first.
     var togglesEnabled: Bool {
         switch authorizationStatus {
         case .authorized, .provisional, .ephemeral:
@@ -82,7 +83,7 @@ final class SettingsViewModel {
         }
     }
 
-    /// Copy shown below the notifications section footer.
+    /// Footer copy shown beneath the notifications section.
     var statusFooter: String {
         switch authorizationStatus {
         case .authorized, .provisional, .ephemeral:
@@ -96,20 +97,134 @@ final class SettingsViewModel {
         }
     }
 
-    // MARK: - System settings deep link
-
-    /// URL used by the Settings screen's "Open System Settings" button when
-    /// permission has been denied.
+    /// URL for the Settings screen's "Open System Settings" button.
     var systemSettingsURL: URL? {
         URL(string: UIApplication.openSettingsURLString)
     }
 
+    // MARK: - Dependencies
+
+    private let notificationsService: NotificationsService
+    private let spotifyService: SpotifyService
+    private let xomifyService: XomifyService
+    private let authService: AuthService
+    private let defaults: UserDefaults
+
+    // MARK: - Init
+
+    init(
+        notificationsService: NotificationsService = NotificationsService.shared,
+        spotifyService: SpotifyService = SpotifyService.shared,
+        xomifyService: XomifyService = XomifyService.shared,
+        authService: AuthService = AuthService.shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.notificationsService = notificationsService
+        self.spotifyService = spotifyService
+        self.xomifyService = xomifyService
+        self.authService = authService
+        self.defaults = defaults
+
+        // Default both notification toggles to true — matches backend default.
+        self.queueNotificationsEnabled = defaults.object(forKey: Self.queueEnabledKey) as? Bool ?? true
+        self.digestEnabled = defaults.object(forKey: Self.digestEnabledKey) as? Bool ?? true
+    }
+
+    // MARK: - Lifecycle
+
+    /// Load all settings data. Call from `.task` on the Settings screen.
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+
+        async let statusTask: Void = refreshAuthorizationStatus()
+
+        do {
+            let fetchedUser = try await spotifyService.getCurrentUser()
+            user = fetchedUser
+
+            if let email = fetchedUser.email {
+                await loadXomifyStatus(email: email)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            print("❌ Settings: failed to load user — \(error)")
+        }
+
+        await statusTask
+        isLoading = false
+    }
+
+    /// Refresh the APNs authorization status. Can be called independently on view appear.
+    func refreshAuthorizationStatus() async {
+        authorizationStatus = await notificationsService.currentAuthorizationStatus()
+    }
+
+    // MARK: - Enrollment
+
+    func toggleWrappedEnrollment() async {
+        guard !isUpdatingEnrollment, let email = user?.email else { return }
+        isUpdatingEnrollment = true
+        let newValue = !isWrappedEnrolled
+        do {
+            try await xomifyService.updateEnrollments(
+                email: email,
+                activeWrapped: newValue,
+                activeReleaseRadar: isReleaseRadarEnrolled
+            )
+            isWrappedEnrolled = newValue
+            print("✅ Settings: Wrapped enrollment → \(newValue)")
+        } catch {
+            print("❌ Settings: Failed to update Wrapped enrollment — \(error)")
+        }
+        isUpdatingEnrollment = false
+    }
+
+    func toggleReleaseRadarEnrollment() async {
+        guard !isUpdatingEnrollment, let email = user?.email else { return }
+        isUpdatingEnrollment = true
+        let newValue = !isReleaseRadarEnrolled
+        do {
+            try await xomifyService.updateEnrollments(
+                email: email,
+                activeWrapped: isWrappedEnrolled,
+                activeReleaseRadar: newValue
+            )
+            isReleaseRadarEnrolled = newValue
+            print("✅ Settings: Release Radar enrollment → \(newValue)")
+        } catch {
+            print("❌ Settings: Failed to update Release Radar enrollment — \(error)")
+        }
+        isUpdatingEnrollment = false
+    }
+
+    // MARK: - Auth
+
+    func logout() {
+        authService.logout()
+    }
+
     // MARK: - Private
 
-    /// Push the latest flags to the backend. Swallows network errors so the UI
-    /// stays responsive; the local `@AppStorage` value is the source of truth
-    /// and the backend reconciles on next register.
-    private func syncPreferences() {
+    private func loadXomifyStatus(email: String) async {
+        do {
+            let userData = try await xomifyService.getUserData(email: email)
+            isWrappedEnrolled = userData.activeWrapped
+            isReleaseRadarEnrolled = userData.activeReleaseRadar
+            print("✅ Settings: enrollment loaded — Wrapped: \(isWrappedEnrolled), RR: \(isReleaseRadarEnrolled)")
+        } catch {
+            // User may not exist yet in Xomify — that's fine.
+            isWrappedEnrolled = false
+            isReleaseRadarEnrolled = false
+            print("⚠️ Settings: could not load Xomify enrollment — \(error)")
+        }
+    }
+
+    /// Push the latest notification flags to the backend. Swallows network
+    /// errors so the UI stays responsive; `UserDefaults` is the source of truth
+    /// and the backend reconciles on the next token register.
+    private func syncNotificationPreferences() {
         let queue = queueNotificationsEnabled
         let digest = digestEnabled
         Task { @MainActor in

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -1,56 +1,42 @@
 import SwiftUI
 
-// MARK: - Profile View (Home)
+// MARK: - Profile View
 
+/// Identity-only profile screen: banner, avatar, display name, email,
+/// Followers / Following stat cards, and Quick Stats (Top Songs/Artists/Genres).
+/// Settings items (enrollment, account details, logout) live in `SettingsView`.
 struct ProfileView: View {
     @State private var viewModel = ProfileViewModel()
-    @State private var showLogoutConfirmation = false
-    
+
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    // Banner header
-                    bannerHeader
-                    
-                    // Main content - reduced top padding
-                    VStack(spacing: 20) {
-                        profileHeader
-                        statsSection
-                        quickStatsSection
-                        enrollmentSection
-                        accountSection
-                        logoutButton
-                    }
-                    .padding(.horizontal)
-                    .padding(.bottom)
+        ScrollView {
+            VStack(spacing: 0) {
+                bannerHeader
+
+                VStack(spacing: 20) {
+                    profileHeader
+                    statsSection
+                    quickStatsSection
                 }
-            }
-            .background(Color.xomifyDark.ignoresSafeArea())
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    xomifyLogo
-                }
-            }
-            .task {
-                await viewModel.loadProfile()
-            }
-            .refreshable {
-                await viewModel.loadProfile()
-            }
-            .confirmationDialog("Are you sure you want to logout?", isPresented: $showLogoutConfirmation, titleVisibility: .visible) {
-                Button("Logout", role: .destructive) { viewModel.logout() }
-                Button("Cancel", role: .cancel) {}
+                .padding(.horizontal)
+                .padding(.bottom)
             }
         }
+        .background(Color.xomifyDark.ignoresSafeArea())
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.loadProfile()
+        }
+        .refreshable {
+            await viewModel.loadProfile()
+        }
     }
-    
+
     // MARK: - Banner Header
-    
+
     private var bannerHeader: some View {
         ZStack(alignment: .bottom) {
-            // Gradient background as fallback
             LinearGradient(
                 colors: [Color.xomifyPurple.opacity(0.6), Color.xomifyDark],
                 startPoint: .topLeading,
@@ -58,15 +44,13 @@ struct ProfileView: View {
             )
             .frame(height: 140)
             .overlay(
-                // Try to load banner image
                 Image("banner")
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(height: 140)
                     .clipped()
             )
-            
-            // Gradient overlay for smooth transition
+
             LinearGradient(
                 colors: [.clear, Color.xomifyDark],
                 startPoint: .top,
@@ -76,270 +60,185 @@ struct ProfileView: View {
         }
         .frame(height: 140)
     }
-    
-    // MARK: - Logo
-    
-    private var xomifyLogo: some View {
-        Image("logo")
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(height: 28)
-    }
-    
+
     // MARK: - Profile Header
-    
+
     private var profileHeader: some View {
         VStack(spacing: 16) {
             AsyncImage(url: viewModel.profileImageUrl) { image in
                 image.resizable().aspectRatio(contentMode: .fill)
             } placeholder: {
-                Image(systemName: "person.circle.fill").resizable().foregroundColor(.gray)
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .foregroundStyle(.gray)
             }
             .frame(width: 100, height: 100)
             .clipShape(Circle())
-            .overlay(Circle().stroke(LinearGradient(colors: [.xomifyPurple, .xomifyGreen], startPoint: .topLeading, endPoint: .bottomTrailing), lineWidth: 3))
+            .overlay(
+                Circle().stroke(
+                    LinearGradient(
+                        colors: [.xomifyPurple, .xomifyGreen],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 3
+                )
+            )
             .shadow(color: .black.opacity(0.5), radius: 10, x: 0, y: 5)
             .offset(y: -50)
             .padding(.bottom, -50)
-            
+            .accessibilityLabel("Profile photo")
+
             if viewModel.isLoading {
                 ProgressView()
             } else {
                 Text(viewModel.displayName)
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
+
                 if !viewModel.email.isEmpty {
                     Text(viewModel.email)
                         .font(.subheadline)
-                        .foregroundColor(.gray)
+                        .foregroundStyle(.gray)
                 }
             }
         }
     }
-    
+
     // MARK: - Stats Section
-    
+
     private var statsSection: some View {
         HStack(spacing: 16) {
-            statCard(title: "Followers", value: "\(viewModel.followersCount)", icon: "person.2.fill", color: .xomifyPurple)
-            
+            statCard(
+                title: "Followers",
+                value: "\(viewModel.followersCount)",
+                icon: "person.2.fill",
+                color: .xomifyPurple
+            )
+
             NavigationLink(destination: FollowingView()) {
-                statCardContent(title: "Following", value: "\(viewModel.followingCount)", icon: "heart.fill", color: .xomifyGreen)
+                statCardContent(
+                    title: "Following",
+                    value: "\(viewModel.followingCount)",
+                    icon: "heart.fill",
+                    color: .xomifyGreen
+                )
             }
+            .accessibilityLabel("Following \(viewModel.followingCount) artists. Tap to view.")
         }
     }
-    
+
     private func statCard(title: String, value: String, icon: String, color: Color) -> some View {
         VStack(spacing: 8) {
-            Image(systemName: icon).font(.title2).foregroundColor(color)
-            Text(value).font(.title2).fontWeight(.bold).foregroundColor(.white)
-            Text(title).font(.caption).foregroundColor(.gray)
+            Image(systemName: icon).font(.title2).foregroundStyle(color).accessibilityHidden(true)
+            Text(value).font(.title2).fontWeight(.bold).foregroundStyle(.white)
+            Text(title).font(.caption).foregroundStyle(.gray)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
         .background(Color.xomifyCard)
-        .cornerRadius(16)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value)")
     }
-    
+
     private func statCardContent(title: String, value: String, icon: String, color: Color) -> some View {
         VStack(spacing: 8) {
-            Image(systemName: icon).font(.title2).foregroundColor(color)
-            Text(value).font(.title2).fontWeight(.bold).foregroundColor(.white)
-            Text(title).font(.caption).foregroundColor(.gray)
-            
+            Image(systemName: icon).font(.title2).foregroundStyle(color).accessibilityHidden(true)
+            Text(value).font(.title2).fontWeight(.bold).foregroundStyle(.white)
+            Text(title).font(.caption).foregroundStyle(.gray)
+
             HStack(spacing: 4) {
-                Text("View")
-                    .font(.caption2)
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8))
+                Text("View").font(.caption2)
+                Image(systemName: "chevron.right").font(.system(size: 8)).accessibilityHidden(true)
             }
-            .foregroundColor(color.opacity(0.7))
+            .foregroundStyle(color.opacity(0.7))
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 20)
         .background(Color.xomifyCard)
-        .cornerRadius(16)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
-    
+
     // MARK: - Quick Stats Section
-    
+
     private var quickStatsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Your Listening").font(.headline).foregroundColor(.white)
-            Text("Quick overview of your music taste").font(.caption).foregroundColor(.gray)
-            
+            Text("Your Listening")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Quick overview of your music taste")
+                .font(.caption)
+                .foregroundStyle(.gray)
+
             VStack(spacing: 12) {
                 NavigationLink(destination: TopItemsView()) {
-                    quickStatRow(title: "Top Songs", subtitle: "View your most played tracks", icon: "music.note", iconColor: .xomifyPurple)
+                    quickStatRow(
+                        title: "Top Songs",
+                        subtitle: "View your most played tracks",
+                        icon: "music.note",
+                        iconColor: .xomifyPurple
+                    )
                 }
-                
+                .accessibilityLabel("Top Songs")
+
                 NavigationLink(destination: TopItemsView()) {
-                    quickStatRow(title: "Top Artists", subtitle: "Discover your favorite artists", icon: "person.2.fill", iconColor: .xomifyGreen)
+                    quickStatRow(
+                        title: "Top Artists",
+                        subtitle: "Discover your favorite artists",
+                        icon: "person.2.fill",
+                        iconColor: .xomifyGreen
+                    )
                 }
-                
+                .accessibilityLabel("Top Artists")
+
                 NavigationLink(destination: TopItemsView()) {
-                    quickStatRow(title: "Top Genres", subtitle: "See what styles you love", icon: "guitars.fill", iconColor: .blue)
+                    quickStatRow(
+                        title: "Top Genres",
+                        subtitle: "See what styles you love",
+                        icon: "guitars.fill",
+                        iconColor: .blue
+                    )
                 }
+                .accessibilityLabel("Top Genres")
             }
         }
     }
-    
+
     private func quickStatRow(title: String, subtitle: String, icon: String, iconColor: Color) -> some View {
         HStack(spacing: 16) {
             ZStack {
-                RoundedRectangle(cornerRadius: 12).fill(iconColor.opacity(0.15)).frame(width: 48, height: 48)
-                Image(systemName: icon).font(.title3).foregroundColor(iconColor)
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(iconColor.opacity(0.15))
+                    .frame(width: 48, height: 48)
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundStyle(iconColor)
+                    .accessibilityHidden(true)
             }
+
             VStack(alignment: .leading, spacing: 2) {
-                Text(title).font(.subheadline).fontWeight(.semibold).foregroundColor(.white)
-                Text(subtitle).font(.caption).foregroundColor(.gray)
+                Text(title).font(.subheadline).fontWeight(.semibold).foregroundStyle(.white)
+                Text(subtitle).font(.caption).foregroundStyle(.gray)
             }
+
             Spacer()
-            Image(systemName: "chevron.right").font(.caption).foregroundColor(.gray)
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .accessibilityHidden(true)
         }
         .padding()
+        .frame(minHeight: 44)
         .background(Color.xomifyCard)
-        .cornerRadius(12)
-    }
-    
-    // MARK: - Enrollment Section
-    
-    private var enrollmentSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Features").font(.headline).foregroundColor(.white)
-            Text("Enhance your Xomify experience").font(.caption).foregroundColor(.gray)
-            
-            VStack(spacing: 16) {
-                NavigationLink(destination: WrappedView()) {
-                    enrollmentCard(
-                        title: "Monthly Wrapped",
-                        description: "Get monthly insights about your listening habits and track your music taste over time.",
-                        icon: "chart.bar.fill",
-                        iconGradient: [.xomifyGreen, Color(red: 23/255, green: 183/255, blue: 91/255)],
-                        isEnrolled: viewModel.isWrappedEnrolled,
-                        isUpdating: viewModel.isUpdatingEnrollment
-                    ) {
-                        Task { await viewModel.toggleWrappedEnrollment() }
-                    }
-                }
-                
-                NavigationLink(destination: ReleaseRadarView()) {
-                    enrollmentCard(
-                        title: "Release Radar",
-                        description: "Stay updated with new releases from your favorite artists. Never miss a drop.",
-                        icon: "antenna.radiowaves.left.and.right",
-                        iconGradient: [.xomifyPurple, Color(red: 122/255, green: 8/255, blue: 150/255)],
-                        isEnrolled: viewModel.isReleaseRadarEnrolled,
-                        isUpdating: viewModel.isUpdatingEnrollment
-                    ) {
-                        Task { await viewModel.toggleReleaseRadarEnrollment() }
-                    }
-                }
-            }
-        }
-    }
-    
-    private func enrollmentCard(title: String, description: String, icon: String, iconGradient: [Color], isEnrolled: Bool, isUpdating: Bool, onToggle: @escaping () -> Void) -> some View {
-        HStack(spacing: 16) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(LinearGradient(colors: iconGradient, startPoint: .topLeading, endPoint: .bottomTrailing))
-                    .frame(width: 56, height: 56)
-                    .shadow(color: iconGradient[0].opacity(0.3), radius: 8, x: 0, y: 4)
-                Image(systemName: icon).font(.title2).foregroundColor(.white)
-            }
-            
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.subheadline).fontWeight(.bold).foregroundColor(.white)
-                Text(description).font(.caption).foregroundColor(.gray).lineLimit(2)
-                if isEnrolled {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark").font(.caption2)
-                        Text("Enrolled").font(.caption2).fontWeight(.medium)
-                    }
-                    .foregroundColor(.xomifyGreen)
-                    .padding(.horizontal, 8).padding(.vertical, 4)
-                    .background(Color.xomifyGreen.opacity(0.15))
-                    .cornerRadius(10)
-                    .padding(.top, 4)
-                }
-            }
-            
-            Spacer()
-            
-            VStack(spacing: 8) {
-                Toggle("", isOn: Binding(get: { isEnrolled }, set: { _ in onToggle() }))
-                    .labelsHidden().tint(.xomifyGreen).disabled(isUpdating)
-                
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(.gray)
-            }
-        }
-        .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 16).fill(Color.xomifyCard)
-                .overlay(RoundedRectangle(cornerRadius: 16).stroke(isEnrolled ? Color.xomifyGreen.opacity(0.3) : Color.clear, lineWidth: 1))
-        )
-    }
-    
-    // MARK: - Account Section
-    
-    private var accountSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Account Details").font(.headline).foregroundColor(.white)
-            
-            VStack(spacing: 0) {
-                accountRow(icon: "globe", title: "Country", value: viewModel.country)
-                Divider().background(Color.gray.opacity(0.3))
-                accountRow(icon: "music.note", title: "Subscription", value: viewModel.accountType)
-                Divider().background(Color.gray.opacity(0.3))
-                accountRow(icon: "person", title: "User ID", value: viewModel.userId)
-            }
-            .background(Color.xomifyCard)
-            .cornerRadius(12)
-            
-            if let url = viewModel.spotifyProfileUrl {
-                Link(destination: url) {
-                    HStack {
-                        Image(systemName: "arrow.up.right.square")
-                        Text("Open Spotify Profile")
-                    }
-                    .frame(maxWidth: .infinity).padding()
-                    .background(Color.spotifyGreen)
-                    .foregroundColor(.white).cornerRadius(12)
-                }
-                .padding(.top, 8)
-            }
-        }
-    }
-    
-    private func accountRow(icon: String, title: String, value: String) -> some View {
-        HStack {
-            Image(systemName: icon).foregroundColor(.xomifyGreen).frame(width: 24)
-            Text(title).foregroundColor(.white)
-            Spacer()
-            Text(value).foregroundColor(.gray).lineLimit(1).truncationMode(.middle)
-        }
-        .padding()
-    }
-    
-    // MARK: - Logout Button
-    
-    private var logoutButton: some View {
-        Button { showLogoutConfirmation = true } label: {
-            HStack {
-                Image(systemName: "rectangle.portrait.and.arrow.right")
-                Text("Logout")
-            }
-            .frame(maxWidth: .infinity).padding()
-            .background(Color.red.opacity(0.2)).foregroundColor(.red).cornerRadius(12)
-        }
-        .padding(.top, 20)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 
 #Preview {
-    ProfileView()
+    NavigationStack {
+        ProfileView()
+    }
 }

--- a/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
@@ -1,24 +1,26 @@
 import SwiftUI
 import UserNotifications
 
-/// Drawer-resident Settings screen. Covers notification toggles, version info,
-/// legal links, support email, and a destructive Sign out action.
-///
-/// Notification toggles are mediated by `SettingsViewModel` (sub-feature #9 —
-/// `ios-notifications`) which mirrors them into `@AppStorage` and POSTs to
-/// `/notifications/register` as an upsert on each flip.
+/// Settings screen. Sections:
+///   **Notifications** — push opt-ins (queue-threshold, weekly digest).
+///   **Features**      — Xomify feature-enrollment toggles (Wrapped, Release Radar).
+///   **Account**       — Country, Subscription, User ID rows + Open Spotify Profile link.
+///   **About**         — Version / build info, Help & About sub-rows, legal links.
+///   **Danger Zone**   — Sign-out with confirmation dialog.
 struct SettingsView: View {
 
     @State private var viewModel = SettingsViewModel()
     @State private var showSignOutConfirm = false
 
     private let supportEmailURL = URL(string: "mailto:support@xomware.com")
-    private let privacyURL = URL(string: "https://xomify.xomware.com/privacy")
-    private let termsURL = URL(string: "https://xomify.xomware.com/terms")
+    private let privacyURL      = URL(string: "https://xomify.xomware.com/privacy")
+    private let termsURL        = URL(string: "https://xomify.xomware.com/terms")
 
     var body: some View {
         List {
             notificationsSection
+            featuresSection
+            accountSection
             aboutSection
             legalSection
             supportSection
@@ -30,7 +32,7 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            await viewModel.refreshAuthorizationStatus()
+            await viewModel.load()
         }
         .confirmationDialog(
             "Sign out of Xomify?",
@@ -38,13 +40,13 @@ struct SettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Sign out", role: .destructive) {
-                AuthService.shared.logout()
+                viewModel.logout()
             }
             Button("Cancel", role: .cancel) {}
         }
     }
 
-    // MARK: - Sections
+    // MARK: - Notifications
 
     private var notificationsSection: some View {
         Section {
@@ -55,6 +57,7 @@ struct SettingsView: View {
             .tint(Color.xomifyGreen)
             .disabled(!viewModel.togglesEnabled)
             .accessibilityHint("Queue-threshold push notifications")
+            .frame(minHeight: 44)
 
             Toggle(isOn: $viewModel.digestEnabled) {
                 Label("Weekly digest", systemImage: "envelope.fill")
@@ -63,6 +66,7 @@ struct SettingsView: View {
             .tint(Color.xomifyGreen)
             .disabled(!viewModel.togglesEnabled)
             .accessibilityHint("Weekly digest push notifications")
+            .frame(minHeight: 44)
 
             if viewModel.authorizationStatus == .denied,
                let url = viewModel.systemSettingsURL {
@@ -70,6 +74,7 @@ struct SettingsView: View {
                     Label("Open System Settings", systemImage: "gear")
                         .foregroundStyle(Color.xomifyGreen)
                 }
+                .frame(minHeight: 44)
                 .accessibilityHint("Opens the iOS Settings app to enable notifications")
             }
         } header: {
@@ -83,6 +88,142 @@ struct SettingsView: View {
         .listRowBackground(Color.xomifyCard)
     }
 
+    // MARK: - Features (enrollment)
+
+    private var featuresSection: some View {
+        Section {
+            enrollmentRow(
+                title: "Monthly Wrapped",
+                description: "Monthly insights about your listening habits.",
+                icon: "chart.bar.fill",
+                iconGradient: [.xomifyGreen, Color(red: 23/255, green: 183/255, blue: 91/255)],
+                isEnrolled: viewModel.isWrappedEnrolled,
+                isUpdating: viewModel.isUpdatingEnrollment
+            ) {
+                Task { await viewModel.toggleWrappedEnrollment() }
+            }
+
+            enrollmentRow(
+                title: "Release Radar",
+                description: "New releases from your favorite artists.",
+                icon: "antenna.radiowaves.left.and.right",
+                iconGradient: [.xomifyPurple, Color(red: 122/255, green: 8/255, blue: 150/255)],
+                isEnrolled: viewModel.isReleaseRadarEnrolled,
+                isUpdating: viewModel.isUpdatingEnrollment
+            ) {
+                Task { await viewModel.toggleReleaseRadarEnrollment() }
+            }
+        } header: {
+            Text("Features")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    private func enrollmentRow(
+        title: String,
+        description: String,
+        icon: String,
+        iconGradient: [Color],
+        isEnrolled: Bool,
+        isUpdating: Bool,
+        onToggle: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(LinearGradient(
+                        colors: iconGradient,
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ))
+                    .frame(width: 48, height: 48)
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundStyle(.white)
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                    .lineLimit(2)
+                if isEnrolled {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark").font(.caption2).accessibilityHidden(true)
+                        Text("Enrolled").font(.caption2).fontWeight(.medium)
+                    }
+                    .foregroundStyle(Color.xomifyGreen)
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+                    .background(Color.xomifyGreen.opacity(0.15))
+                    .clipShape(Capsule())
+                    .padding(.top, 2)
+                }
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(get: { isEnrolled }, set: { _ in onToggle() }))
+                .labelsHidden()
+                .tint(.xomifyGreen)
+                .disabled(isUpdating)
+                .accessibilityLabel("\(title) enrollment")
+        }
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+    }
+
+    // MARK: - Account
+
+    @ViewBuilder
+    private var accountSection: some View {
+        Section {
+            accountRow(icon: "globe",      title: "Country",      value: viewModel.country)
+            accountRow(icon: "music.note", title: "Subscription", value: viewModel.accountType)
+            accountRow(icon: "person",     title: "User ID",      value: viewModel.userId)
+
+            if let url = viewModel.spotifyProfileUrl {
+                Link(destination: url) {
+                    Label("Open Spotify Profile", systemImage: "arrow.up.right.square")
+                        .foregroundStyle(Color.xomifyGreen)
+                }
+                .frame(minHeight: 44)
+                .accessibilityLabel("Open Spotify Profile")
+                .accessibilityHint("Opens your profile in the Spotify app or website")
+            }
+        } header: {
+            Text("Account")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    private func accountRow(icon: String, title: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon)
+                .foregroundStyle(Color.xomifyGreen)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+            Text(title)
+                .foregroundStyle(.white)
+            Spacer()
+            Text(value.isEmpty ? "—" : value)
+                .foregroundStyle(.gray)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value.isEmpty ? "unknown" : value)")
+    }
+
+    // MARK: - About
+
     private var aboutSection: some View {
         Section {
             HStack {
@@ -94,6 +235,7 @@ struct SettingsView: View {
                     .foregroundStyle(.gray)
                     .accessibilityLabel("Version \(Self.versionString)")
             }
+            .frame(minHeight: 44)
 
             HStack {
                 Label("Build", systemImage: "hammer.fill")
@@ -104,12 +246,15 @@ struct SettingsView: View {
                     .foregroundStyle(.gray)
                     .accessibilityLabel("Build \(Self.buildString)")
             }
+            .frame(minHeight: 44)
         } header: {
             Text("About")
                 .foregroundStyle(.gray)
         }
         .listRowBackground(Color.xomifyCard)
     }
+
+    // MARK: - Legal
 
     @ViewBuilder
     private var legalSection: some View {
@@ -119,12 +264,14 @@ struct SettingsView: View {
                     Label("Privacy Policy", systemImage: "lock.fill")
                         .foregroundStyle(.white)
                 }
+                .frame(minHeight: 44)
             }
             if let termsURL {
                 Link(destination: termsURL) {
                     Label("Terms of Service", systemImage: "doc.text.fill")
                         .foregroundStyle(.white)
                 }
+                .frame(minHeight: 44)
             }
         } header: {
             Text("Legal")
@@ -132,6 +279,8 @@ struct SettingsView: View {
         }
         .listRowBackground(Color.xomifyCard)
     }
+
+    // MARK: - Support
 
     @ViewBuilder
     private var supportSection: some View {
@@ -141,6 +290,7 @@ struct SettingsView: View {
                     Label("Email support", systemImage: "envelope.badge.fill")
                         .foregroundStyle(.white)
                 }
+                .frame(minHeight: 44)
             }
         } header: {
             Text("Support")
@@ -149,6 +299,8 @@ struct SettingsView: View {
         .listRowBackground(Color.xomifyCard)
     }
 
+    // MARK: - Danger Zone
+
     private var dangerSection: some View {
         Section {
             Button(role: .destructive) {
@@ -156,6 +308,7 @@ struct SettingsView: View {
             } label: {
                 Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
             }
+            .frame(minHeight: 44)
             .accessibilityHint("Signs you out of Xomify")
         }
         .listRowBackground(Color.xomifyCard)

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -1,27 +1,34 @@
 import SwiftUI
 
-/// Slide-out navigation drawer. Overlays leading edge of the screen.
-/// Width: min(80% of screen width, 320pt) per plan spec.
+/// Slide-out navigation drawer. Overlays the leading edge of the screen.
+/// Width: min(80 % of screen width, 320 pt).
+///
+/// The drawer is a pure menu: each row calls `navStore.select(_:)` which
+/// sets `currentDestination` on `NavigationStore` AND closes the drawer in
+/// a single animation. No inner `NavigationStack` lives here — destination
+/// views render full-bleed inside `MainShell`.
 struct DrawerView: View {
     @Environment(NavigationStore.self) private var navStore
 
     // MARK: - Drawer entries
 
-    private struct DrawerEntry {
-        let destination: DrawerDestination
+    private struct DrawerEntry: Identifiable {
+        let destination: SidebarDestination
         let label: String
         let systemImage: String
+        var id: SidebarDestination { destination }
     }
 
     private let entries: [DrawerEntry] = [
-        .init(destination: .profile,        label: "Profile",         systemImage: "person.fill"),
-        .init(destination: .stats,          label: "Stats",           systemImage: "chart.bar.fill"),
-        .init(destination: .following,      label: "Following",       systemImage: "music.mic"),
-        .init(destination: .friends,        label: "Friends",         systemImage: "person.2.fill"),
-        .init(destination: .groups,         label: "Groups",          systemImage: "person.3.fill"),
-        .init(destination: .ratingsHistory, label: "Ratings History", systemImage: "star.fill"),
-        .init(destination: .settings,       label: "Settings",        systemImage: "gearshape.fill"),
-        .init(destination: .helpAbout,      label: "Help & About",    systemImage: "questionmark.circle.fill"),
+        .init(destination: .feed,         label: "Feed",            systemImage: "sparkles"),
+        .init(destination: .wrapped,      label: "Wrapped",         systemImage: "chart.bar.fill"),
+        .init(destination: .releaseRadar, label: "Release Radar",   systemImage: "antenna.radiowaves.left.and.right"),
+        .init(destination: .ratings,      label: "Ratings",         systemImage: "star.fill"),
+        .init(destination: .groups,       label: "Groups",          systemImage: "person.3.fill"),
+        .init(destination: .friends,      label: "Friends",         systemImage: "person.2.fill"),
+        .init(destination: .profile,      label: "Profile",         systemImage: "person.fill"),
+        .init(destination: .settings,     label: "Settings",        systemImage: "gearshape.fill"),
+        .init(destination: .builder,      label: "Playlist Builder", systemImage: "music.note.list"),
     ]
 
     // MARK: - Layout constants
@@ -46,90 +53,46 @@ struct DrawerView: View {
     // MARK: - Drawer panel
 
     private var drawerPanel: some View {
-        NavigationStack(path: Binding(
-            get: { navStore.drawerPath },
-            set: { navStore.drawerPath = $0 }
-        )) {
-            List {
-                // App name header inside drawer.
-                Section {
-                    Text("Xomify")
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.white)
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                }
+        List {
+            // App name header inside the drawer.
+            Section {
+                Text("Xomify")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
 
-                // Navigation entries.
-                Section {
-                    ForEach(entries, id: \.destination) { entry in
-                        Button {
-                            navStore.navigate(to: entry.destination)
-                        } label: {
-                            Label {
-                                Text(entry.label)
-                                    .foregroundStyle(.white)
-                                    .accessibilityLabel(entry.label)
-                            } icon: {
-                                Image(systemName: entry.systemImage)
-                                    .foregroundStyle(Color.xomifyGreen)
-                                    .accessibilityHidden(true)
-                            }
-                        }
-                        .listRowBackground(Color.xomifyCard)
-                    }
-                }
-
-                // Sign out at the bottom.
-                Section {
-                    Button(role: .destructive) {
-                        navStore.closeDrawer()
-                        AuthService.shared.logout()
+            // Navigation entries.
+            Section {
+                ForEach(entries) { entry in
+                    Button {
+                        navStore.select(entry.destination)
                     } label: {
                         Label {
-                            Text("Sign out")
-                                .accessibilityLabel("Sign out")
+                            Text(entry.label)
+                                .foregroundStyle(.white)
                         } icon: {
-                            Image(systemName: "rectangle.portrait.and.arrow.right")
+                            Image(systemName: entry.systemImage)
+                                .foregroundStyle(Color.xomifyGreen)
                                 .accessibilityHidden(true)
                         }
                     }
-                    .listRowBackground(Color.xomifyCard)
+                    // 44 pt minimum touch target via explicit frame on the row.
+                    .frame(minHeight: 44)
+                    .accessibilityLabel(entry.label)
+                    .listRowBackground(
+                        navStore.currentDestination == entry.destination
+                            ? Color.xomifyGreen.opacity(0.15)
+                            : Color.xomifyCard
+                    )
                 }
             }
-            .listStyle(.insetGrouped)
-            .scrollContentBackground(.hidden)
-            .background(Color.xomifyDark)
-            .navigationDestination(for: DrawerDestination.self) { destination in
-                destinationView(for: destination)
-            }
         }
-        .frame(width: drawerWidth)
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
         .background(Color.xomifyDark)
-    }
-
-    // MARK: - Destination routing
-
-    @ViewBuilder
-    private func destinationView(for destination: DrawerDestination) -> some View {
-        switch destination {
-        case .profile:
-            ProfileView()
-        case .stats:
-            StatsView()
-        case .following:
-            FollowingContent()
-        case .friends:
-            FriendsView()
-        case .groups:
-            GroupsView()
-        case .ratingsHistory:
-            RatingsHistoryView()
-        case .settings:
-            SettingsView()
-        case .helpAbout:
-            HelpAboutView()
-        }
+        .frame(width: drawerWidth)
     }
 }

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
-/// Signed-in root view. Replaces MainTabView.
-/// ZStack layout: persistent HeaderBar + 4-tab TabView, with DrawerView + DrawerScrim overlaid.
+/// Signed-in root view. Hosts a full-screen `NavigationStack` whose root
+/// switches on `navStore.currentDestination`. The slide-out `DrawerView` and
+/// its `DrawerScrim` are overlaid above the content column.
+///
+/// Architecture: the drawer is a pure menu — it mutates `currentDestination`
+/// via `navStore.select(_:)` and never hosts its own navigation stack.
 struct MainShell: View {
 
     // MARK: - State
@@ -13,71 +17,35 @@ struct MainShell: View {
 
     var body: some View {
         ZStack(alignment: .leading) {
-            // Primary content: header + tab bar.
+            // Primary content: header bar + full-screen destination.
             VStack(spacing: 0) {
                 HeaderBar(avatarURL: avatarURL)
                     .environment(navStore)
 
-                TabView(selection: Binding(
-                    get: { navStore.selectedTab },
-                    set: { navStore.selectedTab = $0 }
-                )) {
-                    // Home — routes to ProfileView (existing Home screen).
-                    NavigationStack {
-                        ProfileView()
-                    }
-                    .tabItem {
-                        Label(ShellTab.home.label, systemImage: ShellTab.home.systemImage)
-                    }
-                    .tag(ShellTab.home)
-
-                    // Feed — social feed tab (ios-feed #5).
-                    NavigationStack {
-                        FeedView()
-                    }
-                    .tabItem {
-                        Label(ShellTab.feed.label, systemImage: ShellTab.feed.systemImage)
-                    }
-                    .tag(ShellTab.feed)
-
-                    // Releases.
-                    NavigationStack {
-                        ReleaseRadarView()
-                    }
-                    .tabItem {
-                        Label(ShellTab.releases.label, systemImage: ShellTab.releases.systemImage)
-                    }
-                    .tag(ShellTab.releases)
-
-                    // Builder.
-                    PlaylistBuilderTabView()
-                        .tabItem {
-                            Label(ShellTab.builder.label, systemImage: ShellTab.builder.systemImage)
-                        }
-                        .tag(ShellTab.builder)
+                NavigationStack {
+                    destinationRoot
                 }
-                .tint(Color.xomifyGreen)
             }
 
-            // Scrim — renders above content, below drawer.
+            // Scrim — above content, below drawer.
             DrawerScrim()
                 .environment(navStore)
 
-            // Drawer — slides in from leading edge.
+            // Drawer — slides in from the leading edge.
             DrawerView()
                 .environment(navStore)
         }
         .environment(navStore)
         .ignoresSafeArea(edges: .bottom)
         .task {
-            // Share the nav store with the push pipeline so `didReceive` can
-            // tab-switch into Feed on push-open.
+            // Share the nav store with the push pipeline so push-open handlers
+            // can call `select(.feed)`.
             NotificationsService.shared.navigationStore = navStore
             await fetchAvatar()
         }
         .onChange(of: navStore.pendingDeepLink) { _, newValue in
-            // FeedView's empty-state CTAs set `pendingDeepLink`; consume on
-            // the next runloop so the drawer animation runs cleanly.
+            // Feed empty-state CTAs set `pendingDeepLink`; consume on the next
+            // runloop so the drawer animation runs cleanly.
             guard newValue != nil else { return }
             Task { @MainActor in
                 navStore.consumePendingDeepLink()
@@ -85,18 +53,42 @@ struct MainShell: View {
         }
     }
 
+    // MARK: - Destination root
+
+    @ViewBuilder
+    private var destinationRoot: some View {
+        switch navStore.currentDestination {
+        case .feed:
+            FeedView()
+        case .wrapped:
+            WrappedView()
+        case .releaseRadar:
+            ReleaseRadarView()
+        case .ratings:
+            RatingsHistoryView()
+        case .groups:
+            GroupsView()
+        case .friends:
+            FriendsView()
+        case .profile:
+            ProfileView()
+        case .settings:
+            SettingsView()
+        case .builder:
+            PlaylistBuilderTabView()
+        }
+    }
+
     // MARK: - Avatar fetch
 
-    /// Fetches the current user profile for the header avatar.
-    /// Non-blocking — placeholder shown until resolved.
+    /// Fetches the current user's profile image URL for the header bar.
+    /// Non-blocking — placeholder is shown until the request resolves.
     private func fetchAvatar() async {
         do {
             let user = try await SpotifyService.shared.getCurrentUser()
-            await MainActor.run {
-                avatarURL = user.profileImageUrl
-            }
+            avatarURL = user.profileImageUrl
         } catch {
-            // Silently fall back to SF symbol placeholder — non-critical.
+            // Silently fall back to the SF symbol placeholder — non-critical.
         }
     }
 }


### PR DESCRIPTION
## Summary
Closes the redundant tab-bar + sidebar combo and fixes the drawer dismissal / 320pt-sliver bug in one shot. Plan: `docs/features/ios-nav-ia-cleanup/PLAN.md`. Execution log: `docs/features/ios-nav-ia-cleanup/EXECUTION_LOG.md`.

**What changed**
- Killed the 4-tab `TabView`. Sidebar is now the only primary-nav surface.
- Moved `NavigationStack` up from inside `DrawerView` → `MainShell`, so selected destinations render full-bleed instead of in the 320pt drawer panel. Tapping a sidebar row now also dismisses the drawer.
- `ShellTab` + `DrawerDestination` → single `SidebarDestination` enum. Default landing = `.feed`.
- Sidebar order: Feed, Wrapped, Release Radar, Ratings, Groups, Friends, Playlist Builder, Profile, Settings.
- Profile is now identity + social counts only.
- New Settings screen absorbs enrollment toggles, account readouts, Spotify profile link, notifications, about/legal/support sub-rows, and Logout.

**Dropped from the old drawer** (confirmed 2026-04-23): `stats` folds into Profile Quick Stats, `following` reached via Profile Following card tap, `helpAbout` is a Settings sub-row.

## Test plan
- [ ] iPhone: launch, land on Feed (not Profile)
- [ ] Tap avatar → drawer slides in → tap any row → drawer dismisses AND destination takes full screen
- [ ] Deep-link from Feed empty-state CTA (e.g. "Find Friends") still navigates correctly
- [ ] Push notification deep-link still routes to Feed
- [ ] Profile: no enrollment / account / logout sections remain — only identity + Quick Stats
- [ ] Settings: toggle Wrapped / Release Radar → persists, UI reflects new state
- [ ] Settings: Logout confirmation dialog → confirm → returns to login
- [ ] VoiceOver reads each sidebar row; 44pt touch targets; Dynamic Type scales