### PR TITLE
feat(ui): replace ProgressView with Xomify branded loaders

### DIFF
--- a/Xomify-iOS/Views/AlbumView.swift
+++ b/Xomify-iOS/Views/AlbumView.swift
@@ -15,7 +15,7 @@ struct AlbumView: View {
         ZStack {
             ScrollView {
                 if isLoading {
-                    ProgressView()
+                    XomifyLoaderPulse()
                         .padding(.top, 100)
                 } else if let error = errorMessage {
                     errorState(error)

--- a/Xomify-iOS/Views/ArtistView.swift
+++ b/Xomify-iOS/Views/ArtistView.swift
@@ -20,7 +20,7 @@ struct ArtistView: View {
         ZStack {
             ScrollView {
                 if isLoading {
-                    ProgressView()
+                    XomifyLoaderPulse()
                         .padding(.top, 100)
                 } else if let error = errorMessage {
                     errorState(error)

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -85,8 +85,7 @@ struct FeedView: View {
                 }
 
                 if viewModel.isLoading && !viewModel.shares.isEmpty {
-                    ProgressView()
-                        .tint(Color.xomifyGreen)
+                    XomifyLoaderSpin()
                         .padding(.vertical, 16)
                 }
 
@@ -98,8 +97,7 @@ struct FeedView: View {
 
     private var loadingState: some View {
         VStack(spacing: 12) {
-            ProgressView()
-                .tint(Color.xomifyGreen)
+            XomifyLoaderPulse()
             Text("Loading feed...")
                 .font(.caption)
                 .foregroundStyle(.gray)

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -152,7 +152,7 @@ struct GroupDetailView: View {
             addSongBar
 
             if viewModel.isLoading && viewModel.tracks.isEmpty {
-                ProgressView().tint(.xomifyGreen)
+                XomifyLoaderPulse()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if viewModel.tracks.isEmpty {
                 emptyTab(icon: "music.note", title: "No tracks yet",
@@ -280,7 +280,7 @@ struct GroupDetailView: View {
             addMembersButton
 
             if viewModel.isLoading && viewModel.members.isEmpty {
-                ProgressView().tint(.xomifyGreen)
+                XomifyLoaderPulse()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if viewModel.members.isEmpty {
                 emptyTab(icon: "person.2", title: "No members yet",

--- a/Xomify-iOS/Views/GroupsView.swift
+++ b/Xomify-iOS/Views/GroupsView.swift
@@ -93,7 +93,7 @@ struct GroupsView: View {
     @ViewBuilder
     private var content: some View {
         if isLoadingUser || viewModel.isLoading {
-            ProgressView().tint(.xomifyGreen)
+            XomifyLoaderPulse()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = viewModel.errorMessage, viewModel.isEmpty {
             errorState(error)

--- a/Xomify-iOS/Views/MoodPicksView.swift
+++ b/Xomify-iOS/Views/MoodPicksView.swift
@@ -55,7 +55,7 @@ struct MoodPicksView: View {
     private var content: some View {
         if viewModel.isLoading {
             VStack(spacing: 10) {
-                ProgressView().tint(.xomifyGreen)
+                XomifyLoaderPulse()
                 Text("Building your \(viewModel.selectedMood?.rawValue ?? "") picks...")
                     .font(.caption).foregroundColor(.gray)
             }

--- a/Xomify-iOS/Views/PlaylistAnalysisView.swift
+++ b/Xomify-iOS/Views/PlaylistAnalysisView.swift
@@ -24,7 +24,7 @@ struct PlaylistAnalysisView: View {
     private var content: some View {
         if viewModel.isAnalyzing {
             VStack(spacing: 12) {
-                ProgressView().tint(.xomifyGreen)
+                XomifyLoaderPulse()
                 Text("Analyzing \(viewModel.selectedPlaylist?.name ?? "playlist")...")
                     .font(.caption).foregroundColor(.gray)
             }
@@ -32,7 +32,7 @@ struct PlaylistAnalysisView: View {
         } else if let analysis = viewModel.analysis {
             analysisResults(analysis)
         } else if viewModel.isLoadingPlaylists {
-            ProgressView().tint(.xomifyGreen)
+            XomifyLoaderPulse()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = viewModel.errorMessage {
             errorState(error)

--- a/Xomify-iOS/Views/PlaylistBuilderTabView.swift
+++ b/Xomify-iOS/Views/PlaylistBuilderTabView.swift
@@ -121,8 +121,7 @@ struct PlaylistBuilderTabView: View {
 
             if viewModel.isSearching {
                 Spacer()
-                ProgressView()
-                    .tint(Color.xomifyGreen)
+                XomifyLoaderPulse()
                 Spacer()
             } else if viewModel.searchResults.isEmpty {
                 searchEmptyState

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -77,8 +77,7 @@ struct ProfileHeaderView: View {
     private var identityBlock: some View {
         VStack(spacing: 4) {
             if viewModel.isLoading && viewModel.displayName.isEmpty {
-                ProgressView()
-                    .tint(.xomifyGreen)
+                XomifyLoaderSpin()
             } else {
                 Text(viewModel.displayName.isEmpty ? viewModel.profileEmail : viewModel.displayName)
                     .font(.title2)

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
@@ -15,7 +15,7 @@ struct ProfileRatingsTab: View {
     var body: some View {
         Group {
             if viewModel.isLoading && viewModel.ratings.isEmpty {
-                ProgressView().tint(.xomifyGreen)
+                XomifyLoaderPulse()
                     .frame(maxWidth: .infinity, minHeight: 160)
             } else if let error = viewModel.errorMessage, viewModel.isEmpty {
                 errorState(error)

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
@@ -13,7 +13,7 @@ struct ProfileSharesTab: View {
     var body: some View {
         Group {
             if viewModel.isRefreshing && viewModel.shares.isEmpty {
-                VStack { ProgressView().tint(.xomifyGreen) }
+                VStack { XomifyLoaderPulse() }
                     .frame(maxWidth: .infinity, minHeight: 160)
             } else if let error = viewModel.errorMessage, viewModel.shares.isEmpty {
                 errorState(error)
@@ -45,8 +45,7 @@ struct ProfileSharesTab: View {
             }
 
             if viewModel.isLoading {
-                ProgressView()
-                    .tint(.xomifyGreen)
+                XomifyLoaderSpin()
                     .padding(.vertical, 12)
             }
         }

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -29,7 +29,7 @@ struct ProfileView: View {
     @ViewBuilder
     private var content: some View {
         if viewModel.isLoading && viewModel.displayName.isEmpty {
-            VStack { ProgressView().tint(.xomifyGreen) }
+            VStack { XomifyLoaderPulse() }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = viewModel.errorMessage, viewModel.displayName.isEmpty {
             errorState(error)
@@ -87,8 +87,7 @@ struct ProfileView: View {
     }
 
     private var loadingTab: some View {
-        ProgressView()
-            .tint(.xomifyGreen)
+        XomifyLoaderSpin()
             .frame(maxWidth: .infinity, minHeight: 120)
     }
 

--- a/Xomify-iOS/Views/QueueBuilderView.swift
+++ b/Xomify-iOS/Views/QueueBuilderView.swift
@@ -93,7 +93,7 @@ struct QueueBuilderView: View {
             ScrollView {
                 LazyVStack(spacing: 8) {
                     if viewModel.isSearching {
-                        ProgressView().padding(.top, 40)
+                        XomifyLoaderSpin().padding(.top, 40)
                     } else if viewModel.searchResults.isEmpty && !viewModel.searchQuery.isEmpty {
                         Text("No results found").foregroundColor(.gray).padding(.top, 40)
                     } else if viewModel.searchResults.isEmpty {

--- a/Xomify-iOS/Views/RatingsView.swift
+++ b/Xomify-iOS/Views/RatingsView.swift
@@ -37,7 +37,7 @@ struct RatingsView: View {
     @ViewBuilder
     private var content: some View {
         if isLoadingUser || viewModel.isLoading {
-            ProgressView().tint(.xomifyGreen)
+            XomifyLoaderPulse()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = viewModel.errorMessage, viewModel.isEmpty {
             errorState(error)

--- a/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/RatingsHistoryView.swift
@@ -185,8 +185,8 @@ struct RatingsHistoryView: View {
     // MARK: - States
 
     private var loadingState: some View {
-        VStack(spacing: 12) {
-            ProgressView().tint(Color.xomifyGreen)
+        VStack(spacing: 16) {
+            XomifyLoaderPulse()
             Text("Loading ratings…")
                 .font(.xomifyCaption)
                 .foregroundStyle(.white.opacity(0.7))

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -269,7 +269,7 @@ struct WrappedContent: View {
     private var contentView: some View {
         ScrollView {
             if isLoadingContent {
-                ProgressView()
+                XomifyLoaderSpin()
                     .padding(.top, 40)
             } else {
                 switch selectedTab {
@@ -648,7 +648,7 @@ struct WrappedContent: View {
 
     private var loadingState: some View {
         VStack(spacing: 12) {
-            ProgressView()
+            XomifyLoaderPulse()
             Text("Loading wrapped data...")
                 .font(.caption)
                 .foregroundStyle(.gray)


### PR DESCRIPTION
## Summary
- Swap generic `ProgressView()` to `XomifyLoaderPulse` / `XomifyLoaderSpin` across all visible loading states — so every screen carries Xomify's visual identity instead of the system wheel.
- 16 view files touched (feed, profile tabs, ratings, groups, wrapped, album/artist, mood picks, playlist builder/analysis, queue builder, etc).
- Inline button spinners (login, queue pill, invite mint, etc.) intentionally left as `ProgressView` — they live inside <30pt pill buttons where the branded loader would overflow.

## Rationale
Fixes: "still dont have the xomify loader - its just spinning wheel everywhere"

`XomifyLoaderPulse` — medium / full-screen loads.
`XomifyLoaderSpin` — inline / compact loads (under 40pt).

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS` → **BUILD SUCCEEDED**
- [ ] Launch app, observe branded loader on Feed / Profile / Ratings / Groups / Wrapped / Mood Picks