### PR TITLE
feat(groups): owner-only edit sheet for name + description

### DIFF
--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -24,6 +24,9 @@ final class GroupDetailViewModel {
     var addSongUrl: String = ""
     var isAddingSong = false
 
+    /// Edit-group form state (owner-only).
+    var isSavingEdit = false
+
     /// Accepted-friends cache used by the add-member sheet picker.
     var friends: [Friend] = []
     var isLoadingFriends = false
@@ -164,6 +167,53 @@ final class GroupDetailViewModel {
         } catch {
             errorMessage = "Failed to remove member: \(error.localizedDescription)"
             print("❌ GroupDetail: removeMember failed - \(error)")
+        }
+    }
+
+    // MARK: - Edit (owner-only)
+
+    /// Owner-only edit of name + description. Optimistically patches `group`
+    /// on success so the header re-renders without waiting for refresh.
+    /// Returns `true` on success so the sheet can dismiss.
+    @discardableResult
+    func saveEdit(name: String, description: String) async -> Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDesc = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !groupId.isEmpty, !userEmail.isEmpty else {
+            errorMessage = "Name is required"
+            return false
+        }
+        guard !isSavingEdit else { return false }
+        isSavingEdit = true
+        defer { isSavingEdit = false }
+
+        do {
+            _ = try await xomify.updateGroup(
+                email: userEmail,
+                groupId: groupId,
+                name: trimmedName,
+                description: trimmedDesc
+            )
+            if let current = group {
+                group = XomifyGroup(
+                    groupId: current.groupId,
+                    name: trimmedName,
+                    description: trimmedDesc.isEmpty ? nil : trimmedDesc,
+                    ownerEmail: current.ownerEmail,
+                    createdBy: current.createdBy,
+                    createdAt: current.createdAt,
+                    memberCount: current.memberCount,
+                    trackCount: current.trackCount,
+                    imageUrl: current.imageUrl,
+                    role: current.role,
+                    joinedAt: current.joinedAt
+                )
+            }
+            return true
+        } catch {
+            errorMessage = "Failed to save: \(error.localizedDescription)"
+            print("❌ GroupDetail: saveEdit failed - \(error)")
+            return false
         }
     }
 

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -9,6 +9,7 @@ struct GroupDetailView: View {
     @State private var viewModel = GroupDetailViewModel()
     @State private var selectedTab: Tab = .tracks
     @State private var showingAddMembers = false
+    @State private var showingEditGroup = false
     @State private var showLeaveConfirm = false
     @State private var showDeleteConfirm = false
 
@@ -68,6 +69,12 @@ struct GroupDetailView: View {
                 onDismiss: { showingAddMembers = false }
             )
         }
+        .sheet(isPresented: $showingEditGroup) {
+            EditGroupSheet(
+                viewModel: viewModel,
+                onDismiss: { showingEditGroup = false }
+            )
+        }
         .confirmationDialog(
             "Leave this group?",
             isPresented: $showLeaveConfirm,
@@ -114,6 +121,12 @@ struct GroupDetailView: View {
             .disabled(viewModel.isRefreshing)
 
             if isOwner {
+                Button {
+                    showingEditGroup = true
+                } label: {
+                    Label("Edit Group", systemImage: "pencil")
+                }
+
                 Button(role: .destructive) {
                     showDeleteConfirm = true
                 } label: {

--- a/Xomify-iOS/Views/Groups/EditGroupSheet.swift
+++ b/Xomify-iOS/Views/Groups/EditGroupSheet.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Owner-only sheet to edit a group's name + description. Image editing is
+/// intentionally deferred until the backend supports image uploads.
+struct EditGroupSheet: View {
+
+    @Bindable var viewModel: GroupDetailViewModel
+    let onDismiss: () -> Void
+
+    @State private var name: String = ""
+    @State private var description: String = ""
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasChanges: Bool {
+        trimmedName != (viewModel.group?.name ?? "")
+            || description.trimmingCharacters(in: .whitespacesAndNewlines)
+                != (viewModel.group?.description ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+
+                VStack(alignment: .leading, spacing: 16) {
+                    nameField
+                    descriptionField
+                    Spacer()
+                    saveButton
+                }
+                .padding()
+            }
+            .navigationTitle("Edit Group")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { onDismiss() }
+                }
+            }
+            .tint(Color.xomifyGreen)
+        }
+        .presentationDetents([.medium])
+        .onAppear {
+            name = viewModel.group?.name ?? ""
+            description = viewModel.group?.description ?? ""
+        }
+    }
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Name")
+                .font(.caption)
+                .foregroundStyle(.gray)
+            TextField("Group name", text: $name)
+                .textInputAutocapitalization(.words)
+                .padding()
+                .background(Color.white.opacity(0.05))
+                .clipShape(.rect(cornerRadius: 10))
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var descriptionField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Description")
+                .font(.caption)
+                .foregroundStyle(.gray)
+            TextField("What's this group about?", text: $description, axis: .vertical)
+                .lineLimit(3...6)
+                .padding()
+                .background(Color.white.opacity(0.05))
+                .clipShape(.rect(cornerRadius: 10))
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var saveButton: some View {
+        Button {
+            Task {
+                if await viewModel.saveEdit(name: name, description: description) {
+                    onDismiss()
+                }
+            }
+        } label: {
+            HStack {
+                if viewModel.isSavingEdit {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Save")
+                        .fontWeight(.semibold)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .background(LinearGradient.xomifyGradient)
+            .foregroundStyle(.white)
+            .clipShape(.rect(cornerRadius: 22))
+            .opacity((trimmedName.isEmpty || !hasChanges) ? 0.5 : 1)
+        }
+        .disabled(viewModel.isSavingEdit || trimmedName.isEmpty || !hasChanges)
+        .accessibilityLabel("Save group changes")
+    }
+}


### PR DESCRIPTION
## Summary
Adds an **Edit Group** action for owners in the group detail toolbar menu. Opens a sheet with name + description fields, saves via `POST /groups/update`.

- Fixes: "Groups need to be able to be edited. Name, picture, members etc."
- Members management already exists (Add Members sheet + per-row remove).
- Name + description shipping now.
- **Image editing intentionally deferred** — backend doesn't support image upload yet; scoping a separate PR once that lands.

## Behavior
- Edit item only shown to the owner (mirrors Delete Group placement).
- Save button is disabled until name is non-empty **and** something actually changed.
- On success, sheet dismisses and header re-renders optimistically.
- Failures surface via the existing `errorMessage` banner.

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS` → **BUILD SUCCEEDED**
- [ ] Open a group I own → ellipsis → Edit Group → change name → save → banner updates
- [ ] Non-owner: Edit Group item is not visible