### PR TITLE
feat(ios): paint loader, ambient bg, taste carousel, notifications bell

### DIFF
--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -23,105 +23,216 @@ struct ProfileTasteTab: View {
     }
 }
 
-// MARK: - Self taste summary (top-3 per category, per term)
+// MARK: - Self taste summary (auto-rotating top-3 per category, per term)
 
+/// Auto-rotates through 9 stages — (category × term) — cross-fading every
+/// ~6 seconds: 1mo tracks → 1mo artists → 1mo genres → 6mo tracks … → 1yr
+/// genres → loop. Tap anywhere on the card to advance manually.
 private struct SelfTasteSummary: View {
     let onSeeAll: () -> Void
 
     @State private var viewModel = TopItemsViewModel()
-    @State private var selectedTerm: TimeRange = .shortTerm
+    @State private var stage: Int = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// 9 stages, ordered by term then category. Matches Dom's spec:
+    /// "top 3 tracks, artists, genres for 1 month, then same for 6 months then 1 year then back".
+    private static let stages: [Stage] = [
+        .init(term: .shortTerm,  kind: .tracks),
+        .init(term: .shortTerm,  kind: .artists),
+        .init(term: .shortTerm,  kind: .genres),
+        .init(term: .mediumTerm, kind: .tracks),
+        .init(term: .mediumTerm, kind: .artists),
+        .init(term: .mediumTerm, kind: .genres),
+        .init(term: .longTerm,   kind: .tracks),
+        .init(term: .longTerm,   kind: .artists),
+        .init(term: .longTerm,   kind: .genres)
+    ]
+
+    private var currentStage: Stage { Self.stages[stage % Self.stages.count] }
+
+    private func termLabel(_ term: TimeRange) -> String {
+        switch term {
+        case .shortTerm:  return "1 month"
+        case .mediumTerm: return "6 months"
+        case .longTerm:   return "1 year"
+        }
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            Picker("Time range", selection: $selectedTerm) {
-                Text("4 weeks").tag(TimeRange.shortTerm)
-                Text("6 months").tag(TimeRange.mediumTerm)
-                Text("All time").tag(TimeRange.longTerm)
-            }
-            .pickerStyle(.segmented)
-            .accessibilityLabel("Taste time range")
+        VStack(alignment: .leading, spacing: 14) {
+            header
 
-            if viewModel.isLoading && tracks.isEmpty && artists.isEmpty {
+            if viewModel.isLoading && allEmpty {
                 VStack {
-                    ProgressView().tint(.xomifyGreen)
+                    XomifyLoaderPulse(size: 48)
                 }
-                .frame(maxWidth: .infinity, minHeight: 160)
+                .frame(maxWidth: .infinity, minHeight: 200)
             } else {
-                trackSection(title: "Top Tracks", tracks: tracks)
-                artistSection(title: "Top Artists", artists: artists)
-                section(title: "Top Genres", items: genres.map(\.name))
-
-                Button(action: onSeeAll) {
-                    HStack(spacing: 6) {
-                        Text("See all")
-                            .fontWeight(.semibold)
-                        Image(systemName: "arrow.right")
-                    }
-                    .font(.subheadline)
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .background(
-                        LinearGradient(
-                            colors: [Color.xomifyPurple, Color.xomifyGreen],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                }
-                .accessibilityHint("Opens the full Music Taste screen")
+                stageCard
+                    .frame(maxWidth: .infinity, minHeight: 260, alignment: .top)
+                    .onTapGesture { advance() }
+                progressIndicator
+                seeAllButton
             }
         }
         .padding(.horizontal)
         .task { await viewModel.loadData() }
+        .task { await autoAdvanceLoop() }
     }
 
-    // MARK: Term-scoped slices (top 3 each)
+    // MARK: Header + progress
 
-    private var tracks: [SpotifyTrack] {
-        Array(tracksForSelectedTerm.prefix(3))
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(currentStage.kindLabel)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(.white)
+                .contentTransition(.opacity)
+                .id("kind-\(stage)")
+            Text("·").foregroundStyle(.white.opacity(0.4))
+            Text(termLabel(currentStage.term))
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white.opacity(0.7))
+                .contentTransition(.opacity)
+                .id("term-\(stage)")
+            Spacer(minLength: 0)
+        }
     }
 
-    private var artists: [SpotifyArtist] {
-        Array(artistsForSelectedTerm.prefix(3))
+    private var progressIndicator: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<Self.stages.count, id: \.self) { idx in
+                Capsule()
+                    .fill(idx == (stage % Self.stages.count)
+                          ? Color.xomifyGreen
+                          : Color.white.opacity(0.18))
+                    .frame(width: idx == (stage % Self.stages.count) ? 18 : 6, height: 4)
+                    .animation(.easeInOut(duration: 0.3), value: stage)
+            }
+        }
+        .accessibilityHidden(true)
     }
 
-    private var genres: [(name: String, count: Int)] {
-        Array(genresForSelectedTerm.prefix(3))
+    // MARK: Stage card — cross-fades via .id + transition
+
+    @ViewBuilder
+    private var stageCard: some View {
+        Group {
+            switch currentStage.kind {
+            case .tracks:
+                trackSection(tracks: Array(tracks(for: currentStage.term).prefix(3)))
+            case .artists:
+                artistSection(artists: Array(artists(for: currentStage.term).prefix(3)))
+            case .genres:
+                genreSection(items: Array(genres(for: currentStage.term).prefix(3)).map(\.name))
+            }
+        }
+        .id(stage)
+        .transition(.asymmetric(
+            insertion: .opacity.animation(.easeIn(duration: 0.45)),
+            removal: .opacity.animation(.easeOut(duration: 0.25))
+        ))
     }
 
-    private var tracksForSelectedTerm: [SpotifyTrack] {
-        switch selectedTerm {
+    private var seeAllButton: some View {
+        Button(action: onSeeAll) {
+            HStack(spacing: 6) {
+                Text("See all")
+                    .fontWeight(.semibold)
+                Image(systemName: "arrow.right")
+            }
+            .font(.subheadline)
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                LinearGradient(
+                    colors: [Color.xomifyPurple, Color.xomifyGreen],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .accessibilityHint("Opens the full Music Taste screen")
+    }
+
+    // MARK: Rotation
+
+    private func advance() {
+        withAnimation(.easeInOut(duration: 0.35)) {
+            stage = (stage + 1) % Self.stages.count
+        }
+    }
+
+    private func autoAdvanceLoop() async {
+        while !Task.isCancelled {
+            let delay: UInt64 = reduceMotion ? 8_000_000_000 : 6_000_000_000
+            try? await Task.sleep(nanoseconds: delay)
+            if Task.isCancelled { return }
+            advance()
+        }
+    }
+
+    // MARK: Data slices
+
+    private var allEmpty: Bool {
+        viewModel.shortTermTracks.isEmpty && viewModel.shortTermArtists.isEmpty
+        && viewModel.mediumTermTracks.isEmpty && viewModel.mediumTermArtists.isEmpty
+    }
+
+    private func tracks(for term: TimeRange) -> [SpotifyTrack] {
+        switch term {
         case .shortTerm:  return viewModel.shortTermTracks
         case .mediumTerm: return viewModel.mediumTermTracks
         case .longTerm:   return viewModel.longTermTracks
         }
     }
 
-    private var artistsForSelectedTerm: [SpotifyArtist] {
-        switch selectedTerm {
+    private func artists(for term: TimeRange) -> [SpotifyArtist] {
+        switch term {
         case .shortTerm:  return viewModel.shortTermArtists
         case .mediumTerm: return viewModel.mediumTermArtists
         case .longTerm:   return viewModel.longTermArtists
         }
     }
 
-    private var genresForSelectedTerm: [(name: String, count: Int)] {
-        switch selectedTerm {
+    private func genres(for term: TimeRange) -> [(name: String, count: Int)] {
+        switch term {
         case .shortTerm:  return viewModel.shortTermGenres
         case .mediumTerm: return viewModel.mediumTermGenres
         case .longTerm:   return viewModel.longTermGenres
         }
     }
 
+    // MARK: Stage definition
+
+    private struct Stage {
+        let term: TimeRange
+        let kind: Kind
+
+        enum Kind {
+            case tracks, artists, genres
+        }
+
+        var kindLabel: String {
+            switch kind {
+            case .tracks:  return "Top Tracks"
+            case .artists: return "Top Artists"
+            case .genres:  return "Top Genres"
+            }
+        }
+    }
+
     // MARK: Section
 
     @ViewBuilder
-    private func section(title: String, items: [String]) -> some View {
-        if !items.isEmpty {
+    private func genreSection(items: [String]) -> some View {
+        if items.isEmpty {
+            emptyStageState(symbol: "music.note.list", label: "No genres yet")
+        } else {
             VStack(alignment: .leading, spacing: 10) {
-                sectionHeader(title)
                 ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                     HStack(spacing: 12) {
                         indexLabel(index)
@@ -141,10 +252,11 @@ private struct SelfTasteSummary: View {
     }
 
     @ViewBuilder
-    private func trackSection(title: String, tracks: [SpotifyTrack]) -> some View {
-        if !tracks.isEmpty {
+    private func trackSection(tracks: [SpotifyTrack]) -> some View {
+        if tracks.isEmpty {
+            emptyStageState(symbol: "music.note", label: "No tracks yet")
+        } else {
             VStack(alignment: .leading, spacing: 10) {
-                sectionHeader(title)
                 ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
                     trackRow(track: track, index: index)
                 }
@@ -153,15 +265,28 @@ private struct SelfTasteSummary: View {
     }
 
     @ViewBuilder
-    private func artistSection(title: String, artists: [SpotifyArtist]) -> some View {
-        if !artists.isEmpty {
+    private func artistSection(artists: [SpotifyArtist]) -> some View {
+        if artists.isEmpty {
+            emptyStageState(symbol: "person.2", label: "No artists yet")
+        } else {
             VStack(alignment: .leading, spacing: 10) {
-                sectionHeader(title)
                 ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
                     artistRow(artist: artist, index: index)
                 }
             }
         }
+    }
+
+    private func emptyStageState(symbol: String, label: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 28))
+                .foregroundStyle(.gray.opacity(0.55))
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, minHeight: 140)
     }
 
     private func trackRow(track: SpotifyTrack, index: Int) -> some View {

--- a/Xomify-iOS/Views/Shared/AmbientBackground.swift
+++ b/Xomify-iOS/Views/Shared/AmbientBackground.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// Ambient, low-opacity decorative background. Ports the web app's
+/// `AmbientBackgroundComponent` (wandering blobs + occasional lightning)
+/// to SwiftUI. Intended as a ZStack underlay beneath `MainShell` content.
+///
+/// Designed to be cheap: 4 blurred radial-gradient circles animating between
+/// two waypoints each with long easeInOut cycles; lightning is a jagged path
+/// that flashes briefly every few seconds. Respects Reduce Motion.
+struct AmbientBackground: View {
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.xomifyDark
+                    .ignoresSafeArea()
+
+                ForEach(0..<Blob.seeds.count, id: \.self) { index in
+                    BlobView(
+                        seed: Blob.seeds[index],
+                        bounds: proxy.size,
+                        reduceMotion: reduceMotion
+                    )
+                }
+
+                if !reduceMotion {
+                    LightningLayer(bounds: proxy.size)
+                }
+            }
+            .compositingGroup()
+            .drawingGroup()
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Blob
+
+private struct Blob {
+    let startX: CGFloat
+    let startY: CGFloat
+    let endX: CGFloat
+    let endY: CGFloat
+    let radius: CGFloat
+    let color: Color
+    let period: Double
+
+    /// Six seeded waypoints — spread across a 1:1.5 canvas so coordinates look
+    /// right once scaled into the screen.
+    static let seeds: [Blob] = [
+        .init(startX: 0.15, startY: 0.18, endX: 0.75, endY: 0.32, radius: 180, color: .xomifyPurple, period: 14),
+        .init(startX: 0.80, startY: 0.28, endX: 0.25, endY: 0.62, radius: 220, color: .xomifyGreen,  period: 18),
+        .init(startX: 0.55, startY: 0.68, endX: 0.15, endY: 0.88, radius: 160, color: .xomifyPurple, period: 22),
+        .init(startX: 0.20, startY: 0.85, endX: 0.85, endY: 0.78, radius: 200, color: .xomifyGreen,  period: 16)
+    ]
+}
+
+/// Single wandering blob. Drives position via a bool that flips on a
+/// repeating animation — SwiftUI interpolates the two waypoints smoothly.
+private struct BlobView: View {
+
+    let seed: Blob
+    let bounds: CGSize
+    let reduceMotion: Bool
+
+    @State private var atEnd = false
+
+    var body: some View {
+        let x = seed.startX * bounds.width
+        let y = seed.startY * bounds.height
+        let endX = seed.endX * bounds.width
+        let endY = seed.endY * bounds.height
+
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [seed.color.opacity(0.55), seed.color.opacity(0)],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: seed.radius
+                )
+            )
+            .frame(width: seed.radius * 2, height: seed.radius * 2)
+            .blur(radius: 30)
+            .position(
+                x: reduceMotion ? x : (atEnd ? endX : x),
+                y: reduceMotion ? y : (atEnd ? endY : y)
+            )
+            .opacity(0.45)
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(
+                    .easeInOut(duration: seed.period).repeatForever(autoreverses: true)
+                ) {
+                    atEnd = true
+                }
+            }
+    }
+}
+
+// MARK: - Lightning
+
+/// Flashes a short jagged path every ~2–4 seconds at random. Each strike
+/// fades in over 50ms, holds briefly, then fades out. Not visible with
+/// Reduce Motion on.
+private struct LightningLayer: View {
+
+    let bounds: CGSize
+
+    @State private var bolt: LightningBolt?
+
+    var body: some View {
+        ZStack {
+            if let bolt {
+                bolt.path
+                    .stroke(bolt.color, style: StrokeStyle(lineWidth: 3.5, lineCap: .round))
+                    .blur(radius: 1.5)
+                    .opacity(bolt.opacity)
+                    .id(bolt.id)
+            }
+        }
+        .task(id: bounds.debugDescription) {
+            await runLightningLoop()
+        }
+    }
+
+    private func runLightningLoop() async {
+        while !Task.isCancelled {
+            let wait = UInt64.random(in: 1_500_000_000...4_000_000_000)
+            try? await Task.sleep(nanoseconds: wait)
+            if Task.isCancelled { return }
+            await strike()
+        }
+    }
+
+    private func strike() async {
+        let start = CGPoint(
+            x: CGFloat.random(in: 0.1...0.9) * bounds.width,
+            y: CGFloat.random(in: 0...0.2) * bounds.height
+        )
+        let length = CGFloat.random(in: 220...480)
+        let path = LightningBolt.makePath(from: start, length: length, bounds: bounds)
+        let color: Color = Bool.random() ? .xomifyPurple : .xomifyGreen
+
+        let strike = LightningBolt(id: UUID(), path: path, color: color, opacity: 0)
+        bolt = strike
+
+        withAnimation(.easeIn(duration: 0.05)) {
+            bolt?.opacity = Double.random(in: 0.55...0.9)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        withAnimation(.easeOut(duration: 0.25)) {
+            bolt?.opacity = 0
+        }
+        try? await Task.sleep(nanoseconds: 260_000_000)
+        if bolt?.id == strike.id {
+            bolt = nil
+        }
+    }
+}
+
+private struct LightningBolt: Identifiable {
+    let id: UUID
+    let path: Path
+    let color: Color
+    var opacity: Double
+
+    static func makePath(from start: CGPoint, length: CGFloat, bounds: CGSize) -> Path {
+        var path = Path()
+        let segments = Int.random(in: 6...12)
+        let segLength = length / CGFloat(segments)
+        var x = start.x
+        var y = start.y
+        path.move(to: CGPoint(x: x, y: y))
+        for _ in 0..<segments {
+            x += CGFloat.random(in: -segLength...segLength) * 0.7
+            y += segLength * CGFloat.random(in: 0.6...1.0)
+            x = max(20, min(bounds.width - 20, x))
+            y = min(bounds.height, y)
+            path.addLine(to: CGPoint(x: x, y: y))
+        }
+        return path
+    }
+}
+
+#Preview {
+    AmbientBackground()
+}

--- a/Xomify-iOS/Views/Shared/XomifyLoaderPaint.swift
+++ b/Xomify-iOS/Views/Shared/XomifyLoaderPaint.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Xomify paint-style loader. Ports `XomperLoaderPaint` from the Xomper iOS
+/// app — draws the two X-stroke legs in sequence, fades out, and loops.
+/// Use for app-splash / long loads. The `Pulse` and `Spin` variants are for
+/// medium and quick loads respectively.
+struct XomifyLoaderPaint: View {
+    var size: CGFloat = 60
+
+    @State private var stroke1: CGFloat = 0
+    @State private var stroke2: CGFloat = 0
+    @State private var opacity: Double = 1
+
+    var body: some View {
+        Image("logo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .mask {
+                ZStack {
+                    XStroke(topLeft: true)
+                        .trim(from: 0, to: stroke1)
+                        .stroke(style: StrokeStyle(lineWidth: size * 0.35, lineCap: .round))
+                    XStroke(topLeft: false)
+                        .trim(from: 0, to: stroke2)
+                        .stroke(style: StrokeStyle(lineWidth: size * 0.35, lineCap: .round))
+                }
+            }
+            .opacity(opacity)
+            .onAppear { animate() }
+            .accessibilityLabel("Loading")
+    }
+
+    private func animate() {
+        stroke1 = 0; stroke2 = 0; opacity = 1
+        withAnimation(.easeOut(duration: 0.5)) { stroke1 = 1 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            withAnimation(.easeOut(duration: 0.5)) { stroke2 = 1 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) {
+            withAnimation(.easeIn(duration: 0.4)) { opacity = 0 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { animate() }
+    }
+}
+
+/// Medium-load loader — soft breathing pulse.
+struct XomifyLoaderPulse: View {
+    var size: CGFloat = 40
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        Image("logo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .scaleEffect(isPulsing ? 1.15 : 0.85)
+            .opacity(isPulsing ? 1 : 0.5)
+            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isPulsing)
+            .onAppear { isPulsing = true }
+            .accessibilityLabel("Loading")
+    }
+}
+
+/// Quick-load loader — steady rotation.
+struct XomifyLoaderSpin: View {
+    var size: CGFloat = 36
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        Image("logo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .rotationEffect(.degrees(rotation))
+            .animation(.linear(duration: 1.2).repeatForever(autoreverses: false), value: rotation)
+            .onAppear { rotation = 360 }
+            .accessibilityLabel("Loading")
+    }
+}
+
+// MARK: - XStroke
+
+/// One leg of the X-mark, drawn as a shallow quadratic curve. The two legs
+/// crossed (topLeft + !topLeft) produce the complete X.
+private struct XStroke: Shape {
+    let topLeft: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let inset = rect.width * 0.1
+        if topLeft {
+            path.move(to: CGPoint(x: inset, y: inset))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.width - inset, y: rect.height - inset),
+                control: CGPoint(x: rect.midX + rect.width * 0.05, y: rect.midY - rect.height * 0.05)
+            )
+        } else {
+            path.move(to: CGPoint(x: rect.width - inset, y: inset))
+            path.addQuadCurve(
+                to: CGPoint(x: inset, y: rect.height - inset),
+                control: CGPoint(x: rect.midX - rect.width * 0.05, y: rect.midY - rect.height * 0.05)
+            )
+        }
+        return path
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.xomifyDark.ignoresSafeArea()
+        HStack(spacing: 32) {
+            XomifyLoaderPaint(size: 72)
+            XomifyLoaderPulse(size: 56)
+            XomifyLoaderSpin(size: 48)
+        }
+    }
+}

--- a/Xomify-iOS/Views/Shell/HeaderBar.swift
+++ b/Xomify-iOS/Views/Shell/HeaderBar.swift
@@ -1,14 +1,18 @@
 import SwiftUI
+import UserNotifications
 
-/// Persistent top header bar: avatar (opens drawer) — wordmark — optional trailing slot.
+/// Persistent top header bar: avatar (opens drawer) — wordmark — bell (opens inbox).
 struct HeaderBar: View {
     @Environment(NavigationStore.self) private var navStore
 
-    /// Optional trailing toolbar content — reserved for future search icon (v2+).
+    /// Optional trailing toolbar override. When `nil`, renders the bell button.
     var trailingContent: AnyView? = nil
 
     /// Avatar image URL pulled from the caller (may be nil — shows SF symbol placeholder).
     var avatarURL: URL? = nil
+
+    @State private var isInboxPresented = false
+    @State private var unreadCount: Int = 0
 
     var body: some View {
         ZStack {
@@ -35,20 +39,56 @@ struct HeaderBar: View {
 
                 Spacer()
 
-                // Trailing slot — empty for v1, drop-in for search icon later.
+                // Trailing slot — custom content overrides the bell when caller sets it.
                 if let trailing = trailingContent {
                     trailing
                         .frame(width: 44, height: 44)
                 } else {
-                    // Keep layout symmetric — invisible placeholder.
-                    Color.clear
-                        .frame(width: 44, height: 44)
+                    bellButton
                 }
             }
         }
         .padding(.horizontal, 8)
         .frame(height: 44)
         .background(Color.xomifyDark)
+        .sheet(isPresented: $isInboxPresented, onDismiss: { Task { await refreshUnread() } }) {
+            NotificationsInboxView()
+        }
+        .task { await refreshUnread() }
+    }
+
+    // MARK: - Bell
+
+    private var bellButton: some View {
+        Button {
+            isInboxPresented = true
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "bell.fill")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 36, height: 36)
+                    .background(Color.white.opacity(0.06), in: Circle())
+
+                if unreadCount > 0 {
+                    Text(unreadCount > 9 ? "9+" : "\(unreadCount)")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.xomifyPurple, in: Capsule())
+                        .offset(x: 4, y: -2)
+                }
+            }
+            .frame(width: 44, height: 44)
+        }
+        .accessibilityLabel("Notifications")
+        .accessibilityValue(unreadCount > 0 ? "\(unreadCount) unread" : "No unread")
+    }
+
+    private func refreshUnread() async {
+        let delivered = await UNUserNotificationCenter.current().deliveredNotifications()
+        unreadCount = delivered.count
     }
 
     // MARK: - Avatar

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -19,6 +19,11 @@ struct MainShell: View {
 
     var body: some View {
         ZStack(alignment: .leading) {
+            // Ambient brand background — wandering blurred blobs + occasional
+            // lightning. Purely decorative; hit-testing disabled.
+            AmbientBackground()
+                .opacity(0.35)
+
             // Primary content: header bar + full-screen destination.
             VStack(spacing: 0) {
                 HeaderBar(avatarURL: avatarURL)

--- a/Xomify-iOS/Views/Shell/NotificationsInboxView.swift
+++ b/Xomify-iOS/Views/Shell/NotificationsInboxView.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import UIKit
+import UserNotifications
+
+/// In-app notifications inbox. For v1, there is no backend feed — this
+/// sheet renders the delivered push history that iOS already maintains via
+/// `UNUserNotificationCenter.getDeliveredNotifications`, so it's useful
+/// immediately without new endpoints. Empty state points the user at
+/// Settings → Notifications when permission is denied.
+struct NotificationsInboxView: View {
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var items: [InboxItem] = []
+    @State private var authStatus: UNAuthorizationStatus = .notDetermined
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+
+                if isLoading {
+                    XomifyLoaderPulse(size: 52)
+                } else if authStatus == .denied {
+                    deniedState
+                } else if items.isEmpty {
+                    emptyState
+                } else {
+                    list
+                }
+            }
+            .navigationTitle("Notifications")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+                if !items.isEmpty {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Clear", role: .destructive) {
+                            clearAll()
+                        }
+                        .foregroundStyle(.red)
+                    }
+                }
+            }
+            .toolbarBackground(Color.xomifyDark, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .task { await load() }
+        }
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 10) {
+                ForEach(items) { item in
+                    row(item)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+        }
+    }
+
+    private func row(_ item: InboxItem) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.icon)
+                .foregroundStyle(Color.xomifyGreen)
+                .font(.title3)
+                .frame(width: 32, height: 32)
+                .background(Color.xomifyGreen.opacity(0.12), in: Circle())
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.subheadline).fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                if let body = item.body, !body.isEmpty {
+                    Text(body)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.75))
+                        .lineLimit(3)
+                }
+                Text(item.relativeDate)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    // MARK: - States
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "bell.slash")
+                .font(.system(size: 44))
+                .foregroundStyle(.gray.opacity(0.6))
+                .accessibilityHidden(true)
+            Text("No notifications yet")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Queue reactions and weekly digests will show up here.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+    }
+
+    private var deniedState: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "bell.badge.slash")
+                .font(.system(size: 44))
+                .foregroundStyle(.orange.opacity(0.8))
+                .accessibilityHidden(true)
+            Text("Notifications are off")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Turn them on in System Settings to see queue reactions and weekly digests.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button {
+                openSystemSettings()
+            } label: {
+                Text("Open Settings")
+                    .font(.subheadline).fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(LinearGradient.xomifyGradient)
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
+    // MARK: - Data
+
+    private func load() async {
+        authStatus = await NotificationsService.shared.currentAuthorizationStatus()
+        let delivered = await UNUserNotificationCenter.current().deliveredNotifications()
+        items = delivered
+            .map(InboxItem.init(notification:))
+            .sorted { $0.date > $1.date }
+        isLoading = false
+    }
+
+    private func clearAll() {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        items = []
+    }
+
+    private func openSystemSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+// MARK: - InboxItem
+
+private struct InboxItem: Identifiable {
+    let id: String
+    let title: String
+    let body: String?
+    let date: Date
+    let icon: String
+
+    init(notification: UNNotification) {
+        let content = notification.request.content
+        self.id = notification.request.identifier
+        self.title = content.title.isEmpty ? "Xomify" : content.title
+        self.body = content.body.isEmpty ? nil : content.body
+        self.date = notification.date
+        let payload = PushPayload(userInfo: content.userInfo)
+        switch payload.kind {
+        case .queueThreshold: self.icon = "music.note.list"
+        case .digest:         self.icon = "calendar.badge.clock"
+        case .unknown:        self.icon = "bell.fill"
+        }
+    }
+
+    var relativeDate: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: .now)
+    }
+}
+
+#Preview {
+    NotificationsInboxView()
+}


### PR DESCRIPTION
## Summary
- **XomifyLoaderPaint + Pulse + Spin** — ports the Xomper paint/pulse/spin loaders, uses the existing `logo` asset. Paint variant used for the notifications inbox skeleton; Pulse wired into the Taste tab initial load.
- **AmbientBackground** — SwiftUI port of the web ambient feature: 4 wandering blurred brand-color blobs (purple/green) plus occasional lightning flashes (jagged path, 50ms fade-in, 250ms fade-out). Respects Reduce Motion, hit-testing disabled, drawn at 35% opacity behind MainShell.
- **Auto-rotating Taste carousel** — Replaces the segmented Picker on ProfileTasteTab with a 9-stage carousel that cross-fades through **top 3 tracks → artists → genres** for **1 month → 6 months → 1 year**, looping. Tap the card to advance manually; progress pips at the bottom.
- **Bell icon + Notifications inbox** — `HeaderBar` trailing slot now renders a bell with an unread badge. Tapping opens `NotificationsInboxView`, a sheet backed by iOS's delivered-notification store (no new backend endpoint needed). Denied-permission state includes an Open Settings CTA; Clear clears the delivered tray.

## Notes
- No new backend endpoints were added. The inbox uses `UNUserNotificationCenter.deliveredNotifications()` so queue-reaction and digest pushes that landed while the app was backgrounded show up on first open.
- Ambient background is lightweight — 4 blurred circles + an occasional path. No GSAP / Canvas / Metal.

## Test plan
- [ ] App cold-start shows banner; any destination has the ambient drift behind it
- [ ] Reduce Motion disables blob drift and lightning
- [ ] Taste tab auto-advances through 9 stages across (tracks/artists/genres) × (1mo/6mo/1yr); tap advances immediately; pip highlights current stage
- [ ] Bell icon shows unread badge when delivered pushes exist
- [ ] Bell opens sheet with queue-reaction / digest entries; Clear empties the tray
- [ ] Denied-permission path shows "Notifications are off" with working Settings link