### PR TITLE
feat(queue): universal Add-to-Queue button + fix silent failures

### DIFF
--- a/Xomify-iOS/Services/QueueActionController.swift
+++ b/Xomify-iOS/Services/QueueActionController.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Shared controller that powers every "Add to Spotify queue" button in the app.
+///
+/// Why this exists:
+/// - The taste stage + other track rows were calling `SpotifyService.queueTrack`
+///   with `try?`, swallowing every error silently. Users tapped the button and
+///   saw nothing happen (especially when no device was active).
+/// - Each track row would otherwise have to reimplement the same in-flight +
+///   error-surfacing dance.
+///
+/// Errors are routed to a single `toast` string that `QueueToastHost` renders
+/// at `MainShell`. Per-URI `isQueuing(uri:)` lets buttons show a spinner +
+/// disable themselves while a queue attempt is in flight.
+@Observable
+@MainActor
+final class QueueActionController {
+
+    static let shared = QueueActionController()
+
+    /// The most recent user-visible message from a queue attempt. Nil when no
+    /// toast should be shown. `QueueToastHost` auto-clears this after a delay.
+    var toast: String?
+
+    /// URIs currently mid-flight. Used so double-taps of the same button no-op
+    /// and so the button can show a spinner without each call site tracking it.
+    private var inFlight: Set<String> = []
+
+    private let spotifyService: SpotifyQueueing
+
+    init(spotifyService: SpotifyQueueing = SpotifyService.shared) {
+        self.spotifyService = spotifyService
+    }
+
+    func isQueuing(uri: String) -> Bool {
+        inFlight.contains(uri)
+    }
+
+    /// Queue a track. Shows a success toast on 2xx, an actionable error
+    /// message on failure. Safe to call while another queue is in flight for
+    /// a different URI.
+    func queue(uri: String, trackName: String? = nil) async {
+        guard !uri.isEmpty else {
+            toast = "Couldn't queue — missing track URI."
+            return
+        }
+        guard !inFlight.contains(uri) else { return }
+
+        inFlight.insert(uri)
+        defer { inFlight.remove(uri) }
+
+        do {
+            try await spotifyService.queueTrack(uri: uri)
+            if let name = trackName, !name.isEmpty {
+                toast = "Queued \(name)"
+            } else {
+                toast = "Queued on Spotify"
+            }
+        } catch let error as SpotifyServiceError {
+            toast = error.errorDescription
+        } catch {
+            toast = error.localizedDescription
+        }
+    }
+}

--- a/Xomify-iOS/Views/AlbumView.swift
+++ b/Xomify-iOS/Views/AlbumView.swift
@@ -244,9 +244,14 @@ struct AlbumView: View {
                 .font(.caption)
                 .foregroundColor(.gray)
             
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
+
             // Add to playlist builder
             AddToPlaylistButton(track: track)
-            
+
             // Play button
             Button {
                 playTrack(track)

--- a/Xomify-iOS/Views/ArtistView.swift
+++ b/Xomify-iOS/Views/ArtistView.swift
@@ -336,10 +336,15 @@ struct ArtistView: View {
             }
             
             Spacer()
-            
+
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
+
             // Add to playlist builder
             AddToPlaylistButton(track: track)
-            
+
             // Play button
             Button {
                 playTrack(track)

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -254,6 +254,10 @@ struct GroupDetailView: View {
 
             Spacer()
 
+            if let tid = track.trackId, !tid.isEmpty {
+                QueueButton(uri: "spotify:track:\(tid)", trackName: track.trackName)
+            }
+
             Button(role: .destructive) {
                 Task { await viewModel.removeSong(track) }
             } label: {

--- a/Xomify-iOS/Views/MoodPicksView.swift
+++ b/Xomify-iOS/Views/MoodPicksView.swift
@@ -134,6 +134,11 @@ struct MoodPicksView: View {
 
             Spacer()
 
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
+
             if let urlString = track.externalUrls?["spotify"], let url = URL(string: urlString) {
                 Link(destination: url) {
                     Image(systemName: "play.circle.fill")

--- a/Xomify-iOS/Views/PlaylistBuilderView.swift
+++ b/Xomify-iOS/Views/PlaylistBuilderView.swift
@@ -204,11 +204,16 @@ struct PlaylistBuilderView: View {
             }
             
             Spacer()
-            
+
             // Duration
             Text(track.duration)
                 .font(.caption)
                 .foregroundColor(.gray)
+
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
         }
     }
     

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
@@ -79,12 +79,14 @@ struct ProfileRatingsTab: View {
 
             Spacer()
 
+            if !rating.trackId.isEmpty {
+                QueueButton(
+                    uri: "spotify:track:\(rating.trackId)",
+                    trackName: rating.trackName
+                )
+            }
+
             Menu {
-                Button {
-                    Task { await queue(rating: rating) }
-                } label: {
-                    Label("Add to Spotify queue", systemImage: "text.badge.plus")
-                }
                 Button {
                     openInSpotify(trackId: rating.trackId)
                 } label: {
@@ -105,7 +107,7 @@ struct ProfileRatingsTab: View {
                     .frame(width: 32, height: 32)
                     .background(Color.white.opacity(0.08), in: Circle())
             }
-            .accessibilityLabel("Actions for \(rating.trackName ?? "track")")
+            .accessibilityLabel("More actions for \(rating.trackName ?? "track")")
         }
         .padding(12)
         .background(Color.xomifyCard)
@@ -148,15 +150,6 @@ struct ProfileRatingsTab: View {
     private func openInSpotify(trackId: String) {
         guard !trackId.isEmpty, let url = URL(string: "spotify:track:\(trackId)") else { return }
         UIApplication.shared.open(url)
-    }
-
-    private func queue(rating: TrackRating) async {
-        guard !rating.trackId.isEmpty else { return }
-        do {
-            try await SpotifyService.shared.queueTrack(uri: "spotify:track:\(rating.trackId)")
-        } catch {
-            print("ProfileRatingsTab: queue failed — \(error)")
-        }
     }
 
     // MARK: - States

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -304,6 +304,7 @@ private struct SelfTasteSummary: View {
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
+            QueueButton(uri: track.uri ?? "spotify:track:\(track.id)", trackName: track.name)
             trackActions(trackId: track.id, uri: track.uri ?? "spotify:track:\(track.id)")
         }
         .padding(.vertical, 8)
@@ -342,11 +343,6 @@ private struct SelfTasteSummary: View {
 
     private func trackActions(trackId: String, uri: String) -> some View {
         Menu {
-            Button {
-                Task { try? await SpotifyService.shared.queueTrack(uri: uri) }
-            } label: {
-                Label("Add to Spotify queue", systemImage: "text.badge.plus")
-            }
             Button {
                 openURL(uri)
             } label: {

--- a/Xomify-iOS/Views/Shared/QueueButton.swift
+++ b/Xomify-iOS/Views/Shared/QueueButton.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Reusable "Add to Spotify queue" button used by every track row in the app.
+/// Routes to `QueueActionController.shared` so success + error state lands in
+/// one place (the root `QueueToastHost`).
+///
+/// Two variants:
+/// - `.icon`   — compact circle button for dense rows
+/// - `.pill`   — labelled pill for card UIs (feed, shares)
+struct QueueButton: View {
+
+    enum Style {
+        case icon
+        case pill
+    }
+
+    let uri: String
+    let trackName: String?
+    var style: Style = .icon
+
+    @State private var queueAction = QueueActionController.shared
+
+    var body: some View {
+        Button {
+            Task { await queueAction.queue(uri: uri, trackName: trackName) }
+        } label: {
+            switch style {
+            case .icon:
+                iconLabel
+            case .pill:
+                pillLabel
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(uri.isEmpty || queueAction.isQueuing(uri: uri))
+        .accessibilityLabel("Add \(trackName ?? "track") to Spotify queue")
+    }
+
+    private var iconLabel: some View {
+        ZStack {
+            Circle()
+                .fill(Color.white.opacity(0.08))
+                .frame(width: 32, height: 32)
+            if queueAction.isQueuing(uri: uri) {
+                ProgressView().tint(.white.opacity(0.8)).controlSize(.small)
+            } else {
+                Image(systemName: "text.badge.plus")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.85))
+            }
+        }
+        .frame(minWidth: 44, minHeight: 44)
+    }
+
+    private var pillLabel: some View {
+        HStack(spacing: 6) {
+            if queueAction.isQueuing(uri: uri) {
+                ProgressView().tint(.white).controlSize(.small)
+            } else {
+                Image(systemName: "text.badge.plus")
+            }
+            Text(queueAction.isQueuing(uri: uri) ? "Queueing…" : "Queue")
+        }
+        .font(.caption)
+        .fontWeight(.medium)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.08))
+        .foregroundStyle(.white)
+        .clipShape(.rect(cornerRadius: 16))
+        .frame(minHeight: 44)
+    }
+}

--- a/Xomify-iOS/Views/Shared/QueueToastHost.swift
+++ b/Xomify-iOS/Views/Shared/QueueToastHost.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// App-root overlay that renders toasts emitted by `QueueActionController`.
+/// Mount once on `MainShell` — any `QueueButton` anywhere in the tree will
+/// surface its success/failure message here.
+struct QueueToastHost: View {
+
+    @State private var queueAction = QueueActionController.shared
+    @State private var clearTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack {
+            if let message = queueAction.toast {
+                HStack(spacing: 10) {
+                    Image(systemName: "text.badge.plus")
+                        .font(.footnote.weight(.semibold))
+                    Text(message)
+                        .font(.footnote)
+                        .fontWeight(.medium)
+                        .lineLimit(2)
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.black.opacity(0.85))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                )
+                .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 4)
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .accessibilityAddTraits(.isStaticText)
+            }
+            Spacer()
+        }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: queueAction.toast)
+        .allowsHitTesting(false)
+        .onChange(of: queueAction.toast) { _, newValue in
+            clearTask?.cancel()
+            guard newValue != nil else { return }
+            clearTask = Task {
+                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                if !Task.isCancelled {
+                    queueAction.toast = nil
+                }
+            }
+        }
+    }
+}

--- a/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
@@ -5,7 +5,6 @@ import UIKit
 /// Tapping a row opens the track in Spotify. Swipe-to-delete removes a rating.
 struct RatingsHistoryView: View {
     @State private var viewModel = RatingsHistoryViewModel()
-    @State private var queueErrorMessage: String?
     @State private var query: String = ""
 
     var body: some View {
@@ -43,15 +42,6 @@ struct RatingsHistoryView: View {
             }
         }
         .refreshable { await viewModel.load() }
-        .overlay(alignment: .bottom) {
-            if let message = queueErrorMessage {
-                queueBanner(message)
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 24)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-        }
-        .animation(.easeInOut, value: queueErrorMessage)
     }
 
     // MARK: - Filtered ratings
@@ -121,18 +111,32 @@ struct RatingsHistoryView: View {
 
                         VStack(spacing: 10) {
                             ForEach(group.ratings) { rating in
-                                Button {
-                                    openInSpotify(trackId: rating.trackId)
-                                } label: {
-                                    RatingCard(
-                                        rating: rating,
-                                        artwork: viewModel.artworkByTrackId[rating.trackId]
-                                    )
+                                HStack(spacing: 10) {
+                                    Button {
+                                        openInSpotify(trackId: rating.trackId)
+                                    } label: {
+                                        RatingCard(
+                                            rating: rating,
+                                            artwork: viewModel.artworkByTrackId[rating.trackId]
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+
+                                    if !rating.trackId.isEmpty {
+                                        QueueButton(
+                                            uri: "spotify:track:\(rating.trackId)",
+                                            trackName: rating.trackName
+                                        )
+                                    }
                                 }
-                                .buttonStyle(.plain)
                                 .contextMenu {
                                     Button {
-                                        queue(rating: rating)
+                                        Task {
+                                            await QueueActionController.shared.queue(
+                                                uri: "spotify:track:\(rating.trackId)",
+                                                trackName: rating.trackName
+                                            )
+                                        }
                                     } label: {
                                         Label("Add to Spotify queue", systemImage: "text.badge.plus")
                                     }
@@ -259,51 +263,6 @@ struct RatingsHistoryView: View {
         }
     }
 
-    private func queue(rating: TrackRating) {
-        guard !rating.trackId.isEmpty else { return }
-        let uri = "spotify:track:\(rating.trackId)"
-        Task {
-            do {
-                try await SpotifyService.shared.queueTrack(uri: uri)
-                withAnimation { queueErrorMessage = "Queued on Spotify" }
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                withAnimation { queueErrorMessage = nil }
-            } catch {
-                withAnimation { queueErrorMessage = queueFailureMessage(from: error) }
-                try? await Task.sleep(nanoseconds: 3_500_000_000)
-                withAnimation { queueErrorMessage = nil }
-            }
-        }
-    }
-
-    private func queueFailureMessage(from error: Error) -> String {
-        if case SpotifyServiceError.premiumRequired = error {
-            return "Spotify Premium is required to queue tracks."
-        }
-        if case SpotifyServiceError.noActiveDevice = error {
-            return "Open Spotify on a device first, then try again."
-        }
-        return "Could not add to queue."
-    }
-
-    private func queueBanner(_ message: String) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: message.hasPrefix("Queued") ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .foregroundStyle(message.hasPrefix("Queued") ? Color.xomifyGreen : .orange)
-            Text(message)
-                .font(.xomifyFootnote.weight(.semibold))
-                .foregroundStyle(.white)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(Color.xomifyCard)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.white.opacity(0.1), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
 }
 
 // MARK: - Card

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -45,6 +45,9 @@ struct MainShell: View {
                 email: userEmail
             )
             .environment(navStore)
+
+            // App-root toast for Queue actions. Floats above everything.
+            QueueToastHost()
         }
         .environment(navStore)
         .ignoresSafeArea(edges: .bottom)

--- a/Xomify-iOS/Views/TopItemsView.swift
+++ b/Xomify-iOS/Views/TopItemsView.swift
@@ -347,6 +347,12 @@ struct TopItemsContent: View {
 
             Spacer()
 
+            // Add to Spotify queue
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
+
             // Add to playlist builder
             AddToPlaylistButton(track: track)
 

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -340,7 +340,12 @@ struct WrappedContent: View {
 
             Spacer()
 
-            // Add button
+            QueueButton(
+                uri: track.uri ?? "spotify:track:\(track.id)",
+                trackName: track.name
+            )
+
+            // Add to playlist builder
             Button {
                 if playlistBuilder.contains(track) {
                     playlistBuilder.removeTrack(track)


### PR DESCRIPTION
## Summary
Fixes the broken Add-to-Queue on the Taste stage and gives every track row in the app a working queue button + visible feedback toast.

## Root cause of the \"nothing happens\" bug
\`ProfileTasteTab\` called \`Task { try? await SpotifyService.shared.queueTrack(uri:) }\`. The \`try?\` swallowed every error, including the common \`.noActiveDevice\` (Spotify not playing anywhere) and \`.premiumRequired\`. Users tapped, nothing visible happened, looked broken.

## New infra
- **\`QueueActionController\`** — \`@MainActor @Observable\` singleton
  - Per-URI in-flight set so double-taps no-op
  - Maps \`SpotifyServiceError\` cases to human messages
  - Publishes \`toast: String?\` consumed at \`MainShell\`
- **\`QueueButton\`** — reusable (.icon / .pill) view with loading spinner + disabled state
- **\`QueueToastHost\`** — mounted once on \`MainShell\`, shows transient pill for ~2.5s

## Coverage
Queue button now appears on every list that shows a track:
- Profile: Taste, Ratings tabs
- Ratings History (visible icon next to each card + still in context menu)
- Feed share cards (already had via \`ShareCardViewModel\`)
- Groups detail track rows
- Top Items (tracks tab)
- Wrapped track rows
- Album + Artist track rows
- Mood Picks
- Playlist Builder

Deliberately skipped: composer search results (tap-to-select is the primary action there — adding a queue tap conflicts).

## Test plan
- [x] \`xcodebuild build\` — SUCCEEDED
- [ ] Queue from Taste stage with no device open → toast "Open Spotify on a device and play something first"
- [ ] Queue from any row with device active → toast "Queued <track name>"
- [ ] Double-tap a queue button mid-flight → second tap is a no-op (button is disabled)