### PR TITLE
fix(groups): tolerate partial /groups/list payloads

### DIFF
--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -541,16 +541,40 @@ struct SearchResult: Codable, Sendable, Identifiable, Hashable {
 // MARK: - Groups
 
 /// A group you belong to.
+///
+/// The backend's `/groups/list` endpoint used to return only membership
+/// rows (no `name`/`createdBy`), which crashed decoding. Backend now
+/// hydrates from the Groups table, but we keep most fields optional so a
+/// partial payload from any source degrades to a usable row rather than
+/// failing the whole list. `groupId` is always required — without it the
+/// row is meaningless.
 struct XomifyGroup: Codable, Sendable, Identifiable, Hashable {
     let groupId: String
-    let name: String
+    let name: String?
     let description: String?
     let ownerEmail: String?
+    let createdBy: String?
     let createdAt: String?
     let memberCount: Int?
     let trackCount: Int?
+    let imageUrl: String?
+    let role: String?
+    let joinedAt: String?
 
     var id: String { groupId }
+
+    /// Display-safe name — falls back to a short id suffix when the backend
+    /// returns a headless row so the UI never renders an empty label.
+    var displayName: String {
+        if let name, !name.isEmpty { return name }
+        let suffix = groupId.suffix(6)
+        return "Group \(suffix)"
+    }
+
+    /// Prefer `createdBy` (new hydrated shape) over `ownerEmail` (legacy).
+    var ownerLabel: String? {
+        createdBy ?? ownerEmail
+    }
 }
 
 /// Response for GET /groups/list

--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -31,7 +31,7 @@ enum FeedFilter: Hashable, Sendable {
         switch self {
         case .all:              return "All"
         case .friends:          return "Friends only"
-        case .group(let group): return group.name
+        case .group(let group): return group.displayName
         }
     }
 }

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -14,7 +14,7 @@ enum ComposerAudience: Hashable, Sendable {
         switch self {
         case .all:               return "Everyone"
         case .friendsOnly:       return "Friends only"
-        case .group(let group):  return group.name
+        case .group(let group):  return group.displayName
         }
     }
 

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -21,7 +21,7 @@ struct GroupDetailView: View {
     }
 
     private var isOwner: Bool {
-        viewModel.group?.ownerEmail == viewerEmail
+        (viewModel.group?.ownerLabel) == viewerEmail
     }
 
     var body: some View {

--- a/Xomify-iOS/Views/GroupsView.swift
+++ b/Xomify-iOS/Views/GroupsView.swift
@@ -124,7 +124,7 @@ struct GroupsView: View {
     }
 
     private func groupRow(_ group: XomifyGroup) -> some View {
-        let isOwner = group.ownerEmail == viewModel.userEmail
+        let isOwner = (group.ownerLabel ?? "") == viewModel.userEmail
         let memberCount = group.memberCount ?? 0
         let trackCount = group.trackCount ?? 0
 
@@ -139,7 +139,7 @@ struct GroupsView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(group.name)
+                    Text(group.displayName)
                         .font(.subheadline)
                         .fontWeight(.semibold)
                         .foregroundStyle(.white)
@@ -194,7 +194,7 @@ struct GroupsView: View {
         memberCount: Int,
         trackCount: Int
     ) -> String {
-        var parts: [String] = [group.name]
+        var parts: [String] = [group.displayName]
         if isOwner { parts.append("owner") }
         parts.append("\(memberCount) member\(memberCount == 1 ? "" : "s")")
         parts.append("\(trackCount) track\(trackCount == 1 ? "" : "s")")


### PR DESCRIPTION
## Summary
Defense-in-depth for the groups decode crash — paired with backend PR https://github.com/Xomware/xomify-backend/pull/134 which fixes the root cause (hydrating memberships with full GROUPS rows).

## Changes
- `XomifyGroup`: `name`, `description`, `ownerEmail`, `createdBy`, `createdAt`, `memberCount`, `trackCount`, `imageUrl` are now `Optional`
- Added `displayName` (falls back to \"Group <last-6-of-id>\") and `ownerLabel` (createdBy ?? ownerEmail) computed properties
- Call sites updated: `GroupsView`, `GroupDetailView`, `FeedViewModel`, `ShareComposerViewModel`

## Why ship both
Even after backend is deployed, a future schema drift or partial backfill shouldn't crash the Groups tab. Accepting the raw shape means we degrade gracefully instead of serving a decode error banner.

## Test plan
- [x] `xcodebuild build` — SUCCEEDED
- [ ] Post-merge: verify Groups tab renders real names (backend merged) and would still render if any field went missing