### PR TITLE
fix(ios): remove duplicate SpotifyImage breaking TestFlight archive

### DIFF
--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -439,10 +439,6 @@ private struct SpotifyUserProfile: Codable {
     }
 }
 
-private struct SpotifyImage: Codable {
-    let url: String
-}
-
 // MARK: - Auth Errors
 
 enum AuthError: Error, LocalizedError {


### PR DESCRIPTION
## Summary

- `AuthService.swift` had a private `struct SpotifyImage` duplicating the module-scope one in `Models/SpotifyModels.swift` (PR #35 regression)
- In Release/archive builds the ambiguity cascades: `SpotifyUserProfile` stops conforming to `Codable`, failing TestFlight deploy with 3 compile errors
- Module-scope `SpotifyImage` already exposes `url` (plus `height`/`width`), so just delete the dupe

## Impact

Fixes two consecutive TestFlight deploy failures (runs 24859068696 post-#35, 24859312199 post-#36). Simulator builds were passing, which is why the issue wasn't caught by CI's Build & Test step.

## Test plan

- [x] `xcodebuild -sdk iphonesimulator build` — succeeds
- [x] `xcodebuild -sdk iphoneos -configuration Release build` — succeeds (archive path)
- [ ] TestFlight deploy succeeds on merge