### PR TITLE
feat(ios): profile polish — stats swap, cover art, context actions, pill tabs

### DIFF
--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -58,6 +58,16 @@ protocol XomifyServiceProtocol: Sendable {
         rating: Int,
         review: String?
     ) async throws -> SuccessResponse
+
+    // MARK: - Self-profile counts
+
+    /// All ratings authored by the caller. Used by the self-profile header to
+    /// populate the Ratings stat without a dedicated counts endpoint.
+    func getAllRatings(email: String) async throws -> RatingsAllResponse
+
+    /// Full friends payload for the caller. Used by the self-profile header
+    /// (friend count) and the Friends drawer.
+    func getAllFriends(email: String) async throws -> FriendsAllResponse
 }
 
 extension XomifyService: XomifyServiceProtocol {}

--- a/Xomify-iOS/ViewModels/RatingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/RatingsViewModel.swift
@@ -12,7 +12,12 @@ final class RatingsViewModel {
     var isRefreshing = false
     var errorMessage: String?
 
+    /// Cover art URL per `trackId`. Resolved after ratings load — see
+    /// `RatingsHistoryViewModel` for the same pattern.
+    var artworkByTrackId: [String: URL] = [:]
+
     private let xomify = XomifyService.shared
+    private let spotify = SpotifyService.shared
 
     var isEmpty: Bool { ratings.isEmpty }
 
@@ -42,12 +47,29 @@ final class RatingsViewModel {
         do {
             let response = try await xomify.getAllRatings(email: email)
             ratings = response.ratings ?? []
+            await resolveArtwork()
         } catch {
             errorMessage = error.localizedDescription
             print("❌ Ratings: load failed - \(error)")
         }
 
         isLoading = false
+    }
+
+    private func resolveArtwork() async {
+        let missing = ratings.map(\.trackId).filter { !$0.isEmpty && artworkByTrackId[$0] == nil }
+        guard !missing.isEmpty else { return }
+
+        do {
+            let tracks = try await spotify.getTracks(ids: missing)
+            for track in tracks {
+                if let url = track.imageUrl {
+                    artworkByTrackId[track.id] = url
+                }
+            }
+        } catch {
+            print("⚠️ Ratings: artwork fetch failed - \(error)")
+        }
     }
 
     func refresh() async {

--- a/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
+++ b/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
@@ -12,6 +12,11 @@ final class RatingsHistoryViewModel {
     var isLoading = false
     var errorMessage: String?
 
+    /// Cover art URL per `trackId`. Resolved lazily after ratings load via
+    /// the Spotify `GET /tracks` batch endpoint. Views fall back to a gradient
+    /// placeholder when a key is missing.
+    var artworkByTrackId: [String: URL] = [:]
+
     // MARK: - Dependencies
 
     private let spotifyService = SpotifyService.shared
@@ -36,12 +41,32 @@ final class RatingsHistoryViewModel {
             let loaded = response.ratings ?? []
             ratings = loaded.sorted(by: Self.isMoreRecent)
             print("✅ RatingsHistory: loaded \(ratings.count) ratings")
+            await resolveArtwork()
         } catch {
             errorMessage = error.localizedDescription
             print("❌ RatingsHistory: load failed - \(error)")
         }
 
         isLoading = false
+    }
+
+    /// Fetch album art for every rated track via Spotify's batch tracks
+    /// endpoint. Skips ids already resolved. Best-effort — errors are logged
+    /// and the view falls back to gradient placeholders.
+    private func resolveArtwork() async {
+        let missing = ratings.map(\.trackId).filter { !$0.isEmpty && artworkByTrackId[$0] == nil }
+        guard !missing.isEmpty else { return }
+
+        do {
+            let tracks = try await spotifyService.getTracks(ids: missing)
+            for track in tracks {
+                if let url = track.imageUrl {
+                    artworkByTrackId[track.id] = url
+                }
+            }
+        } catch {
+            print("⚠️ RatingsHistory: artwork fetch failed - \(error)")
+        }
     }
 
     /// Optimistically remove a rating. On error, re-insert at original index and surface the message.

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -8,7 +8,7 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
 
     var title: String {
         switch self {
-        case .shares:  return "Shares"
+        case .shares:  return "Posts"
         case .ratings: return "Ratings"
         case .taste:   return "Taste"
         }
@@ -141,6 +141,20 @@ final class UserProfileViewModel {
         profileEmail = user.email ?? callerEmail
         avatarURL = user.profileImageUrl
         followersCount = user.followers?.total
+
+        // Populate the three header stats (Friends / Ratings / Posts) with
+        // parallel fetches. Missing counts fall through to nil so the header
+        // skeleton keeps working if any single call fails.
+        async let ratings: RatingsAllResponse? = try? xomifyService.getAllRatings(email: callerEmail)
+        async let friends: FriendsAllResponse? = try? xomifyService.getAllFriends(email: callerEmail)
+        async let shares: FeedResponse?       = try? xomifyService.getSharesByUser(
+            email: callerEmail, targetEmail: callerEmail, limit: 1, before: nil
+        )
+
+        let (r, f, s) = await (ratings, friends, shares)
+        ratingCount = r?.totalCount ?? r?.ratings?.count
+        friendCount = f?.acceptedCount ?? f?.accepted?.count
+        shareCount  = s?.totalCount ?? s?.shares.count
     }
 
     private func loadOtherHeader(email: String) async throws {

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -106,19 +106,11 @@ struct ProfileHeaderView: View {
                 divider
                 skeletonStat
             } else {
-                if let shares = viewModel.shareCount {
-                    statItem(value: shares, label: "Shares", color: .xomifyGreen)
-                    divider
-                }
-                if let ratings = viewModel.ratingCount {
-                    statItem(value: ratings, label: "Ratings", color: .xomifyPurple)
-                    divider
-                }
-                if let friends = viewModel.friendCount {
-                    statItem(value: friends, label: "Friends", color: .xomifyGreen)
-                } else if let followers = viewModel.followersCount {
-                    statItem(value: followers, label: "Followers", color: .xomifyGreen)
-                }
+                statItem(value: viewModel.friendCount ?? 0, label: "Friends", color: .xomifyGreen)
+                divider
+                statItem(value: viewModel.ratingCount ?? 0, label: "Ratings", color: .xomifyPurple)
+                divider
+                statItem(value: viewModel.shareCount ?? 0, label: "Posts", color: .xomifyGreen)
             }
         }
         .padding(.vertical, 12)

--- a/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
+++ b/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
@@ -1,23 +1,67 @@
 import SwiftUI
 
-/// Segmented control swapping between `Shares / Ratings / Taste`. Kept
-/// separate from the view models so the chrome can iterate independently.
+/// Pill-style tab switcher used above the tabbed `ProfileView` content. Mirrors
+/// the web app's Overview/Settings pill group so brand feel matches across
+/// surfaces — gradient fill on the active pill, subtle inactive label.
 struct ProfileTabPicker: View {
 
     @Binding var selection: ProfileTab
 
+    private let namespace: Namespace.ID
+
+    init(selection: Binding<ProfileTab>, namespace: Namespace.ID) {
+        self._selection = selection
+        self.namespace = namespace
+    }
+
     var body: some View {
-        Picker("Profile tab", selection: $selection) {
+        HStack(spacing: 4) {
             ForEach(ProfileTab.allCases, id: \.self) { tab in
-                Text(tab.title)
-                    .tag(tab)
-                    .accessibilityLabel("\(tab.title) tab")
+                tabButton(tab)
             }
         }
-        .pickerStyle(.segmented)
+        .padding(4)
+        .background(Color.xomifyCard.opacity(0.7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 999, style: .continuous)
+                .stroke(Color.xomifyPurple.opacity(0.25), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 999, style: .continuous))
         .padding(.horizontal)
-        .padding(.bottom, 8)
+        .padding(.bottom, 12)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("Profile sections")
-        .accessibilityHint("Swipe to switch between Shares, Ratings, and Taste")
+    }
+
+    private func tabButton(_ tab: ProfileTab) -> some View {
+        let isSelected = selection == tab
+        return Button {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                selection = tab
+            }
+        } label: {
+            ZStack {
+                if isSelected {
+                    LinearGradient(
+                        colors: [Color.xomifyPurple, Color.xomifyGreen],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 999, style: .continuous))
+                    .matchedGeometryEffect(id: "profileTabActive", in: namespace)
+                    .shadow(color: Color.xomifyPurple.opacity(0.35), radius: 8, y: 3)
+                }
+                Text(tab.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(isSelected ? .white : Color.white.opacity(0.6))
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 8)
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(tab.title) tab")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Ratings tab on `ProfileView`. Reuses `RatingsViewModel` parameterised by
 /// the context email. Hides delete on `.other` — viewers can't mutate
@@ -61,13 +62,7 @@ struct ProfileRatingsTab: View {
 
     private func ratingRow(_ rating: TrackRating) -> some View {
         HStack(spacing: 12) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.gray.opacity(0.3))
-                    .frame(width: 44, height: 44)
-                Image(systemName: "music.note")
-                    .foregroundStyle(.white.opacity(0.7))
-            }
+            artworkTile(for: rating)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(rating.trackName ?? "Unknown")
@@ -84,19 +79,84 @@ struct ProfileRatingsTab: View {
 
             Spacer()
 
-            if context.isSelf {
-                Button(role: .destructive) {
-                    Task { await viewModel.delete(rating) }
+            Menu {
+                Button {
+                    Task { await queue(rating: rating) }
                 } label: {
-                    Image(systemName: "trash").foregroundStyle(.red)
+                    Label("Add to Spotify queue", systemImage: "text.badge.plus")
                 }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("Delete rating for \(rating.trackName ?? "track")")
+                Button {
+                    openInSpotify(trackId: rating.trackId)
+                } label: {
+                    Label("Open in Spotify", systemImage: "arrow.up.forward.app")
+                }
+                if context.isSelf {
+                    Divider()
+                    Button(role: .destructive) {
+                        Task { await viewModel.delete(rating) }
+                    } label: {
+                        Label("Delete rating", systemImage: "trash")
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.7))
+                    .frame(width: 32, height: 32)
+                    .background(Color.white.opacity(0.08), in: Circle())
             }
+            .accessibilityLabel("Actions for \(rating.trackName ?? "track")")
         }
         .padding(12)
         .background(Color.xomifyCard)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func artworkTile(for rating: TrackRating) -> some View {
+        if let url = viewModel.artworkByTrackId[rating.trackId] {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    artworkPlaceholder
+                }
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        } else {
+            artworkPlaceholder
+                .frame(width: 44, height: 44)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+    }
+
+    private var artworkPlaceholder: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyPurple.opacity(0.35), Color.xomifyGreen.opacity(0.25)],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            Image(systemName: "music.note")
+                .foregroundStyle(.white.opacity(0.85))
+        }
+    }
+
+    // MARK: - Actions
+
+    private func openInSpotify(trackId: String) {
+        guard !trackId.isEmpty, let url = URL(string: "spotify:track:\(trackId)") else { return }
+        UIApplication.shared.open(url)
+    }
+
+    private func queue(rating: TrackRating) async {
+        guard !rating.trackId.isEmpty else { return }
+        do {
+            try await SpotifyService.shared.queueTrack(uri: "spotify:track:\(rating.trackId)")
+        } catch {
+            print("ProfileRatingsTab: queue failed — \(error)")
+        }
     }
 
     // MARK: - States

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
@@ -75,13 +75,13 @@ struct ProfileSharesTab: View {
     }
 
     private var emptyTitle: String {
-        context.isSelf ? "Share your first track" : "No shares yet"
+        context.isSelf ? "Post your first track" : "No posts yet"
     }
 
     private var emptySubtitle: String {
         context.isSelf
-        ? "When you share a song, it lands here."
-        : "This user hasn't shared anything yet."
+        ? "When you post a song, it lands here."
+        : "This user hasn't posted anything yet."
     }
 
     private func errorState(_ message: String) -> some View {
@@ -90,7 +90,7 @@ struct ProfileSharesTab: View {
                 .font(.system(size: 36))
                 .foregroundStyle(.orange.opacity(0.8))
                 .accessibilityHidden(true)
-            Text("Couldn't load shares")
+            Text("Couldn't load posts")
                 .font(.headline)
                 .foregroundStyle(.white)
             Text(message)

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Taste tab on `ProfileView`. Compact summary — top 3 of each category per
 /// term — with a "See all" CTA that jumps to the full `Music Taste` drawer
@@ -46,8 +47,8 @@ private struct SelfTasteSummary: View {
                 }
                 .frame(maxWidth: .infinity, minHeight: 160)
             } else {
-                section(title: "Top Tracks", items: tracks.map(\.name))
-                section(title: "Top Artists", items: artists.map(\.name))
+                trackSection(title: "Top Tracks", tracks: tracks)
+                artistSection(title: "Top Artists", artists: artists)
                 section(title: "Top Genres", items: genres.map(\.name))
 
                 Button(action: onSeeAll) {
@@ -120,28 +121,171 @@ private struct SelfTasteSummary: View {
     private func section(title: String, items: [String]) -> some View {
         if !items.isEmpty {
             VStack(alignment: .leading, spacing: 10) {
-                Text(title)
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(.white)
+                sectionHeader(title)
                 ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                     HStack(spacing: 12) {
-                        Text("\(index + 1)")
-                            .font(.subheadline.monospacedDigit().weight(.bold))
-                            .foregroundStyle(Color.xomifyGreen)
-                            .frame(width: 20, alignment: .leading)
+                        indexLabel(index)
                         Text(item)
                             .font(.subheadline)
                             .foregroundStyle(.white)
                             .lineLimit(1)
                         Spacer(minLength: 0)
                     }
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 10)
                     .padding(.horizontal, 12)
                     .background(Color.xomifyCard)
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func trackSection(title: String, tracks: [SpotifyTrack]) -> some View {
+        if !tracks.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionHeader(title)
+                ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
+                    trackRow(track: track, index: index)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func artistSection(title: String, artists: [SpotifyArtist]) -> some View {
+        if !artists.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                sectionHeader(title)
+                ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                    artistRow(artist: artist, index: index)
+                }
+            }
+        }
+    }
+
+    private func trackRow(track: SpotifyTrack, index: Int) -> some View {
+        HStack(spacing: 12) {
+            indexLabel(index)
+            artworkThumb(url: track.imageUrl)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.name)
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(track.artistNames)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.65))
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            trackActions(trackId: track.id, uri: track.uri ?? "spotify:track:\(track.id)")
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func artistRow(artist: SpotifyArtist, index: Int) -> some View {
+        HStack(spacing: 12) {
+            indexLabel(index)
+            artworkThumb(url: artist.imageUrl, circular: true)
+            Text(artist.name)
+                .font(.subheadline)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+            if let artistId = artist.id {
+                Button {
+                    openURL("spotify:artist:\(artistId)")
+                } label: {
+                    Image(systemName: "arrow.up.forward.app")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.75))
+                        .frame(width: 32, height: 32)
+                        .background(Color.white.opacity(0.08), in: Circle())
+                }
+                .accessibilityLabel("Open \(artist.name) in Spotify")
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func trackActions(trackId: String, uri: String) -> some View {
+        Menu {
+            Button {
+                Task { try? await SpotifyService.shared.queueTrack(uri: uri) }
+            } label: {
+                Label("Add to Spotify queue", systemImage: "text.badge.plus")
+            }
+            Button {
+                openURL(uri)
+            } label: {
+                Label("Open in Spotify", systemImage: "arrow.up.forward.app")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.7))
+                .frame(width: 32, height: 32)
+                .background(Color.white.opacity(0.08), in: Circle())
+        }
+        .accessibilityLabel("Track actions")
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline.weight(.semibold))
+            .foregroundStyle(.white)
+    }
+
+    private func indexLabel(_ index: Int) -> some View {
+        Text("\(index + 1)")
+            .font(.subheadline.monospacedDigit().weight(.bold))
+            .foregroundStyle(Color.xomifyGreen)
+            .frame(width: 20, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func artworkThumb(url: URL?, circular: Bool = false) -> some View {
+        let shape: AnyShape = circular
+            ? AnyShape(Circle())
+            : AnyShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        Group {
+            if let url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let img): img.resizable().scaledToFill()
+                    default: artworkThumbFallback
+                    }
+                }
+            } else {
+                artworkThumbFallback
+            }
+        }
+        .frame(width: 36, height: 36)
+        .clipShape(shape)
+    }
+
+    private var artworkThumbFallback: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyPurple.opacity(0.35), Color.xomifyGreen.opacity(0.25)],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            Image(systemName: "music.note")
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.85))
+        }
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else { return }
+        UIApplication.shared.open(url)
     }
 }
 

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct ProfileView: View {
 
     @State private var viewModel: UserProfileViewModel
+    @Namespace private var tabNamespace
 
     init(context: ProfileContext = .me) {
         _viewModel = State(wrappedValue: UserProfileViewModel(context: context))
@@ -43,10 +44,13 @@ struct ProfileView: View {
                 ProfileHeaderView(viewModel: viewModel)
                     .padding(.top, 12)
 
-                ProfileTabPicker(selection: Binding(
-                    get: { viewModel.selectedTab },
-                    set: { viewModel.selectedTab = $0 }
-                ))
+                ProfileTabPicker(
+                    selection: Binding(
+                        get: { viewModel.selectedTab },
+                        set: { viewModel.selectedTab = $0 }
+                    ),
+                    namespace: tabNamespace
+                )
 
                 tabContent
                     .padding(.bottom, 24)

--- a/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
@@ -5,6 +5,8 @@ import UIKit
 /// Tapping a row opens the track in Spotify. Swipe-to-delete removes a rating.
 struct RatingsHistoryView: View {
     @State private var viewModel = RatingsHistoryViewModel()
+    @State private var queueErrorMessage: String?
+    @State private var query: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -14,6 +16,10 @@ struct RatingsHistoryView: View {
                 systemImage: "star.fill"
             )
 
+            if !viewModel.ratings.isEmpty {
+                searchField
+            }
+
             Group {
                 if viewModel.isLoading && viewModel.ratings.isEmpty {
                     loadingState
@@ -21,6 +27,8 @@ struct RatingsHistoryView: View {
                     errorState(error)
                 } else if viewModel.ratings.isEmpty {
                     emptyState
+                } else if filteredRatings.isEmpty {
+                    noMatchesState
                 } else {
                     list
                 }
@@ -35,6 +43,64 @@ struct RatingsHistoryView: View {
             }
         }
         .refreshable { await viewModel.load() }
+        .overlay(alignment: .bottom) {
+            if let message = queueErrorMessage {
+                queueBanner(message)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut, value: queueErrorMessage)
+    }
+
+    // MARK: - Filtered ratings
+
+    private var filteredRatings: [TrackRating] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return viewModel.ratings }
+        let needle = trimmed.lowercased()
+        return viewModel.ratings.filter { rating in
+            (rating.trackName ?? "").lowercased().contains(needle)
+                || (rating.artistName ?? "").lowercased().contains(needle)
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.white.opacity(0.6))
+            TextField("Search track or artist", text: $query)
+                .textFieldStyle(.plain)
+                .foregroundStyle(.white)
+                .accessibilityLabel("Search ratings")
+            if !query.isEmpty {
+                Button { query = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.white.opacity(0.5))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    private var noMatchesState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.title3)
+                .foregroundStyle(.white.opacity(0.5))
+            Text("No ratings match \"\(query)\"")
+                .font(.xomifyCaption)
+                .foregroundStyle(.white.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var subtitleText: String {
@@ -58,10 +124,24 @@ struct RatingsHistoryView: View {
                                 Button {
                                     openInSpotify(trackId: rating.trackId)
                                 } label: {
-                                    RatingCard(rating: rating)
+                                    RatingCard(
+                                        rating: rating,
+                                        artwork: viewModel.artworkByTrackId[rating.trackId]
+                                    )
                                 }
                                 .buttonStyle(.plain)
                                 .contextMenu {
+                                    Button {
+                                        queue(rating: rating)
+                                    } label: {
+                                        Label("Add to Spotify queue", systemImage: "text.badge.plus")
+                                    }
+                                    Button {
+                                        openInSpotify(trackId: rating.trackId)
+                                    } label: {
+                                        Label("Open in Spotify", systemImage: "arrow.up.forward.app")
+                                    }
+                                    Divider()
                                     Button(role: .destructive) {
                                         Task { await viewModel.delete(rating) }
                                     } label: {
@@ -79,7 +159,7 @@ struct RatingsHistoryView: View {
     }
 
     private var groupedByStars: [(stars: Int, ratings: [TrackRating])] {
-        Dictionary(grouping: viewModel.ratings, by: { $0.rating })
+        Dictionary(grouping: filteredRatings, by: { $0.rating })
             .map { (stars: $0.key, ratings: $0.value) }
             .sorted { $0.stars > $1.stars }
     }
@@ -178,12 +258,62 @@ struct RatingsHistoryView: View {
             }
         }
     }
+
+    private func queue(rating: TrackRating) {
+        guard !rating.trackId.isEmpty else { return }
+        let uri = "spotify:track:\(rating.trackId)"
+        Task {
+            do {
+                try await SpotifyService.shared.queueTrack(uri: uri)
+                withAnimation { queueErrorMessage = "Queued on Spotify" }
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                withAnimation { queueErrorMessage = nil }
+            } catch {
+                withAnimation { queueErrorMessage = queueFailureMessage(from: error) }
+                try? await Task.sleep(nanoseconds: 3_500_000_000)
+                withAnimation { queueErrorMessage = nil }
+            }
+        }
+    }
+
+    private func queueFailureMessage(from error: Error) -> String {
+        if case SpotifyServiceError.premiumRequired = error {
+            return "Spotify Premium is required to queue tracks."
+        }
+        if case SpotifyServiceError.noActiveDevice = error {
+            return "Open Spotify on a device first, then try again."
+        }
+        return "Could not add to queue."
+    }
+
+    private func queueBanner(_ message: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: message.hasPrefix("Queued") ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(message.hasPrefix("Queued") ? Color.xomifyGreen : .orange)
+            Text(message)
+                .font(.xomifyFootnote.weight(.semibold))
+                .foregroundStyle(.white)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.xomifyCard)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
 }
 
 // MARK: - Card
 
 private struct RatingCard: View {
     let rating: TrackRating
+    /// Cover art URL. Provided by the parent view model via
+    /// `artworkByTrackId`. When `nil`, the gradient placeholder renders
+    /// instead.
+    let artwork: URL?
 
     var body: some View {
         HStack(spacing: 14) {
@@ -248,14 +378,18 @@ private struct RatingCard: View {
 
     private var artworkTile: some View {
         ZStack {
-            LinearGradient(
-                colors: [Color.xomifyPurple, Color.xomifyGreen],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            Image(systemName: "music.note")
-                .font(.title3.weight(.bold))
-                .foregroundStyle(.white)
+            if let artwork {
+                AsyncImage(url: artwork) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFill()
+                    default:
+                        placeholderTile
+                    }
+                }
+            } else {
+                placeholderTile
+            }
         }
         .frame(width: 52, height: 52)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -267,6 +401,19 @@ private struct RatingCard: View {
                 .background(Color.xomifyGreen, in: Circle())
                 .overlay(Circle().stroke(Color.xomifyDark, lineWidth: 2))
                 .offset(x: 6, y: 6)
+        }
+    }
+
+    private var placeholderTile: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyPurple, Color.xomifyGreen],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Image(systemName: "music.note")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.white)
         }
     }
 

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -27,8 +27,9 @@ struct DrawerView: View {
     }
 
     /// Primary entries (everything except Settings — pinned to the bottom).
+    /// Profile is reached via the profile card above this list, so it is not
+    /// duplicated as a row.
     private let primaryEntries: [DrawerEntry] = [
-        .init(destination: .profile,      label: "Profile",          systemImage: "person.crop.circle.fill"),
         .init(destination: .feed,         label: "Feed",             systemImage: "sparkles"),
         .init(destination: .musicTaste,   label: "Music Taste",      systemImage: "waveform"),
         .init(destination: .wrapped,      label: "Wrapped",          systemImage: "chart.bar.fill"),

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -83,6 +83,19 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     ) async throws -> SuccessResponse {
         SuccessResponse(success: true)
     }
+
+    func getAllRatings(email: String) async throws -> RatingsAllResponse {
+        RatingsAllResponse(email: email, ratings: [], totalCount: 0)
+    }
+
+    func getAllFriends(email: String) async throws -> FriendsAllResponse {
+        FriendsAllResponse(
+            email: email,
+            accepted: [], requested: [], pending: [], blocked: [],
+            acceptedCount: 0, requestedCount: 0, pendingCount: 0, blockedCount: 0,
+            totalCount: 0
+        )
+    }
 }
 
 // MARK: - SpotifyCurrentUserProviding mock


### PR DESCRIPTION
## Summary
- Profile stats now show **Friends / Ratings / Posts** (followers removed). Self-profile counts fetched in parallel via `getAllRatings`, `getAllFriends`, `getSharesByUser`.
- **Cover art** now renders on Profile ratings + taste tabs and on the Ratings History screen, backed by a batched `SpotifyService.getTracks(ids:)` fetch cached by `trackId`.
- **Context actions everywhere**: every rating and taste row gets a menu with **Add to Spotify queue** (fixes Dom's "mobile NEEDS everywhere a button to add to active Spotify queue" ask), **Open in Spotify**, and **Delete** (self only).
- Ratings History gets inline **search/filter** field with empty-match state.
- New **pill-style tab switcher** using `matchedGeometryEffect` and a gradient fill on the selected tab — replaces the boring stock segmented picker.
- Drawer: redundant **Profile** row removed (top-bar avatar already navigates there).
- **Shares → Posts** UI rename per Dom's note ("ui label only — I might change back"); enum cases unchanged.

## Test plan
- [ ] Profile header shows 3 stats with real counts for self, 0s until loaded
- [ ] Ratings on Profile tab + Ratings History show artwork, fallback gradient otherwise
- [ ] Taste tab rows show track art + artist image thumbs
- [ ] Tapping `…` on any rating/taste row shows Queue / Open in Spotify / Delete
- [ ] Queue action surfaces Premium / active-device errors as banner on Ratings History
- [ ] Search in Ratings History filters by track/artist/review
- [ ] Tab picker animates pill between Taste / Ratings / Posts
- [ ] Drawer no longer shows Profile row; avatar still opens profile