### PR TITLE
fix(feed): resilient bootstrap, sharer identity, drop All filter

### DIFF
--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -2,38 +2,45 @@ import Foundation
 
 // MARK: - FeedFilter
 
-/// User-visible filter selection driving the filter chip row.
+/// User-visible filter selection driving the filter chip row. `.all` was
+/// dropped in 2026-04: the feed is always friends-graph-scoped (plus the
+/// caller themselves), so `.all` and `.friends` resolved to the same
+/// backend query and having both was just UI noise.
 enum FeedFilter: Hashable, Sendable {
-    case all
     case friends
     case group(XomifyGroup)
 
     /// Stable cache key for the filter, used by `FeedCacheService`.
     var cacheKey: String {
         switch self {
-        case .all:                 return "all"
         case .friends:             return "friends"
         case .group(let group):    return "group:\(group.groupId)"
         }
     }
 
     /// The `groupId` to send to `shares_feed` when this filter is active.
-    /// `nil` for `.all` and `.friends` — backend infers scope from the caller.
+    /// `nil` for `.friends` — backend infers scope from the caller.
     var groupId: String? {
         if case .group(let g) = self { return g.groupId }
         return nil
     }
 
-    /// Backend currently has no separate `friends-only` param — "all" and
-    /// "friends" both return the friend-graph feed. Chip UI surfaces both so
-    /// future backend splits don't need a UI change.
     var label: String {
         switch self {
-        case .all:              return "All"
-        case .friends:          return "Friends only"
+        case .friends:          return "Friends"
         case .group(let group): return group.displayName
         }
     }
+}
+
+// MARK: - SharerIdentity
+
+/// Resolved display name + avatar for a share author. Feed batches these
+/// from `getAllFriends` + the viewer's own Spotify profile so the feed can
+/// render "Dom" + avatar instead of raw emails.
+struct SharerIdentity: Hashable, Sendable {
+    let displayName: String
+    let avatarURL: URL?
 }
 
 // MARK: - FeedViewModel
@@ -55,8 +62,13 @@ final class FeedViewModel {
     var isRefreshing: Bool = false
     var errorMessage: String?
 
-    var selectedFilter: FeedFilter = .all
+    var selectedFilter: FeedFilter = .friends
     var groups: [XomifyGroup] = []
+
+    /// displayName + avatar keyed by email. Populated on bootstrap from the
+    /// viewer's own profile + all accepted friends. Falls back to email when
+    /// a sharer isn't in the map (shouldn't happen for friend-graph feeds).
+    var identitiesByEmail: [String: SharerIdentity] = [:]
 
     /// Pagination cursor — the `sharedAt` of the last received share, or `nil`
     /// when we've never fetched / there are no more pages.
@@ -68,6 +80,16 @@ final class FeedViewModel {
     private let xomifyService: XomifyServiceProtocol
     private let spotifyService: SpotifyCurrentUserProviding
     private let cacheService: FeedCacheService
+    private let defaults: UserDefaults
+
+    // MARK: - Persistence keys
+
+    /// Last successfully-resolved Spotify email. Written after every
+    /// `getCurrentUser` success, read as a fallback on bootstrap when the
+    /// network call fails transiently. Prevents "posted, came back, now
+    /// errors" UX when a transient 401/offline blip on bootstrap would
+    /// otherwise leave the feed empty.
+    private static let cachedEmailKey = "feed.cachedEmail"
 
     // MARK: - Private state
 
@@ -79,45 +101,79 @@ final class FeedViewModel {
     init(
         xomifyService: XomifyServiceProtocol = XomifyService.shared,
         spotifyService: SpotifyCurrentUserProviding = SpotifyService.shared,
-        cacheService: FeedCacheService = .shared
+        cacheService: FeedCacheService = .shared,
+        defaults: UserDefaults = .standard
     ) {
         self.xomifyService = xomifyService
         self.spotifyService = spotifyService
         self.cacheService = cacheService
+        self.defaults = defaults
     }
 
     // MARK: - Bootstrap
 
     /// Cache-first render, then network refresh. Safe to call from `.task`.
+    ///
+    /// Resilient to transient Spotify `/me` failures: when `getCurrentUser`
+    /// throws, falls back to the last-known email from UserDefaults and
+    /// still paints the cached feed. Only surfaces an error when neither
+    /// source resolves an email.
     func bootstrap() async {
-        // 1. Resolve the current user once.
-        if userEmail.isEmpty {
-            do {
-                let user = try await spotifyService.getCurrentUser()
-                guard let email = user.email, !email.isEmpty else {
-                    errorMessage = "Could not load feed — missing email."
-                    return
-                }
-                userEmail = email
-            } catch {
-                errorMessage = "Could not load feed: \(error.localizedDescription)"
-                return
-            }
-        }
-
-        // 2. Paint from cache if we have one — instant first frame on cold launch.
+        // 1. Paint from cache first — instant first frame, independent of
+        //    whether we can resolve the current user right now.
         if let cached = await cacheService.load(filterKey: selectedFilter.cacheKey), !cached.isEmpty {
             shares = cached
         }
 
-        // 3. Fire the network refresh.
-        await refresh()
+        // 2. Resolve the current user. Prefer the network, fall back to the
+        //    last-known email from UserDefaults on failure.
+        if userEmail.isEmpty {
+            if let email = await resolveCurrentEmail() {
+                userEmail = email
+            } else {
+                // Only surface an error when there's nothing painted AND we
+                // have no way to refresh. If we already painted from cache,
+                // the user gets the last-known feed and a quiet retry later.
+                if shares.isEmpty {
+                    errorMessage = "Could not load feed — please try again."
+                }
+                return
+            }
+        }
+
+        // 3. Populate identity map in parallel with the refresh. Identity
+        //    lookups aren't user-facing blockers — a miss just falls back to
+        //    the email string.
+        async let identitiesTask: Void = loadIdentities()
+        async let refreshTask: Void = refresh()
+        _ = await (identitiesTask, refreshTask)
+    }
+
+    /// Prefer network; fall back to UserDefaults cache on transient failure.
+    /// Persists the email on every successful resolve.
+    private func resolveCurrentEmail() async -> String? {
+        do {
+            let user = try await spotifyService.getCurrentUser()
+            if let email = user.email, !email.isEmpty {
+                defaults.set(email, forKey: Self.cachedEmailKey)
+                return email
+            }
+        } catch {
+            // Fall through to the cached email.
+        }
+        let cached = defaults.string(forKey: Self.cachedEmailKey)
+        return (cached?.isEmpty == false) ? cached : nil
     }
 
     // MARK: - Refresh
 
     /// Pull-to-refresh + initial load. Replaces shares, resets pagination,
     /// rewrites cache for the current filter.
+    ///
+    /// When refresh fails but we already have cached shares painted, the
+    /// error is swallowed so the user keeps seeing the last-known feed
+    /// rather than an error screen. The full error is only surfaced when
+    /// shares is empty (first-ever load or stale cache evicted).
     func refresh() async {
         guard !userEmail.isEmpty else { return }
         guard !isRefreshing else { return }
@@ -137,7 +193,11 @@ final class FeedViewModel {
             hasMorePages = response.nextBefore != nil
             await cacheService.save(response.shares, forKey: selectedFilter.cacheKey)
         } catch {
-            errorMessage = error.localizedDescription
+            // Don't blow the UI away over a refresh hiccup if we already
+            // have content painted from cache.
+            if shares.isEmpty {
+                errorMessage = error.localizedDescription
+            }
         }
 
         isRefreshing = false
@@ -201,8 +261,46 @@ final class FeedViewModel {
             let response = try await xomifyService.listGroups(email: userEmail)
             groups = response.groups ?? []
         } catch {
-            // Non-fatal — chips just show `All` / `Friends only` without group rows.
+            // Non-fatal — chips just show `Friends` without group rows.
         }
+    }
+
+    // MARK: - Identities
+
+    /// Populate `identitiesByEmail` from the viewer's own profile + all
+    /// accepted friends. Best-effort: a failure here silently falls back to
+    /// email-as-label on each card.
+    private func loadIdentities() async {
+        var map: [String: SharerIdentity] = [:]
+
+        // Viewer's own identity from Spotify.
+        if let user = try? await spotifyService.getCurrentUser(),
+           let email = user.email, !email.isEmpty {
+            let name = user.displayName?.isEmpty == false ? user.displayName! : email
+            let url = (user.images?.first?.url).flatMap(URL.init(string:))
+            map[email] = SharerIdentity(displayName: name, avatarURL: url)
+        }
+
+        // Friends — `email` on the row is the CALLER's email, `friendEmail`
+        // is the other party. Always key by `targetEmail`.
+        if let response = try? await xomifyService.getAllFriends(email: userEmail) {
+            for friend in response.accepted ?? [] {
+                let email = friend.targetEmail
+                guard !email.isEmpty else { continue }
+                let name = friend.displayName?.isEmpty == false ? friend.displayName! : email
+                let url = friend.avatar.flatMap(URL.init(string:))
+                map[email] = SharerIdentity(displayName: name, avatarURL: url)
+            }
+        }
+
+        identitiesByEmail = map
+    }
+
+    /// Resolve a display identity for a given email. Falls back to the
+    /// email string when the user isn't in the map.
+    func identity(for email: String) -> SharerIdentity {
+        if let hit = identitiesByEmail[email] { return hit }
+        return SharerIdentity(displayName: email, avatarURL: nil)
     }
 
     // MARK: - Share composer integration

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -74,7 +74,8 @@ struct FeedView: View {
                 ForEach(viewModel.shares) { share in
                     ShareCardView(
                         share: share,
-                        viewerEmail: viewModel.userEmail
+                        viewerEmail: viewModel.userEmail,
+                        sharerIdentity: viewModel.identity(for: share.sharedBy)
                     )
                     .padding(.horizontal, 16)
                     .onAppear {

--- a/Xomify-iOS/Views/Feed/FilterChipsView.swift
+++ b/Xomify-iOS/Views/Feed/FilterChipsView.swift
@@ -9,7 +9,6 @@ struct FilterChipsView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                chip(for: .all)
                 chip(for: .friends)
 
                 ForEach(viewModel.groups) { group in

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -7,11 +7,17 @@ struct ShareCardView: View {
     @State private var viewModel: ShareCardViewModel
     @State private var showRateSheet: Bool = false
 
-    init(share: Share, viewerEmail: String) {
+    /// Resolved sharer identity (display name + avatar). Falls back to the
+    /// email when unresolved — `FeedViewModel.identity(for:)` always returns
+    /// a value, so the fallback tree is handled upstream.
+    let sharerIdentity: SharerIdentity
+
+    init(share: Share, viewerEmail: String, sharerIdentity: SharerIdentity) {
         _viewModel = State(initialValue: ShareCardViewModel(
             share: share,
             viewerEmail: viewerEmail
         ))
+        self.sharerIdentity = sharerIdentity
     }
 
     var body: some View {
@@ -45,19 +51,11 @@ struct ShareCardView: View {
 
     private var sharerRow: some View {
         HStack(spacing: 10) {
-            ZStack {
-                Circle()
-                    .fill(LinearGradient.xomifyGradient)
-                    .frame(width: 36, height: 36)
-                Text(String(viewModel.share.sharedBy.prefix(1)).uppercased())
-                    .font(.subheadline)
-                    .fontWeight(.bold)
-                    .foregroundStyle(.white)
-            }
-            .accessibilityHidden(true)
+            avatarView
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(viewModel.share.sharedBy)
+                Text(sharerIdentity.displayName)
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(.white)
@@ -82,8 +80,38 @@ struct ShareCardView: View {
                 .padding(.vertical, 4)
                 .background(Color.white.opacity(0.08))
                 .clipShape(Capsule())
-                .accessibilityLabel("\(viewModel.share.sharedBy) rated this \(rating) out of 5")
+                .accessibilityLabel("\(sharerIdentity.displayName) rated this \(rating) out of 5")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var avatarView: some View {
+        if let url = sharerIdentity.avatarURL {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    avatarFallback
+                }
+            }
+            .frame(width: 36, height: 36)
+            .clipShape(Circle())
+        } else {
+            avatarFallback
+        }
+    }
+
+    private var avatarFallback: some View {
+        ZStack {
+            Circle()
+                .fill(LinearGradient.xomifyGradient)
+                .frame(width: 36, height: 36)
+            Text(String(sharerIdentity.displayName.prefix(1)).uppercased())
+                .font(.subheadline)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
         }
     }
 

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
@@ -9,6 +9,10 @@ struct ProfileSharesTab: View {
     /// Signed-in user email — passed to each `ShareCardView` so per-card
     /// actions (queue, rate) can hit the right account.
     let viewerEmail: String
+    /// Profile owner's resolved identity — the shares on this tab were all
+    /// authored by this user, so we can pass a single identity to every
+    /// card instead of a per-email lookup.
+    let sharerIdentity: SharerIdentity
 
     var body: some View {
         Group {
@@ -36,7 +40,11 @@ struct ProfileSharesTab: View {
     private var sharesList: some View {
         LazyVStack(spacing: 12) {
             ForEach(viewModel.shares) { share in
-                ShareCardView(share: share, viewerEmail: viewerEmail)
+                ShareCardView(
+                    share: share,
+                    viewerEmail: viewerEmail,
+                    sharerIdentity: sharerIdentity
+                )
                     .onAppear {
                         if share.id == viewModel.shares.last?.id {
                             Task { await viewModel.loadMore() }

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -69,7 +69,11 @@ struct ProfileView: View {
                 ProfileSharesTab(
                     viewModel: sharesVM,
                     context: viewModel.context,
-                    viewerEmail: viewModel.callerEmail
+                    viewerEmail: viewModel.callerEmail,
+                    sharerIdentity: SharerIdentity(
+                        displayName: viewModel.displayName.isEmpty ? viewModel.profileEmail : viewModel.displayName,
+                        avatarURL: viewModel.avatarURL
+                    )
                 )
             } else {
                 loadingTab


### PR DESCRIPTION
## Summary
- Paint cache before `/me` resolves so transient Spotify 401 doesn't blank the feed
- Fall back to last-known email cached in UserDefaults when `/me` fails
- Swallow refresh errors when shares are already painted from cache
- Replace raw email on share cards with display name + avatar (resolved from `/friends/all` + `/me`)
- Drop `.all` filter — `.friends` is default; both mapped to the same backend query anyway

Fixes the "posted, left feed tab, came back, now errors" UX (#54) and consolidates the chip row to Friends + Groups (#56).

## Test plan
- [ ] Post a share, leave feed tab, return → still shows the feed
- [ ] Card shows display name + avatar instead of email
- [ ] Filter chips show only "Friends" + per-group — no "All"
- [ ] Profile > Shares tab renders with profile owner's identity on each card