### PR TITLE
feat(profile): Playlists tab on self-profile

### DIFF
--- a/Xomify-iOS/ViewModels/ProfilePlaylistsViewModel.swift
+++ b/Xomify-iOS/ViewModels/ProfilePlaylistsViewModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Drives the Playlists tab on the signed-in user's profile. Fetches
+/// `/me/playlists` from Spotify and holds a simple search filter — mirrors
+/// the web app's My Playlists page at a profile-tab scope.
+@Observable
+@MainActor
+final class ProfilePlaylistsViewModel {
+
+    var playlists: [SpotifyPlaylist] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var searchQuery: String = ""
+
+    private let spotify: SpotifyService
+
+    init(spotify: SpotifyService = .shared) {
+        self.spotify = spotify
+    }
+
+    /// Playlists filtered by the current `searchQuery`. Empty query -> all.
+    var filteredPlaylists: [SpotifyPlaylist] {
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return playlists }
+        return playlists.filter { playlist in
+            if playlist.name.lowercased().contains(query) { return true }
+            if let desc = playlist.description?.lowercased(), desc.contains(query) { return true }
+            return false
+        }
+    }
+
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            playlists = try await spotify.getUserPlaylists(limit: 50)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -5,12 +5,14 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
     case shares
     case ratings
     case taste
+    case playlists
 
     var title: String {
         switch self {
-        case .shares:  return "Posts"
-        case .ratings: return "Ratings"
-        case .taste:   return "Taste"
+        case .shares:    return "Posts"
+        case .ratings:   return "Ratings"
+        case .taste:     return "Taste"
+        case .playlists: return "Playlists"
         }
     }
 }
@@ -67,6 +69,17 @@ final class UserProfileViewModel {
 
     private var _sharesVM: SharesByUserViewModel?
     private var _ratingsVM: RatingsViewModel?
+    private var _playlistsVM: ProfilePlaylistsViewModel?
+
+    /// Tabs visible for this profile's context. `.playlists` surfaces the
+    /// signed-in user's Spotify playlists — we don't have a reliable fetch
+    /// path for other users yet, so hide the tab for `.other`.
+    var visibleTabs: [ProfileTab] {
+        switch context {
+        case .me:    return [.shares, .ratings, .taste, .playlists]
+        case .other: return [.shares, .ratings, .taste]
+        }
+    }
 
     /// `SharesByUserViewModel` scoped to the author (self or other). Created
     /// on first access and kept alive for the lifetime of this VM.
@@ -86,6 +99,15 @@ final class UserProfileViewModel {
         if let existing = _ratingsVM { return existing }
         let vm = RatingsViewModel()
         _ratingsVM = vm
+        return vm
+    }
+
+    /// Lazy accessor for the Playlists tab view model. Only meaningful for
+    /// `.me` — callers should gate on `visibleTabs` before asking.
+    func playlistsViewModel() -> ProfilePlaylistsViewModel {
+        if let existing = _playlistsVM { return existing }
+        let vm = ProfilePlaylistsViewModel()
+        _playlistsVM = vm
         return vm
     }
 

--- a/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
+++ b/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
@@ -8,15 +8,21 @@ struct ProfileTabPicker: View {
     @Binding var selection: ProfileTab
 
     private let namespace: Namespace.ID
+    private let tabs: [ProfileTab]
 
-    init(selection: Binding<ProfileTab>, namespace: Namespace.ID) {
+    init(
+        selection: Binding<ProfileTab>,
+        namespace: Namespace.ID,
+        tabs: [ProfileTab] = ProfileTab.allCases
+    ) {
         self._selection = selection
         self.namespace = namespace
+        self.tabs = tabs
     }
 
     var body: some View {
         HStack(spacing: 4) {
-            ForEach(ProfileTab.allCases, id: \.self) { tab in
+            ForEach(tabs, id: \.self) { tab in
                 tabButton(tab)
             }
         }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfilePlaylistsTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfilePlaylistsTab.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+/// Profile tab: signed-in user's Spotify playlists. Minimal v1 — search +
+/// list. Taps open Spotify externally since we don't ship a native
+/// playlist detail view yet.
+struct ProfilePlaylistsTab: View {
+
+    @Bindable var viewModel: ProfilePlaylistsViewModel
+
+    var body: some View {
+        VStack(spacing: 12) {
+            searchField
+
+            if viewModel.isLoading && viewModel.playlists.isEmpty {
+                XomifyLoaderPulse()
+                    .frame(maxWidth: .infinity, minHeight: 200)
+            } else if let error = viewModel.errorMessage, viewModel.playlists.isEmpty {
+                errorState(error)
+            } else if viewModel.filteredPlaylists.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .padding(.horizontal)
+        .task {
+            if viewModel.playlists.isEmpty {
+                await viewModel.load()
+            }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.gray)
+            TextField(
+                "Search playlists",
+                text: $viewModel.searchQuery
+            )
+            .textFieldStyle(.plain)
+            .foregroundStyle(.white)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            if !viewModel.searchQuery.isEmpty {
+                Button {
+                    viewModel.searchQuery = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.gray)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var list: some View {
+        LazyVStack(spacing: 10) {
+            ForEach(viewModel.filteredPlaylists) { playlist in
+                Button {
+                    openExternally(playlist)
+                } label: {
+                    row(playlist)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func row(_ playlist: SpotifyPlaylist) -> some View {
+        HStack(spacing: 12) {
+            AsyncImage(url: playlist.imageUrl) { image in
+                image.resizable()
+            } placeholder: {
+                Rectangle().fill(Color.gray.opacity(0.3))
+            }
+            .frame(width: 52, height: 52)
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(playlist.name)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text("\(playlist.tracks?.total ?? 0) tracks")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "arrow.up.right.square")
+                .foregroundStyle(.gray)
+        }
+        .padding(12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(playlist.name), \(playlist.tracks?.total ?? 0) tracks")
+        .accessibilityHint("Opens in Spotify")
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "music.note.list")
+                .font(.system(size: 32))
+                .foregroundStyle(.gray)
+            Text(viewModel.searchQuery.isEmpty ? "No playlists yet" : "No playlists match \"\(viewModel.searchQuery)\"")
+                .font(.subheadline)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+            Text("Could not load playlists")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+            Button("Retry") {
+                Task { await viewModel.load() }
+            }
+            .buttonStyle(.bordered)
+            .tint(.xomifyGreen)
+        }
+        .padding(24)
+    }
+
+    private func openExternally(_ playlist: SpotifyPlaylist) {
+        if let urlString = playlist.externalUrls?["spotify"], let url = URL(string: urlString) {
+            UIApplication.shared.open(url)
+            return
+        }
+        if let uri = playlist.uri, let url = URL(string: uri) {
+            UIApplication.shared.open(url)
+        }
+    }
+}

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -49,7 +49,8 @@ struct ProfileView: View {
                         get: { viewModel.selectedTab },
                         set: { viewModel.selectedTab = $0 }
                     ),
-                    namespace: tabNamespace
+                    namespace: tabNamespace,
+                    tabs: viewModel.visibleTabs
                 )
 
                 tabContent
@@ -83,6 +84,9 @@ struct ProfileView: View {
 
         case .taste:
             ProfileTasteTab(viewModel: viewModel)
+
+        case .playlists:
+            ProfilePlaylistsTab(viewModel: viewModel.playlistsViewModel())
         }
     }
 


### PR DESCRIPTION
## Summary

Adds **My Playlists** as a fourth tab on the signed-in user's profile — parity with the web app's surface, per recent user feedback.

- `ProfileTab` gains `.playlists` case
- `UserProfileViewModel.visibleTabs` — `.me` gets the new tab; `.other` still shows Posts / Ratings / Taste (we don't have a reliable fetch path for another user's playlists yet)
- New `ProfilePlaylistsViewModel` loads `/me/playlists` via `SpotifyService` + case-insensitive name/description filter
- New `ProfilePlaylistsTab` view: search box, cover + track count rows, taps open the playlist in Spotify externally
- `ProfileTabPicker` accepts an explicit `tabs:` list so the picker only renders what the context allows

## Deferred

- Native playlist detail view — tap currently opens externally. iOS has no equivalent of the web's `PlaylistDetailView` yet; separate scope.
- Friend's playlists — `FriendProfile.playlists` is typed as `[JSONValue]?` without a documented shape. Will wire in a follow-up once the backend contract is stable.

## Test plan

- [ ] Sign in → navigate to own profile → Playlists tab renders and loads your Spotify playlists
- [ ] Search box filters by name and description
- [ ] Tapping a row opens Spotify (external URL preferred, falls back to `uri`)
- [ ] Friend profile hides the Playlists tab (only Posts / Ratings / Taste)
- [ ] Empty state and error state both render when applicable