### PR TITLE
ci: auto-create missing TestFlight Beta groups

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -266,10 +266,34 @@ jobs:
               )
               r.raise_for_status()
               data = r.json()["data"]
-              if not data:
-                  print(f"!! Beta group {name!r} not found — skipping. Create it in App Store Connect.")
-                  continue
-              group = data[0]
+              if data:
+                  group = data[0]
+              else:
+                  # Auto-create external beta group if missing. Testers still need
+                  # to be added in ASC UI; this just unblocks build assignment.
+                  print(f"Beta group {name!r} not found — creating as external group")
+                  cr = requests.post(
+                      f"{base}/betaGroups",
+                      headers={**headers, "Content-Type": "application/json"},
+                      json={
+                          "data": {
+                              "type": "betaGroups",
+                              "attributes": {
+                                  "name": name,
+                                  "publicLinkEnabled": False,
+                                  "publicLinkLimitEnabled": False,
+                              },
+                              "relationships": {
+                                  "app": {"data": {"type": "apps", "id": app_id}},
+                              },
+                          }
+                      },
+                  )
+                  if cr.status_code >= 400:
+                      print(f"!! Failed to create group {name!r}: {cr.status_code} {cr.text}", file=sys.stderr)
+                      continue
+                  group = cr.json()["data"]
+                  print(f"Created group {name!r} ({group['id']}) — add testers in App Store Connect")
               group_id = group["id"]
               if group["attributes"].get("isInternalGroup"):
                   print(f"Group {name!r} is internal — auto-receives all builds, skipping manual assignment")


### PR DESCRIPTION
## Summary
Makes the TestFlight deploy self-heal when a named beta group is missing. Previously the assign step logged \`!! Beta group 'Beta Friends' not found — skipping. Create it in App Store Connect.\` and moved on — meaning external testers silently got no builds.

Now the workflow creates it via \`POST /v1/betaGroups\` (external, no public link) and then attaches the build. Testers still need to be added in ASC UI; this just unblocks the automated assignment so the group + build linkage stops rotting.

Mirrors the \`Beta,Beta Friends\` configuration already running for XomFit.

## Why self-heal instead of a one-time UI step
- Keeps the workflow the source of truth for group names
- Future apps using the same template get the group created on first deploy
- The last Xomify deploy (run 24871944506) silently skipped Beta Friends — this would have caught it

## Test plan
- [ ] Next push to master triggers a build that creates the group (or no-ops if it already exists) and attaches the build
- [ ] Add testers to \`Beta Friends\` in ASC UI after group appears