### PR TITLE
feat(ios): visual refresh — brand header, drawer redesign, ratings restyle

### DIFF
--- a/Xomify-iOS/Navigation/NavigationStore.swift
+++ b/Xomify-iOS/Navigation/NavigationStore.swift
@@ -5,15 +5,16 @@ import SwiftUI
 /// All top-level destinations reachable from the sidebar drawer.
 /// This is the sole primary-navigation enum — `ShellTab` has been removed.
 enum SidebarDestination: Hashable {
+    case profile
     case feed
+    case musicTaste
     case wrapped
     case releaseRadar
     case ratings
-    case groups
     case friends
-    case profile
-    case settings
+    case groups
     case builder
+    case settings
 }
 
 // MARK: - NavigationStore

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -270,20 +270,21 @@ actor XomifyService {
     }
 
     /// Bucketed list of friends (accepted / requested / pending / blocked).
+    /// Hits `/friends/list?email=` — the real user-scoped endpoint.
+    /// `/friends/all` is a full-table scan helper and must not be used here.
     func getAllFriends(email: String) async throws -> FriendsAllResponse {
-        try await network.xomifyGet("/friends/all", queryParams: ["email": email])
+        try await network.xomifyGet("/friends/list", queryParams: ["email": email])
     }
 
-    /// Discovery list: every other user on the platform with per-user status.
+    /// Discovery list: every other user on the platform. `/user/all` returns a
+    /// bare JSON array; the backend filters self out server-side when `email`
+    /// is passed.
     func listUsers(email: String) async throws -> UserListResponse {
-        // The backend returns `{ users: [...], totalCount }` or a bare array.
-        // Try the dict shape first; fall back to array if needed.
-        do {
-            return try await network.xomifyGet("/friends/list", queryParams: ["email": email])
-        } catch {
-            let users: [SearchResult] = try await network.xomifyGet("/friends/list", queryParams: ["email": email])
-            return UserListResponse(users: users, totalCount: users.count)
-        }
+        let users: [SearchResult] = try await network.xomifyGet(
+            "/user/all",
+            queryParams: ["email": email]
+        )
+        return UserListResponse(users: users, totalCount: users.count)
     }
 
     /// Incoming friend requests only (subset of /friends/all).

--- a/Xomify-iOS/Utilities/FontExtensions.swift
+++ b/Xomify-iOS/Utilities/FontExtensions.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+// MARK: - Xomify Brand Typography
+//
+// All app-facing type uses the rounded system design so screens feel
+// modern and friendly — closer to Apple Music / Spotify than the default
+// SF blocks. Heights track the same sizes as `.title`, `.headline`,
+// `.body`, etc. so Dynamic Type still scales.
+
+extension Font {
+    static let xomifyLargeTitle = Font.system(.largeTitle, design: .rounded).weight(.heavy)
+    static let xomifyTitle      = Font.system(.title,      design: .rounded).weight(.bold)
+    static let xomifyTitle2     = Font.system(.title2,     design: .rounded).weight(.bold)
+    static let xomifyTitle3     = Font.system(.title3,     design: .rounded).weight(.semibold)
+    static let xomifyHeadline   = Font.system(.headline,   design: .rounded).weight(.semibold)
+    static let xomifySubheadline = Font.system(.subheadline, design: .rounded).weight(.medium)
+    static let xomifyBody       = Font.system(.body,       design: .rounded)
+    static let xomifyCallout    = Font.system(.callout,    design: .rounded)
+    static let xomifyFootnote   = Font.system(.footnote,   design: .rounded)
+    static let xomifyCaption    = Font.system(.caption,    design: .rounded).weight(.medium)
+    static let xomifyCaption2   = Font.system(.caption2,   design: .rounded).weight(.semibold)
+}

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -11,6 +11,12 @@ struct FeedView: View {
             Color.xomifyDark.ignoresSafeArea()
 
             VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Feed",
+                    subtitle: "What your friends are vibing to",
+                    systemImage: "sparkles"
+                )
+
                 FilterChipsView(viewModel: viewModel)
 
                 mainContent
@@ -22,8 +28,8 @@ struct FeedView: View {
                 }
             }
         }
-        .navigationTitle("Feed")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task {
             await viewModel.bootstrap()
             await viewModel.loadGroupsForChips()

--- a/Xomify-iOS/Views/FriendsView.swift
+++ b/Xomify-iOS/Views/FriendsView.swift
@@ -31,14 +31,21 @@ struct FriendsView: View {
             Color.xomifyDark.ignoresSafeArea()
 
             VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Friends",
+                    subtitle: friendsSubtitle,
+                    systemImage: "person.2.fill"
+                ) {
+                    addFriendButton
+                }
+
                 tabPicker
                 searchField
                 content
             }
         }
-        .navigationTitle("Friends")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar { toolbarContent }
+        .toolbar(.hidden, for: .navigationBar)
         .task { await loadUserAndData() }
         .tint(Color.xomifyGreen)
         .confirmationDialog(
@@ -76,39 +83,31 @@ struct FriendsView: View {
         }
     }
 
-    // MARK: - Toolbar
+    // MARK: - Header accessory
 
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                Task { await viewModel.mintInvite() }
-            } label: {
-                if viewModel.isMintingInvite {
-                    ProgressView()
-                } else {
-                    Label("Invite a Friend", systemImage: "person.badge.plus")
-                        .labelStyle(.titleAndIcon)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                }
+    private var friendsSubtitle: String {
+        let count = viewModel.accepted.count
+        if count == 0 { return "Invite friends to start sharing" }
+        return "\(count) \(count == 1 ? "friend" : "friends")"
+    }
+
+    private var addFriendButton: some View {
+        Button {
+            Task { await viewModel.mintInvite() }
+        } label: {
+            if viewModel.isMintingInvite {
+                ProgressView().tint(.white)
+                    .frame(width: 36, height: 36)
+            } else {
+                Image(systemName: "person.badge.plus")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 36, height: 36)
+                    .background(.white.opacity(0.18), in: Circle())
             }
-            .accessibilityLabel("Invite a friend")
-            .disabled(viewModel.isMintingInvite || isLoadingUser)
         }
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                Task { await viewModel.refresh() }
-            } label: {
-                if viewModel.isRefreshing {
-                    ProgressView()
-                } else {
-                    Image(systemName: "arrow.clockwise")
-                }
-            }
-            .accessibilityLabel("Refresh")
-            .disabled(viewModel.isRefreshing || isLoadingUser)
-        }
+        .accessibilityLabel("Invite a friend")
+        .disabled(viewModel.isMintingInvite || isLoadingUser)
     }
 
     private var removalConfirmationTitle: String {

--- a/Xomify-iOS/Views/GroupsView.swift
+++ b/Xomify-iOS/Views/GroupsView.swift
@@ -10,24 +10,38 @@ struct GroupsView: View {
 
     private let spotifyService = SpotifyService.shared
 
+    private var groupsSubtitle: String {
+        let count = viewModel.groups.count
+        if count == 0 { return "Make a group to share with a crew" }
+        return "\(count) \(count == 1 ? "group" : "groups")"
+    }
+
     var body: some View {
         ZStack {
             Color.xomifyDark.ignoresSafeArea()
-            content
-        }
-        .navigationTitle("Groups")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    showingCreate = true
-                } label: {
-                    Image(systemName: "plus")
+            VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Groups",
+                    subtitle: groupsSubtitle,
+                    systemImage: "person.3.fill"
+                ) {
+                    Button {
+                        showingCreate = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 36, height: 36)
+                            .background(.white.opacity(0.18), in: Circle())
+                    }
+                    .disabled(isLoadingUser)
+                    .accessibilityLabel("Create group")
                 }
-                .disabled(isLoadingUser)
-                .accessibilityLabel("Create group")
+                content
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task { await loadUserAndData() }
         .onAppear {
             // Return from GroupDetailView (e.g. after delete/leave) should

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -1,22 +1,146 @@
 import SwiftUI
 
-/// Taste tab on `ProfileView`. v1 delegates to existing surfaces:
-///   `.me`    → embeds `TopItemsView` verbatim so the self-view picker and
-///              rich tiles are preserved.
-///   `.other` → reads the `FriendProfile` payload already loaded by
-///              `UserProfileViewModel` and renders degraded text tiles with
-///              a term picker. Empty-bucket fallback per contract.
+/// Taste tab on `ProfileView`. Compact summary — top 3 of each category per
+/// term — with a "See all" CTA that jumps to the full `Music Taste` drawer
+/// destination (`TopItemsView`). Keeps the profile lightweight and steers
+/// users to the richer surface.
+///   `.me`    → fetches from `TopItemsViewModel` once on first appear.
+///   `.other` → renders degraded text tiles from the already-loaded
+///              `FriendProfile` payload; empty-bucket fallback per contract.
 struct ProfileTasteTab: View {
 
     let viewModel: UserProfileViewModel
+    @Environment(NavigationStore.self) private var navStore
 
     var body: some View {
         switch viewModel.context {
         case .me:
-            TopItemsView()
-                .padding(.horizontal, -16)
+            SelfTasteSummary(onSeeAll: { navStore.select(.musicTaste) })
         case .other:
             OtherTasteView(viewModel: viewModel)
+        }
+    }
+}
+
+// MARK: - Self taste summary (top-3 per category, per term)
+
+private struct SelfTasteSummary: View {
+    let onSeeAll: () -> Void
+
+    @State private var viewModel = TopItemsViewModel()
+    @State private var selectedTerm: TimeRange = .shortTerm
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Picker("Time range", selection: $selectedTerm) {
+                Text("4 weeks").tag(TimeRange.shortTerm)
+                Text("6 months").tag(TimeRange.mediumTerm)
+                Text("All time").tag(TimeRange.longTerm)
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Taste time range")
+
+            if viewModel.isLoading && tracks.isEmpty && artists.isEmpty {
+                VStack {
+                    ProgressView().tint(.xomifyGreen)
+                }
+                .frame(maxWidth: .infinity, minHeight: 160)
+            } else {
+                section(title: "Top Tracks", items: tracks.map(\.name))
+                section(title: "Top Artists", items: artists.map(\.name))
+                section(title: "Top Genres", items: genres.map(\.name))
+
+                Button(action: onSeeAll) {
+                    HStack(spacing: 6) {
+                        Text("See all")
+                            .fontWeight(.semibold)
+                        Image(systemName: "arrow.right")
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        LinearGradient(
+                            colors: [Color.xomifyPurple, Color.xomifyGreen],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .accessibilityHint("Opens the full Music Taste screen")
+            }
+        }
+        .padding(.horizontal)
+        .task { await viewModel.loadData() }
+    }
+
+    // MARK: Term-scoped slices (top 3 each)
+
+    private var tracks: [SpotifyTrack] {
+        Array(tracksForSelectedTerm.prefix(3))
+    }
+
+    private var artists: [SpotifyArtist] {
+        Array(artistsForSelectedTerm.prefix(3))
+    }
+
+    private var genres: [(name: String, count: Int)] {
+        Array(genresForSelectedTerm.prefix(3))
+    }
+
+    private var tracksForSelectedTerm: [SpotifyTrack] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermTracks
+        case .mediumTerm: return viewModel.mediumTermTracks
+        case .longTerm:   return viewModel.longTermTracks
+        }
+    }
+
+    private var artistsForSelectedTerm: [SpotifyArtist] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermArtists
+        case .mediumTerm: return viewModel.mediumTermArtists
+        case .longTerm:   return viewModel.longTermArtists
+        }
+    }
+
+    private var genresForSelectedTerm: [(name: String, count: Int)] {
+        switch selectedTerm {
+        case .shortTerm:  return viewModel.shortTermGenres
+        case .mediumTerm: return viewModel.mediumTermGenres
+        case .longTerm:   return viewModel.longTermGenres
+        }
+    }
+
+    // MARK: Section
+
+    @ViewBuilder
+    private func section(title: String, items: [String]) -> some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(.white)
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    HStack(spacing: 12) {
+                        Text("\(index + 1)")
+                            .font(.subheadline.monospacedDigit().weight(.bold))
+                            .foregroundStyle(Color.xomifyGreen)
+                            .frame(width: 20, alignment: .leading)
+                        Text(item)
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(Color.xomifyCard)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
+            }
         }
     }
 }

--- a/Xomify-iOS/Views/Shell/BrandGradientHeader.swift
+++ b/Xomify-iOS/Views/Shell/BrandGradientHeader.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Reusable brand-gradient header used at the top of full-screen destinations
+/// (Feed, Profile, Ratings, Friends, Groups, Music Taste). Matches the visual
+/// language of Wrapped / Release Radar — purple → green gradient bar with a
+/// title, optional subtitle, and optional trailing accessory.
+struct BrandGradientHeader<Trailing: View>: View {
+
+    let title: String
+    let subtitle: String?
+    let systemImage: String?
+    let trailing: () -> Trailing
+
+    init(
+        _ title: String,
+        subtitle: String? = nil,
+        systemImage: String? = nil,
+        @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+                    .background(.white.opacity(0.15), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.xomifyTitle2)
+                    .foregroundStyle(.white)
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.xomifyFootnote)
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+            }
+
+            Spacer(minLength: 0)
+            trailing()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(
+                colors: [Color.xomifyPurple, Color.xomifyGreen],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        BrandGradientHeader(
+            "Feed",
+            subtitle: "What your friends are vibing to",
+            systemImage: "sparkles"
+        )
+        BrandGradientHeader(
+            "Ratings",
+            subtitle: "128 rated tracks",
+            systemImage: "star.fill"
+        ) {
+            Image(systemName: "ellipsis.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.white)
+        }
+    }
+    .padding(.vertical)
+    .background(Color.xomifyDark)
+}

--- a/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
@@ -7,62 +7,105 @@ struct RatingsHistoryView: View {
     @State private var viewModel = RatingsHistoryViewModel()
 
     var body: some View {
-        Group {
-            if viewModel.isLoading && viewModel.ratings.isEmpty {
-                loadingState
-            } else if let error = viewModel.errorMessage, viewModel.ratings.isEmpty {
-                errorState(error)
-            } else if viewModel.ratings.isEmpty {
-                emptyState
-            } else {
-                list
+        VStack(spacing: 0) {
+            BrandGradientHeader(
+                "Ratings",
+                subtitle: subtitleText,
+                systemImage: "star.fill"
+            )
+
+            Group {
+                if viewModel.isLoading && viewModel.ratings.isEmpty {
+                    loadingState
+                } else if let error = viewModel.errorMessage, viewModel.ratings.isEmpty {
+                    errorState(error)
+                } else if viewModel.ratings.isEmpty {
+                    emptyState
+                } else {
+                    list
+                }
             }
         }
         .background(Color.xomifyDark.ignoresSafeArea())
-        .navigationTitle("Ratings History")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task {
             if viewModel.ratings.isEmpty {
                 await viewModel.load()
             }
         }
-        .refreshable {
-            await viewModel.load()
-        }
+        .refreshable { await viewModel.load() }
     }
 
-    // MARK: - List
+    private var subtitleText: String {
+        let n = viewModel.ratings.count
+        guard n > 0 else { return "Your rated tracks live here" }
+        return "\(n) rated \(n == 1 ? "track" : "tracks")"
+    }
+
+    // MARK: - List (grouped by star count, high → low)
 
     private var list: some View {
-        List {
-            ForEach(viewModel.ratings) { rating in
-                Button {
-                    openInSpotify(trackId: rating.trackId)
-                } label: {
-                    RatingRow(rating: rating)
-                }
-                .listRowBackground(Color.xomifyCard)
-                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    Button(role: .destructive) {
-                        Task { await viewModel.delete(rating) }
-                    } label: {
-                        Label("Delete", systemImage: "trash")
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                ForEach(groupedByStars, id: \.stars) { group in
+                    VStack(alignment: .leading, spacing: 10) {
+                        starGroupHeader(stars: group.stars, count: group.ratings.count)
+                            .padding(.horizontal, 16)
+
+                        VStack(spacing: 10) {
+                            ForEach(group.ratings) { rating in
+                                Button {
+                                    openInSpotify(trackId: rating.trackId)
+                                } label: {
+                                    RatingCard(rating: rating)
+                                }
+                                .buttonStyle(.plain)
+                                .contextMenu {
+                                    Button(role: .destructive) {
+                                        Task { await viewModel.delete(rating) }
+                                    } label: {
+                                        Label("Delete rating", systemImage: "trash")
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 16)
                     }
                 }
             }
+            .padding(.vertical, 20)
         }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
+    }
+
+    private var groupedByStars: [(stars: Int, ratings: [TrackRating])] {
+        Dictionary(grouping: viewModel.ratings, by: { $0.rating })
+            .map { (stars: $0.key, ratings: $0.value) }
+            .sorted { $0.stars > $1.stars }
+    }
+
+    private func starGroupHeader(stars: Int, count: Int) -> some View {
+        HStack(spacing: 6) {
+            ForEach(0..<5, id: \.self) { i in
+                Image(systemName: i < stars ? "star.fill" : "star")
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(i < stars ? Color.xomifyGreen : Color.white.opacity(0.25))
+            }
+            Text("\(count) \(count == 1 ? "track" : "tracks")")
+                .font(.xomifyCaption2)
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.leading, 6)
+        }
     }
 
     // MARK: - States
 
     private var loadingState: some View {
         VStack(spacing: 12) {
-            ProgressView()
-            Text("Loading ratings...")
-                .font(.caption)
-                .foregroundStyle(.gray)
+            ProgressView().tint(Color.xomifyGreen)
+            Text("Loading ratings…")
+                .font(.xomifyCaption)
+                .foregroundStyle(.white.opacity(0.7))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -70,17 +113,20 @@ struct RatingsHistoryView: View {
     private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "star.slash")
-                .font(.system(size: 50))
-                .foregroundStyle(.gray.opacity(0.5))
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(
+                    LinearGradient(colors: [Color.xomifyPurple, Color.xomifyGreen],
+                                   startPoint: .topLeading, endPoint: .bottomTrailing)
+                )
                 .accessibilityHidden(true)
 
             Text("No ratings yet")
-                .font(.headline)
+                .font(.xomifyTitle3)
                 .foregroundStyle(.white)
 
             Text("Rate a track from the feed or a share and it will show up here.")
-                .font(.caption)
-                .foregroundStyle(.gray)
+                .font(.xomifyCaption)
+                .foregroundStyle(.white.opacity(0.7))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
         }
@@ -90,17 +136,17 @@ struct RatingsHistoryView: View {
     private func errorState(_ message: String) -> some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 50))
-                .foregroundStyle(.orange.opacity(0.7))
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(.orange.opacity(0.85))
                 .accessibilityHidden(true)
 
             Text("Couldn't load ratings")
-                .font(.headline)
+                .font(.xomifyTitle3)
                 .foregroundStyle(.white)
 
             Text(message)
-                .font(.caption)
-                .foregroundStyle(.gray)
+                .font(.xomifyCaption)
+                .foregroundStyle(.white.opacity(0.7))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
@@ -108,13 +154,15 @@ struct RatingsHistoryView: View {
                 Task { await viewModel.load() }
             } label: {
                 Text("Try Again")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 10)
-                    .background(Color.xomifyPurple)
+                    .font(.xomifySubheadline.weight(.semibold))
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 12)
+                    .background(
+                        LinearGradient(colors: [Color.xomifyPurple, Color.xomifyGreen],
+                                       startPoint: .leading, endPoint: .trailing)
+                    )
                     .foregroundStyle(.white)
-                    .cornerRadius(20)
+                    .clipShape(Capsule())
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -126,62 +174,99 @@ struct RatingsHistoryView: View {
         guard !trackId.isEmpty, let url = URL(string: "spotify:track:\(trackId)") else { return }
         UIApplication.shared.open(url) { success in
             if !success {
-                print("⚠️ RatingsHistory: could not open Spotify URL for \(trackId)")
+                print("RatingsHistory: could not open Spotify URL for \(trackId)")
             }
         }
     }
 }
 
-// MARK: - Row
+// MARK: - Card
 
-private struct RatingRow: View {
+private struct RatingCard: View {
     let rating: TrackRating
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(rating.trackName ?? "Unknown track")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(.white)
-                .lineLimit(1)
+        HStack(spacing: 14) {
+            artworkTile
 
-            Text(rating.artistName ?? "Unknown artist")
-                .font(.caption)
-                .foregroundStyle(.gray)
-                .lineLimit(1)
-
-            if let review = rating.review, !review.isEmpty {
-                Text(review)
-                    .font(.caption2)
-                    .foregroundStyle(.gray.opacity(0.9))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(rating.trackName ?? "Unknown track")
+                    .font(.xomifySubheadline.weight(.semibold))
+                    .foregroundStyle(.white)
                     .lineLimit(1)
+
+                Text(rating.artistName ?? "Unknown artist")
+                    .font(.xomifyCaption)
+                    .foregroundStyle(.white.opacity(0.7))
+                    .lineLimit(1)
+
+                if let review = rating.review, !review.isEmpty {
+                    Text("“\(review)”")
+                        .font(.xomifyFootnote.italic())
+                        .foregroundStyle(.white.opacity(0.65))
+                        .lineLimit(2)
+                }
+
+                HStack(spacing: 6) {
+                    HStack(spacing: 1) {
+                        ForEach(0..<5, id: \.self) { i in
+                            Image(systemName: i < rating.rating ? "star.fill" : "star")
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(Color.xomifyGreen)
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    if let timestamp = rating.updatedAt ?? rating.createdAt,
+                       let relative = Self.relativeTime(from: timestamp) {
+                        Text(relative)
+                            .font(.xomifyCaption2)
+                            .foregroundStyle(.white.opacity(0.5))
+                    }
+                }
+                .padding(.top, 2)
             }
 
-            HStack(spacing: 8) {
-                stars
-                Spacer()
-                if let timestamp = rating.updatedAt ?? rating.createdAt,
-                   let relative = Self.relativeTime(from: timestamp) {
-                    Text(relative)
-                        .font(.caption2)
-                        .foregroundStyle(.gray)
-                }
-            }
+            Spacer(minLength: 0)
         }
-        .padding(.vertical, 4)
+        .padding(12)
+        .background(
+            LinearGradient(
+                colors: [Color.xomifyCard, Color.xomifySecondary],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Double-tap to open in Spotify")
     }
 
-    private var stars: some View {
-        HStack(spacing: 2) {
-            ForEach(0..<5, id: \.self) { index in
-                Image(systemName: index < rating.rating ? "star.fill" : "star")
-                    .font(.caption)
-                    .foregroundStyle(Color.xomifyGreen)
-                    .accessibilityHidden(true)
-            }
+    private var artworkTile: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyPurple, Color.xomifyGreen],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Image(systemName: "music.note")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.white)
+        }
+        .frame(width: 52, height: 52)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(alignment: .bottomTrailing) {
+            Image(systemName: "star.fill")
+                .font(.caption2.weight(.black))
+                .foregroundStyle(.white)
+                .padding(4)
+                .background(Color.xomifyGreen, in: Circle())
+                .overlay(Circle().stroke(Color.xomifyDark, lineWidth: 2))
+                .offset(x: 6, y: 6)
         }
     }
 

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -20,15 +20,16 @@ struct DrawerView: View {
     }
 
     private let entries: [DrawerEntry] = [
-        .init(destination: .feed,         label: "Feed",            systemImage: "sparkles"),
-        .init(destination: .wrapped,      label: "Wrapped",         systemImage: "chart.bar.fill"),
-        .init(destination: .releaseRadar, label: "Release Radar",   systemImage: "antenna.radiowaves.left.and.right"),
-        .init(destination: .ratings,      label: "Ratings",         systemImage: "star.fill"),
-        .init(destination: .groups,       label: "Groups",          systemImage: "person.3.fill"),
-        .init(destination: .friends,      label: "Friends",         systemImage: "person.2.fill"),
-        .init(destination: .profile,      label: "Profile",         systemImage: "person.fill"),
-        .init(destination: .settings,     label: "Settings",        systemImage: "gearshape.fill"),
+        .init(destination: .profile,      label: "Profile",          systemImage: "person.crop.circle.fill"),
+        .init(destination: .feed,         label: "Feed",             systemImage: "sparkles"),
+        .init(destination: .musicTaste,   label: "Music Taste",      systemImage: "waveform"),
+        .init(destination: .wrapped,      label: "Wrapped",          systemImage: "chart.bar.fill"),
+        .init(destination: .releaseRadar, label: "Release Radar",    systemImage: "antenna.radiowaves.left.and.right"),
+        .init(destination: .ratings,      label: "Ratings",          systemImage: "star.fill"),
+        .init(destination: .friends,      label: "Friends",          systemImage: "person.2.fill"),
+        .init(destination: .groups,       label: "Groups",           systemImage: "person.3.fill"),
         .init(destination: .builder,      label: "Playlist Builder", systemImage: "music.note.list"),
+        .init(destination: .settings,     label: "Settings",         systemImage: "gearshape.fill"),
     ]
 
     // MARK: - Layout constants

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Slide-out navigation drawer. Overlays the leading edge of the screen.
-/// Width: min(80 % of screen width, 320 pt).
+/// Width: min(82 % of screen width, 320 pt).
 ///
 /// The drawer is a pure menu: each row calls `navStore.select(_:)` which
 /// sets `currentDestination` on `NavigationStore` AND closes the drawer in
@@ -9,6 +9,13 @@ import SwiftUI
 /// views render full-bleed inside `MainShell`.
 struct DrawerView: View {
     @Environment(NavigationStore.self) private var navStore
+
+    /// Signed-in user's avatar URL (sourced from `MainShell` via `avatarURL`).
+    let avatarURL: URL?
+    /// Signed-in user's display name for the profile card — falls back to email.
+    let displayName: String?
+    /// Signed-in user's email — always shown as a secondary label.
+    let email: String?
 
     // MARK: - Drawer entries
 
@@ -19,7 +26,8 @@ struct DrawerView: View {
         var id: SidebarDestination { destination }
     }
 
-    private let entries: [DrawerEntry] = [
+    /// Primary entries (everything except Settings — pinned to the bottom).
+    private let primaryEntries: [DrawerEntry] = [
         .init(destination: .profile,      label: "Profile",          systemImage: "person.crop.circle.fill"),
         .init(destination: .feed,         label: "Feed",             systemImage: "sparkles"),
         .init(destination: .musicTaste,   label: "Music Taste",      systemImage: "waveform"),
@@ -29,14 +37,19 @@ struct DrawerView: View {
         .init(destination: .friends,      label: "Friends",          systemImage: "person.2.fill"),
         .init(destination: .groups,       label: "Groups",           systemImage: "person.3.fill"),
         .init(destination: .builder,      label: "Playlist Builder", systemImage: "music.note.list"),
-        .init(destination: .settings,     label: "Settings",         systemImage: "gearshape.fill"),
     ]
+
+    private let settingsEntry = DrawerEntry(
+        destination: .settings,
+        label: "Settings",
+        systemImage: "gearshape.fill"
+    )
 
     // MARK: - Layout constants
 
     private let drawerWidth: CGFloat = {
         let screenWidth = UIScreen.main.bounds.width
-        return min(screenWidth * 0.80, 320)
+        return min(screenWidth * 0.82, 320)
     }()
 
     // MARK: - Body
@@ -54,46 +67,195 @@ struct DrawerView: View {
     // MARK: - Drawer panel
 
     private var drawerPanel: some View {
-        List {
-            // App name header inside the drawer.
-            Section {
-                Text("Xomify")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                    .foregroundStyle(.white)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
+        VStack(spacing: 0) {
+            bannerHeader
+            profileCard
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(primaryEntries) { entry in
+                        drawerRow(entry)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
             }
 
-            // Navigation entries.
-            Section {
-                ForEach(entries) { entry in
-                    Button {
-                        navStore.select(entry.destination)
-                    } label: {
-                        Label {
-                            Text(entry.label)
-                                .foregroundStyle(.white)
-                        } icon: {
-                            Image(systemName: entry.systemImage)
-                                .foregroundStyle(Color.xomifyGreen)
-                                .accessibilityHidden(true)
-                        }
+            // Pinned Settings at the bottom.
+            Divider()
+                .overlay(Color.white.opacity(0.08))
+            VStack(spacing: 6) {
+                drawerRow(settingsEntry)
+            }
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            .padding(.bottom, 24)
+        }
+        .frame(width: drawerWidth)
+        .background(
+            LinearGradient(
+                colors: [Color.xomifyDark, Color.xomifyCard.opacity(0.85)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea(edges: .vertical)
+        )
+        .overlay(alignment: .trailing) {
+            Rectangle()
+                .fill(Color.white.opacity(0.06))
+                .frame(width: 1)
+                .ignoresSafeArea(edges: .vertical)
+        }
+    }
+
+    // MARK: - Banner header
+
+    private var bannerHeader: some View {
+        HStack {
+            Image("banner-logo")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 34)
+                .accessibilityLabel("Xomify")
+                .accessibilityAddTraits(.isHeader)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Profile card
+
+    private var profileCard: some View {
+        Button {
+            navStore.select(.profile)
+        } label: {
+            HStack(spacing: 12) {
+                avatarView
+                    .frame(width: 44, height: 44)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayName ?? "Your Profile")
+                        .font(.xomifyHeadline)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    if let email {
+                        Text(email)
+                            .font(.xomifyCaption)
+                            .foregroundStyle(.white.opacity(0.65))
+                            .lineLimit(1)
                     }
-                    // 44 pt minimum touch target via explicit frame on the row.
-                    .frame(minHeight: 44)
-                    .accessibilityLabel(entry.label)
-                    .listRowBackground(
-                        navStore.currentDestination == entry.destination
-                            ? Color.xomifyGreen.opacity(0.15)
-                            : Color.xomifyCard
-                    )
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+                LinearGradient(
+                    colors: [Color.xomifyPurple.opacity(0.35), Color.xomifyGreen.opacity(0.25)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Open profile for \(displayName ?? email ?? "you")")
+    }
+
+    // MARK: - Avatar
+
+    @ViewBuilder
+    private var avatarView: some View {
+        if let avatarURL {
+            AsyncImage(url: avatarURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                case .failure, .empty:
+                    avatarPlaceholder
+                @unknown default:
+                    avatarPlaceholder
                 }
             }
+            .clipShape(.circle)
+            .overlay(Circle().stroke(Color.white.opacity(0.15), lineWidth: 1))
+        } else {
+            avatarPlaceholder
+                .clipShape(.circle)
+                .overlay(Circle().stroke(Color.white.opacity(0.15), lineWidth: 1))
         }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(Color.xomifyDark)
-        .frame(width: drawerWidth)
+    }
+
+    private var avatarPlaceholder: some View {
+        Image(systemName: "person.crop.circle.fill")
+            .resizable()
+            .scaledToFit()
+            .foregroundStyle(Color.white.opacity(0.75))
+            .background(Color.xomifyPurple.opacity(0.25))
+    }
+
+    // MARK: - Row
+
+    @ViewBuilder
+    private func drawerRow(_ entry: DrawerEntry) -> some View {
+        let isSelected = navStore.currentDestination == entry.destination
+        Button {
+            navStore.select(entry.destination)
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: entry.systemImage)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(isSelected ? .white : Color.xomifyGreen)
+                    .frame(width: 26)
+                    .accessibilityHidden(true)
+
+                Text(entry.label)
+                    .font(.xomifyBody.weight(isSelected ? .semibold : .regular))
+                    .foregroundStyle(.white)
+
+                Spacer(minLength: 0)
+
+                if isSelected {
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.bold))
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 44)
+            .background(rowBackground(isSelected: isSelected))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(entry.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private func rowBackground(isSelected: Bool) -> some View {
+        if isSelected {
+            LinearGradient(
+                colors: [Color.xomifyPurple, Color.xomifyGreen],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        } else {
+            Color.white.opacity(0.04)
+        }
     }
 }

--- a/Xomify-iOS/Views/Shell/HeaderBar.swift
+++ b/Xomify-iOS/Views/Shell/HeaderBar.swift
@@ -12,11 +12,11 @@ struct HeaderBar: View {
 
     var body: some View {
         ZStack {
-            // Wordmark — centered absolutely over the full bar.
-            Text("Xomify")
-                .font(.headline)
-                .fontWeight(.bold)
-                .foregroundStyle(.white)
+            // Banner logo — replaces the old "Xomify" text wordmark.
+            Image("banner-logo")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 28)
                 .accessibilityLabel("Xomify")
                 .accessibilityAddTraits(.isHeader)
 

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -58,24 +58,26 @@ struct MainShell: View {
     @ViewBuilder
     private var destinationRoot: some View {
         switch navStore.currentDestination {
+        case .profile:
+            ProfileView()
         case .feed:
             FeedView()
+        case .musicTaste:
+            TopItemsView()
         case .wrapped:
             WrappedView()
         case .releaseRadar:
             ReleaseRadarView()
         case .ratings:
             RatingsHistoryView()
-        case .groups:
-            GroupsView()
         case .friends:
             FriendsView()
-        case .profile:
-            ProfileView()
-        case .settings:
-            SettingsView()
+        case .groups:
+            GroupsView()
         case .builder:
             PlaylistBuilderTabView()
+        case .settings:
+            SettingsView()
         }
     }
 

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -12,6 +12,8 @@ struct MainShell: View {
 
     @State private var navStore = NavigationStore()
     @State private var avatarURL: URL? = nil
+    @State private var displayName: String? = nil
+    @State private var userEmail: String? = nil
 
     // MARK: - Body
 
@@ -32,8 +34,12 @@ struct MainShell: View {
                 .environment(navStore)
 
             // Drawer — slides in from the leading edge.
-            DrawerView()
-                .environment(navStore)
+            DrawerView(
+                avatarURL: avatarURL,
+                displayName: displayName,
+                email: userEmail
+            )
+            .environment(navStore)
         }
         .environment(navStore)
         .ignoresSafeArea(edges: .bottom)
@@ -83,14 +89,17 @@ struct MainShell: View {
 
     // MARK: - Avatar fetch
 
-    /// Fetches the current user's profile image URL for the header bar.
-    /// Non-blocking — placeholder is shown until the request resolves.
+    /// Fetches the current user's profile image URL and display info for the
+    /// header bar + drawer profile card. Non-blocking — placeholders show
+    /// until the request resolves.
     private func fetchAvatar() async {
         do {
             let user = try await SpotifyService.shared.getCurrentUser()
             avatarURL = user.profileImageUrl
+            displayName = user.displayName
+            userEmail = user.email
         } catch {
-            // Silently fall back to the SF symbol placeholder — non-critical.
+            // Silently fall back — non-critical.
         }
     }
 }

--- a/Xomify-iOS/Views/TopItemsView.swift
+++ b/Xomify-iOS/Views/TopItemsView.swift
@@ -26,6 +26,12 @@ struct TopItemsContent: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Music Taste",
+                    subtitle: "Your top tracks, artists, and genres",
+                    systemImage: "waveform"
+                )
+
                 // Category selector
                 categorySelector
 
@@ -69,8 +75,8 @@ struct TopItemsContent: View {
             }
         }
         .background(Color.xomifyDark.ignoresSafeArea())
-        .navigationTitle("Top Items")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task {
             await viewModel.loadData()
         }


### PR DESCRIPTION
## Summary

A branded facelift across the app shell. Addresses the design requests: banner-logo in place of "Xomify" text, gradient headers everywhere, rounded/friendly fonts, less grey, and a proper sidebar + ratings screen.

### New components
- `BrandGradientHeader` — reusable gradient bar (purple → green) with title, subtitle, optional SF symbol, and trailing slot. Wrapped/ReleaseRadar visual language extended app-wide.
- `FontExtensions` — `Font.xomifyTitle / .xomifyHeadline / .xomifyBody` ... all map to `system(..., design: .rounded)`. Dynamic Type still works.

### Shell
- **HeaderBar** — swaps the "Xomify" text wordmark for the `banner-logo` image.
- **DrawerView** — complete redesign:
  - Banner-logo header, no more text wordmark
  - Profile card at the top: avatar + display name + email, tappable shortcut to Profile
  - Rounded-font rows, gradient fill on the selected row (not just a tint)
  - Settings pinned to the bottom with a divider
  - Vertical gradient background (`xomifyDark → xomifyCard`), hairline right-edge separator
  - Less grey — brand colors do the work

### Destinations
- `BrandGradientHeader` added to: **Feed**, **Friends**, **Groups**, **Music Taste**, **Ratings**. Each loses its old `.navigationTitle` and hides the nav bar to make room.
- **Friends / Groups**: the old trailing toolbar buttons (invite, create) move into the gradient header as circular white-on-gradient icons.
- **Ratings** (`RatingsHistoryView`): rewritten as a grouped-by-star list of gradient artwork cards with a star badge in the corner, italic review pull-quotes, and relative timestamps. Error state gets a gradient pill CTA.

## Test plan
- [ ] Launch → drawer opens showing banner-logo, profile card with your avatar / name / email, and Settings at the bottom
- [ ] Tap profile card → opens Profile
- [ ] Navigate through Feed / Friends / Groups / Music Taste / Ratings — each has the gradient header with the correct title/subtitle
- [ ] Friends header button still mints an invite; Groups header button still opens the create sheet
- [ ] Ratings screen shows grouped stars, cards have artwork + star badge + review + relative time; swipe (context-menu) delete still works
- [ ] Build succeeds for iOS Simulator (verified locally)