### PR TITLE
fix(profile): friend 400, stat nav, icon tabs, edit wiring, ratings shuffle

### DIFF
--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -292,11 +292,12 @@ actor XomifyService {
         try await network.xomifyGet("/friends/pending", queryParams: ["email": email])
     }
 
-    /// Public profile of another user.
+    /// Public profile of another user. Backend expects `friendEmail` and
+    /// resolves the caller from the auth header — previous shape
+    /// (`email` + `profileEmail`) returns 400.
     func getFriendProfile(email: String, profileEmail: String) async throws -> FriendProfile {
         try await network.xomifyGet("/friends/profile", queryParams: [
-            "email": email,
-            "profileEmail": profileEmail
+            "friendEmail": profileEmail
         ])
     }
 

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -15,6 +15,17 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
         case .playlists: return "Playlists"
         }
     }
+
+    /// SF Symbol used in the compact tab picker. Pinned to a filled glyph
+    /// for the active pill's legibility on the gradient background.
+    var systemImage: String {
+        switch self {
+        case .shares:    return "bubble.left.and.bubble.right.fill"
+        case .ratings:   return "star.fill"
+        case .taste:     return "waveform"
+        case .playlists: return "music.note.list"
+        }
+    }
 }
 
 /// Fan-out controller for the new tabbed `ProfileView`. Owns the context,

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ProfileHeaderView: View {
 
     let viewModel: UserProfileViewModel
+    @Environment(NavigationStore.self) private var navStore
 
     var body: some View {
         VStack(spacing: 16) {
@@ -105,11 +106,26 @@ struct ProfileHeaderView: View {
                 divider
                 skeletonStat
             } else {
-                statItem(value: viewModel.friendCount ?? 0, label: "Friends", color: .xomifyGreen)
+                statItem(
+                    value: viewModel.friendCount ?? 0,
+                    label: "Friends",
+                    color: .xomifyGreen,
+                    destination: .friends
+                )
                 divider
-                statItem(value: viewModel.ratingCount ?? 0, label: "Ratings", color: .xomifyPurple)
+                statItem(
+                    value: viewModel.ratingCount ?? 0,
+                    label: "Ratings",
+                    color: .xomifyPurple,
+                    destination: .ratings
+                )
                 divider
-                statItem(value: viewModel.shareCount ?? 0, label: "Posts", color: .xomifyGreen)
+                statItem(
+                    value: viewModel.shareCount ?? 0,
+                    label: "Posts",
+                    color: .xomifyGreen,
+                    destination: .feed
+                )
             }
         }
         .padding(.vertical, 12)
@@ -143,15 +159,39 @@ struct ProfileHeaderView: View {
         Divider().frame(height: 30).background(Color.gray.opacity(0.25))
     }
 
-    private func statItem(value: Int, label: String, color: Color) -> some View {
-        VStack(spacing: 4) {
+    private func statItem(
+        value: Int,
+        label: String,
+        color: Color,
+        destination: SidebarDestination?
+    ) -> some View {
+        let isTappable = destination != nil && viewModel.context.isSelf
+
+        let content = VStack(spacing: 4) {
             Text("\(value)")
                 .font(.title3).fontWeight(.bold).foregroundStyle(color)
             Text(label).font(.caption2).foregroundStyle(.gray)
         }
         .frame(maxWidth: .infinity)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(label): \(value)")
+        .contentShape(Rectangle())
+
+        return Group {
+            if isTappable, let destination {
+                Button {
+                    navStore.select(destination)
+                } label: {
+                    content
+                }
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(label): \(value)")
+                .accessibilityHint("Opens \(label) page")
+            } else {
+                content
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(label): \(value)")
+            }
+        }
     }
 
     // MARK: - Action button
@@ -161,7 +201,7 @@ struct ProfileHeaderView: View {
         switch viewModel.context {
         case .me:
             Button {
-                // Placeholder — Edit Profile sheet deferred beyond v1.
+                navStore.select(.settings)
             } label: {
                 Label("Edit Profile", systemImage: "pencil")
                     .font(.subheadline.weight(.semibold))
@@ -171,7 +211,7 @@ struct ProfileHeaderView: View {
                     .background(Color.xomifyCard)
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
-            .accessibilityHint("Opens the Settings screen from the sidebar")
+            .accessibilityHint("Opens Settings")
 
         case .other:
             Button {

--- a/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
+++ b/Xomify-iOS/Views/Profile/ProfileTabPicker.swift
@@ -57,17 +57,17 @@ struct ProfileTabPicker: View {
                     .matchedGeometryEffect(id: "profileTabActive", in: namespace)
                     .shadow(color: Color.xomifyPurple.opacity(0.35), radius: 8, y: 3)
                 }
-                Text(tab.title)
+                Image(systemName: tab.systemImage)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(isSelected ? .white : Color.white.opacity(0.6))
-                    .padding(.horizontal, 22)
-                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
             }
             .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(tab.title) tab")
+        .accessibilityLabel(tab.title)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRatingsTab.swift
@@ -10,6 +10,12 @@ struct ProfileRatingsTab: View {
     let context: ProfileContext
     let viewerEmail: String
 
+    @Environment(NavigationStore.self) private var navStore
+    @State private var shuffled: [TrackRating] = []
+
+    /// How many cards the shuffle sample shows at a time.
+    private let sampleSize = 5
+
     private var targetEmail: String { context.email ?? viewerEmail }
 
     var body: some View {
@@ -29,35 +35,100 @@ struct ProfileRatingsTab: View {
             if viewModel.userEmail != targetEmail || viewModel.ratings.isEmpty {
                 await viewModel.load(email: targetEmail)
             }
+            if shuffled.isEmpty { reshuffle() }
         }
+        .onChange(of: viewModel.ratings) { _, _ in reshuffle() }
         .refreshable { await viewModel.refresh() }
+    }
+
+    private func reshuffle() {
+        let pool = viewModel.ratings.shuffled()
+        shuffled = Array(pool.prefix(sampleSize))
     }
 
     // MARK: - List
 
     private var ratingsList: some View {
-        LazyVStack(alignment: .leading, spacing: 20) {
-            ForEach(viewModel.grouped, id: \.stars) { group in
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 6) {
-                        ForEach(0..<group.stars, id: \.self) { _ in
-                            Image(systemName: "star.fill").foregroundStyle(Color.xomifyGreen)
-                        }
-                        ForEach(group.stars..<5, id: \.self) { _ in
-                            Image(systemName: "star").foregroundStyle(.gray.opacity(0.4))
-                        }
-                        Text("\(group.ratings.count) songs")
-                            .font(.caption).foregroundStyle(.gray).padding(.leading, 8)
-                    }
-                    .font(.caption)
+        VStack(alignment: .leading, spacing: 12) {
+            shuffleHeader
 
-                    ForEach(group.ratings) { rating in
+            LazyVStack(alignment: .leading, spacing: 10) {
+                ForEach(shuffled) { rating in
+                    HStack(spacing: 8) {
+                        starsBar(for: rating.rating)
                         ratingRow(rating)
                     }
                 }
             }
+
+            viewAllButton
         }
         .padding(.horizontal)
+    }
+
+    private var shuffleHeader: some View {
+        HStack {
+            Text("Sample")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+            Text("· \(viewModel.ratings.count) total")
+                .font(.caption)
+                .foregroundStyle(.gray)
+            Spacer()
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) { reshuffle() }
+            } label: {
+                Label("Shuffle", systemImage: "shuffle")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.xomifyPurple.opacity(0.7))
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Shuffle sample")
+        }
+    }
+
+    private var viewAllButton: some View {
+        Button {
+            navStore.select(.ratings)
+        } label: {
+            HStack {
+                Text("View all ratings")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+            }
+            .foregroundStyle(.white)
+            .padding(14)
+            .background(
+                LinearGradient(
+                    colors: [Color.xomifyPurple, Color.xomifyGreen],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens the full ratings history")
+    }
+
+    @ViewBuilder
+    private func starsBar(for count: Int) -> some View {
+        VStack(spacing: 2) {
+            ForEach(0..<count, id: \.self) { _ in
+                Image(systemName: "star.fill")
+                    .font(.system(size: 8))
+                    .foregroundStyle(Color.xomifyGreen)
+            }
+        }
+        .frame(width: 10)
+        .accessibilityHidden(true)
     }
 
     private func ratingRow(_ rating: TrackRating) -> some View {


### PR DESCRIPTION
## Summary

Batch of profile feedback items.

### 1. Friend profile 400 (regression)
`getFriendProfile` was sending `email` + `profileEmail`. Backend `lambdas/friends_profile/handler.py` requires `friendEmail` only and resolves the caller from auth — the old shape returned 400 every time.

### 2. Header stats are navigation
Friends / Ratings / Posts counts on self-profile are now tappable:
- Friends -> `/friends`
- Ratings -> `/ratings`
- Posts -> `/feed`

Other-user context leaves them non-tappable (no sensible destination).

### 3. Tab picker uses icons
Posts / Ratings / Taste / Playlists titles were wrapping to two lines. Replaced label text with SF Symbols (`bubble.left.and.bubble.right.fill`, `star.fill`, `waveform`, `music.note.list`). VoiceOver labels still read the title.

### 4. Edit Profile button actually works
It was a silent no-op. Now routes to `.settings` via `NavigationStore`.

### 5. Ratings tab shuffles with View All
Profile ratings tab now shows a **shuffled sample of 5** with a Shuffle button and a gradient **"View all ratings"** CTA that navigates to the dedicated `RatingsHistoryView` (which still carries the full grouped-by-stars list, filters, and sorts).

## Test plan
- [ ] Open a friend's profile — loads instead of 400
- [ ] Tap Friends / Ratings / Posts counts on own profile — each opens correct page
- [ ] Own profile tabs render as single-row icons on compact width; VoiceOver reads names
- [ ] Tap Edit Profile — Settings opens
- [ ] Ratings tab: sample reshuffles on tap; View All opens full ratings page