### PR TITLE
fix(ios): friends endpoints, sidebar reorder, compact taste tab

### DIFF
--- a/Xomify-iOS/Navigation/NavigationStore.swift
+++ b/Xomify-iOS/Navigation/NavigationStore.swift
@@ -5,15 +5,16 @@ import SwiftUI
 /// All top-level destinations reachable from the sidebar drawer.
 /// This is the sole primary-navigation enum — `ShellTab` has been removed.
 enum SidebarDestination: Hashable {
+    case profile
     case feed
+    case musicTaste
     case wrapped
     case releaseRadar
     case ratings
-    case groups
     case friends
-    case profile
-    case settings
+    case groups
     case builder
+    case settings
 }
 
 // MARK: - NavigationStore

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -270,20 +270,21 @@ actor XomifyService {
     }
 
     /// Bucketed list of friends (accepted / requested / pending / blocked).
+    /// Hits `/friends/list?email=` — the real user-scoped endpoint.
+    /// `/friends/all` is a full-table scan helper and must not be used here.
     func getAllFriends(email: String) async throws -> FriendsAllResponse {
-        try await network.xomifyGet("/friends/all", queryParams: ["email": email])
+        try await network.xomifyGet("/friends/list", queryParams: ["email": email])
     }
 
-    /// Discovery list: every other user on the platform with per-user status.
+    /// Discovery list: every other user on the platform. `/user/all` returns a
+    /// bare JSON array; the backend filters self out server-side when `email`
+    /// is passed.
     func listUsers(email: String) async throws -> UserListResponse {
-        // The backend returns `{ users: [...], totalCount }` or a bare array.
-        // Try the dict shape first; fall back to array if needed.
-        do {
-            return try await network.xomifyGet("/friends/list", queryParams: ["email": email])
-        } catch {
-            let users: [SearchResult] = try await network.xomifyGet("/friends/list", queryParams: ["email": email])
-            return UserListResponse(users: users, totalCount: users.count)
-        }
+        let users: [SearchResult] = try await network.xomifyGet(
+            "/user/all",
+            queryParams: ["email": email]
+        )
+        return UserListResponse(users: users, totalCount: users.count)
     }
 
     /// Incoming friend requests only (subset of /friends/all).

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -1,22 +1,146 @@
 import SwiftUI
 
-/// Taste tab on `ProfileView`. v1 delegates to existing surfaces:
-///   `.me`    → embeds `TopItemsView` verbatim so the self-view picker and
-///              rich tiles are preserved.
-///   `.other` → reads the `FriendProfile` payload already loaded by
-///              `UserProfileViewModel` and renders degraded text tiles with
-///              a term picker. Empty-bucket fallback per contract.
+/// Taste tab on `ProfileView`. Compact summary — top 3 of each category per
+/// term — with a "See all" CTA that jumps to the full `Music Taste` drawer
+/// destination (`TopItemsView`). Keeps the profile lightweight and steers
+/// users to the richer surface.
+///   `.me`    → fetches from `TopItemsViewModel` once on first appear.
+///   `.other` → renders degraded text tiles from the already-loaded
+///              `FriendProfile` payload; empty-bucket fallback per contract.
 struct ProfileTasteTab: View {
 
     let viewModel: UserProfileViewModel
+    @Environment(NavigationStore.self) private var navStore
 
     var body: some View {
         switch viewModel.context {
         case .me:
-            TopItemsView()
-                .padding(.horizontal, -16)
+            SelfTasteSummary(onSeeAll: { navStore.select(.musicTaste) })
         case .other:
             OtherTasteView(viewModel: viewModel)
+        }
+    }
+}
+
+// MARK: - Self taste summary (top-3 per category, per term)
+
+private struct SelfTasteSummary: View {
+    let onSeeAll: () -> Void
+
+    @State private var viewModel = TopItemsViewModel()
+    @State private var selectedTerm: TimeRange = .shortTerm
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Picker("Time range", selection: $selectedTerm) {
+                Text("4 weeks").tag(TimeRange.shortTerm)
+                Text("6 months").tag(TimeRange.mediumTerm)
+                Text("All time").tag(TimeRange.longTerm)
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Taste time range")
+
+            if viewModel.isLoading && tracks.isEmpty && artists.isEmpty {
+                VStack {
+                    ProgressView().tint(.xomifyGreen)
+                }
+                .frame(maxWidth: .infinity, minHeight: 160)
+            } else {
+                section(title: "Top Tracks", items: tracks.map(\.name))
+                section(title: "Top Artists", items: artists.map(\.name))
+                section(title: "Top Genres", items: genres.map(\.name))
+
+                Button(action: onSeeAll) {
+                    HStack(spacing: 6) {
+                        Text("See all")
+                            .fontWeight(.semibold)
+                        Image(systemName: "arrow.right")
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        LinearGradient(
+                            colors: [Color.xomifyPurple, Color.xomifyGreen],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .accessibilityHint("Opens the full Music Taste screen")
+            }
+        }
+        .padding(.horizontal)
+        .task { await viewModel.loadData() }
+    }
+
+    // MARK: Term-scoped slices (top 3 each)
+
+    private var tracks: [SpotifyTrack] {
+        Array(tracksForSelectedTerm.prefix(3))
+    }
+
+    private var artists: [SpotifyArtist] {
+        Array(artistsForSelectedTerm.prefix(3))
+    }
+
+    private var genres: [(name: String, count: Int)] {
+        Array(genresForSelectedTerm.prefix(3))
+    }
+
+    private var tracksForSelectedTerm: [SpotifyTrack] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermTracks
+        case .mediumTerm: return viewModel.mediumTermTracks
+        case .longTerm:   return viewModel.longTermTracks
+        }
+    }
+
+    private var artistsForSelectedTerm: [SpotifyArtist] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermArtists
+        case .mediumTerm: return viewModel.mediumTermArtists
+        case .longTerm:   return viewModel.longTermArtists
+        }
+    }
+
+    private var genresForSelectedTerm: [(name: String, count: Int)] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermGenres
+        case .mediumTerm: return viewModel.mediumTermGenres
+        case .longTerm:   return viewModel.longTermGenres
+        }
+    }
+
+    // MARK: Section
+
+    @ViewBuilder
+    private func section(title: String, items: [String]) -> some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(.white)
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    HStack(spacing: 12) {
+                        Text("\(index + 1)")
+                            .font(.subheadline.monospacedDigit().weight(.bold))
+                            .foregroundStyle(Color.xomifyGreen)
+                            .frame(width: 20, alignment: .leading)
+                        Text(item)
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(Color.xomifyCard)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
+            }
         }
     }
 }

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -20,15 +20,16 @@ struct DrawerView: View {
     }
 
     private let entries: [DrawerEntry] = [
-        .init(destination: .feed,         label: "Feed",            systemImage: "sparkles"),
-        .init(destination: .wrapped,      label: "Wrapped",         systemImage: "chart.bar.fill"),
-        .init(destination: .releaseRadar, label: "Release Radar",   systemImage: "antenna.radiowaves.left.and.right"),
-        .init(destination: .ratings,      label: "Ratings",         systemImage: "star.fill"),
-        .init(destination: .groups,       label: "Groups",          systemImage: "person.3.fill"),
-        .init(destination: .friends,      label: "Friends",         systemImage: "person.2.fill"),
-        .init(destination: .profile,      label: "Profile",         systemImage: "person.fill"),
-        .init(destination: .settings,     label: "Settings",        systemImage: "gearshape.fill"),
+        .init(destination: .profile,      label: "Profile",          systemImage: "person.crop.circle.fill"),
+        .init(destination: .feed,         label: "Feed",             systemImage: "sparkles"),
+        .init(destination: .musicTaste,   label: "Music Taste",      systemImage: "waveform"),
+        .init(destination: .wrapped,      label: "Wrapped",          systemImage: "chart.bar.fill"),
+        .init(destination: .releaseRadar, label: "Release Radar",    systemImage: "antenna.radiowaves.left.and.right"),
+        .init(destination: .ratings,      label: "Ratings",          systemImage: "star.fill"),
+        .init(destination: .friends,      label: "Friends",          systemImage: "person.2.fill"),
+        .init(destination: .groups,       label: "Groups",           systemImage: "person.3.fill"),
         .init(destination: .builder,      label: "Playlist Builder", systemImage: "music.note.list"),
+        .init(destination: .settings,     label: "Settings",         systemImage: "gearshape.fill"),
     ]
 
     // MARK: - Layout constants

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -58,24 +58,26 @@ struct MainShell: View {
     @ViewBuilder
     private var destinationRoot: some View {
         switch navStore.currentDestination {
+        case .profile:
+            ProfileView()
         case .feed:
             FeedView()
+        case .musicTaste:
+            TopItemsView()
         case .wrapped:
             WrappedView()
         case .releaseRadar:
             ReleaseRadarView()
         case .ratings:
             RatingsHistoryView()
-        case .groups:
-            GroupsView()
         case .friends:
             FriendsView()
-        case .profile:
-            ProfileView()
-        case .settings:
-            SettingsView()
+        case .groups:
+            GroupsView()
         case .builder:
             PlaylistBuilderTabView()
+        case .settings:
+            SettingsView()
         }
     }
 


### PR DESCRIPTION
## Summary
- **Friends loading bug** — `getAllFriends` was calling `/user/all` (a full-table scan of *every* user) and `listUsers` was calling `/friends/list`. The Codable response shapes didn't match, so the Friends tab decoded empty. Swapped to the correct endpoints.
- **Sidebar reorder** — Profile → top, Settings → bottom. Added a dedicated `.musicTaste` destination so top songs/artists/genres live as their own full-screen drawer entry.
- **Profile Taste tab (.me)** — No longer inlines the entire `TopItemsView`. Shows a compact top-3 per category per term, with a gradient "See all" button that jumps to the full Music Taste screen via `navStore.select(.musicTaste)`.

## Test plan
- [ ] Launch as signed-in user → drawer order reads Profile / Feed / Music Taste / Wrapped / Release Radar / Ratings / Friends / Groups / Playlist Builder / Settings
- [ ] Tap **Music Taste** → renders full `TopItemsView`
- [ ] Tap **Profile** → Taste tab shows top-3 songs/artists/genres for the selected term plus "See all" button; button navigates to Music Taste
- [ ] Tap **Friends** → accepted/requested/pending buckets populate; discovery ("Add Friends") list excludes self (after backend PR lands)
- [ ] Build succeeds for iOS Simulator (verified locally)

Related backend PR: adds `?email=` self-filter to `/user/all` and hardens `/friends/list` against legacy rows missing `direction`.