### PR TITLE
feat(ios): profile redesign phase 7 — tests, skeletons, a11y

### DIFF
--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -37,6 +37,13 @@ protocol XomifyServiceProtocol: Sendable {
         before: String?
     ) async throws -> FeedResponse
 
+    // MARK: - Friend profile (used by UserProfileViewModel)
+
+    func getFriendProfile(
+        email: String,
+        profileEmail: String
+    ) async throws -> FriendProfile
+
     // MARK: - Groups (for filter chips)
 
     func listGroups(email: String) async throws -> GroupsListResponse

--- a/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
+++ b/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
@@ -24,8 +24,8 @@ final class SharesByUserViewModel {
     // MARK: - Dependencies
 
     private let xomifyService: XomifyServiceProtocol
-    private let callerEmail: String
-    private let targetEmail: String
+    let callerEmail: String
+    let targetEmail: String
 
     // MARK: - Init
 

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -56,8 +56,8 @@ final class UserProfileViewModel {
 
     // MARK: - Dependencies
 
-    private let xomifyService: XomifyService
-    private let spotifyService: SpotifyService
+    private let xomifyService: XomifyServiceProtocol
+    private let spotifyService: SpotifyCurrentUserProviding
 
     /// Signed-in user's email, resolved once on load. Required as the caller
     /// email for `/shares/user` requests.
@@ -93,8 +93,8 @@ final class UserProfileViewModel {
 
     init(
         context: ProfileContext,
-        xomifyService: XomifyService = .shared,
-        spotifyService: SpotifyService = .shared
+        xomifyService: XomifyServiceProtocol = XomifyService.shared,
+        spotifyService: SpotifyCurrentUserProviding = SpotifyService.shared
     ) {
         self.context = context
         self.xomifyService = xomifyService

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -26,7 +26,9 @@ struct ProfileHeaderView: View {
 
     private var avatar: some View {
         Group {
-            if let url = viewModel.avatarURL {
+            if isInitialLoading {
+                Circle().fill(Color.gray.opacity(0.2))
+            } else if let url = viewModel.avatarURL {
                 AsyncImage(url: url) { image in
                     image.resizable().aspectRatio(contentMode: .fill)
                 } placeholder: {
@@ -97,18 +99,26 @@ struct ProfileHeaderView: View {
 
     private var statsRow: some View {
         HStack(spacing: 0) {
-            if let shares = viewModel.shareCount {
-                statItem(value: shares, label: "Shares", color: .xomifyGreen)
+            if isInitialLoading {
+                skeletonStat
                 divider
-            }
-            if let ratings = viewModel.ratingCount {
-                statItem(value: ratings, label: "Ratings", color: .xomifyPurple)
+                skeletonStat
                 divider
-            }
-            if let friends = viewModel.friendCount {
-                statItem(value: friends, label: "Friends", color: .xomifyGreen)
-            } else if let followers = viewModel.followersCount {
-                statItem(value: followers, label: "Followers", color: .xomifyGreen)
+                skeletonStat
+            } else {
+                if let shares = viewModel.shareCount {
+                    statItem(value: shares, label: "Shares", color: .xomifyGreen)
+                    divider
+                }
+                if let ratings = viewModel.ratingCount {
+                    statItem(value: ratings, label: "Ratings", color: .xomifyPurple)
+                    divider
+                }
+                if let friends = viewModel.friendCount {
+                    statItem(value: friends, label: "Friends", color: .xomifyGreen)
+                } else if let followers = viewModel.followersCount {
+                    statItem(value: followers, label: "Followers", color: .xomifyGreen)
+                }
             }
         }
         .padding(.vertical, 12)
@@ -116,6 +126,26 @@ struct ProfileHeaderView: View {
         .background(Color.xomifyCard)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .frame(maxWidth: .infinity)
+    }
+
+    /// True on first load, before any header field has populated. Drives
+    /// skeleton placeholders in the stats row so the layout doesn't jump
+    /// when real values arrive.
+    private var isInitialLoading: Bool {
+        viewModel.isLoading && viewModel.displayName.isEmpty
+    }
+
+    private var skeletonStat: some View {
+        VStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color.gray.opacity(0.25))
+                .frame(width: 28, height: 16)
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color.gray.opacity(0.18))
+                .frame(width: 44, height: 8)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(true)
     }
 
     private var divider: some View {

--- a/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
+++ b/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
@@ -9,11 +9,15 @@ struct ProfileTabPicker: View {
     var body: some View {
         Picker("Profile tab", selection: $selection) {
             ForEach(ProfileTab.allCases, id: \.self) { tab in
-                Text(tab.title).tag(tab)
+                Text(tab.title)
+                    .tag(tab)
+                    .accessibilityLabel("\(tab.title) tab")
             }
         }
         .pickerStyle(.segmented)
         .padding(.horizontal)
         .padding(.bottom, 8)
+        .accessibilityLabel("Profile sections")
+        .accessibilityHint("Swipe to switch between Shares, Ratings, and Taste")
     }
 }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -50,6 +50,8 @@ private struct OtherTasteView: View {
                 }
             }
             .pickerStyle(.segmented)
+            .accessibilityLabel("Taste time range")
+            .accessibilityHint("Switches between last 4 weeks, last 6 months, and all time")
 
             let artistNames = names(from: viewModel.friendProfileTopArtists, term: selectedTerm)
             let songNames = names(from: viewModel.friendProfileTopSongs, term: selectedTerm)
@@ -105,6 +107,8 @@ private struct OtherTasteView: View {
             .padding(.horizontal, 8)
             .background(Color.xomifyCard)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(label)
     }
 
     // MARK: - JSON → names

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -35,6 +35,28 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
         return getSharesByUserResponses.removeFirst()
     }
 
+    // MARK: - getFriendProfile
+
+    struct GetFriendProfileCall: Equatable {
+        let email: String
+        let profileEmail: String
+    }
+
+    private(set) var getFriendProfileCalls: [GetFriendProfileCall] = []
+    var getFriendProfileResponse: FriendProfile = FriendProfile(
+        email: nil, displayName: nil, userId: nil, avatar: nil,
+        followersCount: nil, followingCount: nil, playlistCount: nil,
+        friendsCount: nil, shareCount: nil,
+        topSongs: nil, topArtists: nil, topGenres: nil, playlists: nil
+    )
+    var getFriendProfileError: Error?
+
+    func getFriendProfile(email: String, profileEmail: String) async throws -> FriendProfile {
+        getFriendProfileCalls.append(GetFriendProfileCall(email: email, profileEmail: profileEmail))
+        if let getFriendProfileError { throw getFriendProfileError }
+        return getFriendProfileResponse
+    }
+
     // MARK: - Unused surface — return empty success shapes so the protocol compiles.
 
     func createShare(
@@ -60,5 +82,31 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
         rating: Int, review: String?
     ) async throws -> SuccessResponse {
         SuccessResponse(success: true)
+    }
+}
+
+// MARK: - SpotifyCurrentUserProviding mock
+
+/// Mock for `SpotifyCurrentUserProviding` — returns a canned `SpotifyUser`
+/// unless `error` is set. Records call count so tests can assert the caller
+/// email is resolved exactly once.
+final class MockSpotifyCurrentUserProviding: SpotifyCurrentUserProviding, @unchecked Sendable {
+    private(set) var callCount: Int = 0
+    var response: SpotifyUser = SpotifyUser(
+        id: "mock-id",
+        displayName: "Mock User",
+        email: "me@example.com",
+        images: nil,
+        followers: nil,
+        country: nil,
+        product: nil,
+        externalUrls: nil
+    )
+    var error: Error?
+
+    func getCurrentUser() async throws -> SpotifyUser {
+        callCount += 1
+        if let error { throw error }
+        return response
     }
 }

--- a/Xomify-iOSTests/UserProfileViewModelTests.swift
+++ b/Xomify-iOSTests/UserProfileViewModelTests.swift
@@ -1,0 +1,276 @@
+import XCTest
+@testable import Xomify_iOS
+
+@MainActor
+final class UserProfileViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeSpotifyUser(
+        email: String = "me@example.com",
+        displayName: String? = "Me",
+        avatarUrl: String? = nil,
+        followers: Int? = nil
+    ) -> SpotifyUser {
+        SpotifyUser(
+            id: "sp-id",
+            displayName: displayName,
+            email: email,
+            images: avatarUrl.map { [SpotifyImage(url: $0, height: nil, width: nil)] },
+            followers: followers.map { SpotifyUser.Followers(total: $0) },
+            country: nil,
+            product: nil,
+            externalUrls: nil
+        )
+    }
+
+    private func makeFriendProfile(
+        email: String = "friend@example.com",
+        displayName: String? = "Friend",
+        avatar: String? = nil,
+        followers: Int? = nil,
+        following: Int? = nil,
+        friends: Int? = nil,
+        shares: Int? = nil
+    ) -> FriendProfile {
+        FriendProfile(
+            email: email,
+            displayName: displayName,
+            userId: nil,
+            avatar: avatar,
+            followersCount: followers,
+            followingCount: following,
+            playlistCount: nil,
+            friendsCount: friends,
+            shareCount: shares,
+            topSongs: nil,
+            topArtists: nil,
+            topGenres: nil,
+            playlists: nil
+        )
+    }
+
+    // MARK: - .me header
+
+    func test_loadHeader_me_populatesFromSpotify() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(
+            email: "me@example.com",
+            displayName: "Dom",
+            avatarUrl: "https://img.example.com/me.jpg",
+            followers: 42
+        )
+        let xomify = MockXomifyServiceProtocol()
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: xomify,
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.displayName, "Dom")
+        XCTAssertEqual(vm.profileEmail, "me@example.com")
+        XCTAssertEqual(vm.callerEmail, "me@example.com")
+        XCTAssertEqual(vm.avatarURL?.absoluteString, "https://img.example.com/me.jpg")
+        XCTAssertEqual(vm.followersCount, 42)
+        XCTAssertNil(vm.errorMessage)
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertTrue(xomify.getFriendProfileCalls.isEmpty)
+    }
+
+    func test_loadHeader_me_fallsBackToYouWhenNameMissing() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(displayName: nil)
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.displayName, "You")
+    }
+
+    // MARK: - .other header
+
+    func test_loadHeader_other_populatesFromFriendProfile() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+        let xomify = MockXomifyServiceProtocol()
+        xomify.getFriendProfileResponse = makeFriendProfile(
+            email: "friend@example.com",
+            displayName: "Friend Name",
+            avatar: "https://img.example.com/friend.jpg",
+            followers: 10,
+            following: 5,
+            friends: 7,
+            shares: 3
+        )
+
+        let vm = UserProfileViewModel(
+            context: .other(email: "friend@example.com"),
+            xomifyService: xomify,
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.displayName, "Friend Name")
+        XCTAssertEqual(vm.profileEmail, "friend@example.com")
+        XCTAssertEqual(vm.avatarURL?.absoluteString, "https://img.example.com/friend.jpg")
+        XCTAssertEqual(vm.followersCount, 10)
+        XCTAssertEqual(vm.followingCount, 5)
+        XCTAssertEqual(vm.friendCount, 7)
+        XCTAssertEqual(vm.shareCount, 3)
+        XCTAssertNotNil(vm.friendProfile)
+        XCTAssertEqual(xomify.getFriendProfileCalls.count, 1)
+        XCTAssertEqual(xomify.getFriendProfileCalls.first?.email, "me@example.com")
+        XCTAssertEqual(xomify.getFriendProfileCalls.first?.profileEmail, "friend@example.com")
+    }
+
+    func test_loadHeader_other_fallsBackToEmailWhenNameMissing() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+        let xomify = MockXomifyServiceProtocol()
+        xomify.getFriendProfileResponse = makeFriendProfile(displayName: nil)
+
+        let vm = UserProfileViewModel(
+            context: .other(email: "friend@example.com"),
+            xomifyService: xomify,
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.displayName, "friend@example.com")
+    }
+
+    // MARK: - Error surfacing
+
+    func test_loadHeader_me_errorSurfaces() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.error = NSError(
+            domain: "spotify", code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "Spotify session expired"]
+        )
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.errorMessage, "Spotify session expired")
+        XCTAssertTrue(vm.displayName.isEmpty)
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    func test_loadHeader_other_errorFromFriendProfileSurfaces() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+        let xomify = MockXomifyServiceProtocol()
+        xomify.getFriendProfileError = NSError(
+            domain: "xomify", code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "Profile unavailable"]
+        )
+
+        let vm = UserProfileViewModel(
+            context: .other(email: "friend@example.com"),
+            xomifyService: xomify,
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.errorMessage, "Profile unavailable")
+        XCTAssertFalse(vm.isLoading)
+    }
+
+    func test_loadHeader_missingEmail_throwsProfileError() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "")
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        XCTAssertEqual(vm.errorMessage, "Could not resolve signed-in user email.")
+    }
+
+    // MARK: - Lazy shares VM
+
+    func test_sharesViewModel_me_targetsCallerEmail() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        let shares = vm.sharesViewModel()
+        XCTAssertNotNil(shares)
+        XCTAssertEqual(shares?.callerEmail, "me@example.com")
+        XCTAssertEqual(shares?.targetEmail, "me@example.com")
+    }
+
+    func test_sharesViewModel_other_targetsOtherEmail() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+        let xomify = MockXomifyServiceProtocol()
+        xomify.getFriendProfileResponse = makeFriendProfile()
+
+        let vm = UserProfileViewModel(
+            context: .other(email: "friend@example.com"),
+            xomifyService: xomify,
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        let shares = vm.sharesViewModel()
+        XCTAssertEqual(shares?.callerEmail, "me@example.com")
+        XCTAssertEqual(shares?.targetEmail, "friend@example.com")
+    }
+
+    func test_sharesViewModel_beforeLoad_returnsNil() {
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: MockSpotifyCurrentUserProviding()
+        )
+
+        XCTAssertNil(vm.sharesViewModel())
+    }
+
+    func test_sharesViewModel_isCachedAcrossCalls() async {
+        let spotify = MockSpotifyCurrentUserProviding()
+        spotify.response = makeSpotifyUser(email: "me@example.com")
+
+        let vm = UserProfileViewModel(
+            context: .me,
+            xomifyService: MockXomifyServiceProtocol(),
+            spotifyService: spotify
+        )
+
+        await vm.loadHeader()
+
+        let first = vm.sharesViewModel()
+        let second = vm.sharesViewModel()
+        XCTAssertNotNil(first)
+        XCTAssertTrue(first === second, "sharesViewModel should return the same instance on repeated calls")
+    }
+}


### PR DESCRIPTION
## Summary

Phase 7 polish on top of the tabbed Profile that shipped in #38.

- **Tests:** 11 new cases in `UserProfileViewModelTests` cover `.me` and `.other` header branches, Spotify / XomifyService error surfacing, the `missingEmail` guard, and the lazy `sharesViewModel()` constructor (caches across calls, correctly scopes `callerEmail`/`targetEmail` per context).
- **Testability:** protocol-inject `xomifyService: XomifyServiceProtocol` + `spotifyService: SpotifyCurrentUserProviding` on `UserProfileViewModel` so tests swap fixtures in without dragging the full service surface.
- **Header skeletons:** avatar and stats row render placeholder rects while `isLoading && displayName.isEmpty` so the layout doesn't shift when header fields arrive.
- **A11y:** labels on the Profile tab picker, Taste time-range picker, and Taste tiles.

Phase 8 (collapsing-header-on-scroll) is deferred per plan.

## Test plan
- [x] `xcodebuild ... build-for-testing` succeeds on iOS Simulator
- [x] `xcodebuild ... build` succeeds on iOS Simulator
- [ ] Self profile: header and tabs render; skeletons appear briefly on first load
- [ ] Other profile: header / Shares / Ratings / Taste render; delete-on-ratings hidden
- [ ] VoiceOver: sweep through header, tab picker, and Taste picker