### PR TITLE
fix(groups): use correct HTTP verbs for update / remove endpoints

### DIFF
--- a/Xomify-iOS/Services/NetworkService.swift
+++ b/Xomify-iOS/Services/NetworkService.swift
@@ -231,49 +231,100 @@ actor NetworkService {
     /// POST request to Xomify API
     func xomifyPost<T: Decodable>(_ endpoint: String, body: [String: Any]) async throws -> T {
         let config = await getXomifyConfig()
-        
+
         let url = URL(string: "\(config.baseUrl)\(endpoint)")!
-        
+
         print("🌐 XomifyAPI POST: \(url.absoluteString)")
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(config.token, forHTTPHeaderField: "Authorization")
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        
+
         return try await performXomifyRequest(request)
     }
+
+    /// PUT request to Xomify API. Used for endpoints the API Gateway only
+    /// binds to PUT (e.g. `/groups/update`) — sending POST there would 403
+    /// before the lambda ever sees the body.
+    func xomifyPut<T: Decodable>(_ endpoint: String, body: [String: Any]) async throws -> T {
+        let config = await getXomifyConfig()
+
+        let url = URL(string: "\(config.baseUrl)\(endpoint)")!
+
+        print("🌐 XomifyAPI PUT: \(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(config.token, forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        return try await performXomifyRequest(request)
+    }
+
+    /// DELETE request to Xomify API. Backend DELETE handlers read
+    /// `queryStringParameters`, not a JSON body — pass identifiers via
+    /// `queryParams`. Most DELETE endpoints return `204 No Content`, so
+    /// this helper accepts an empty body and synthesises a typed result
+    /// when the response carries no payload.
+    func xomifyDelete<T: Decodable>(_ endpoint: String, queryParams: [String: String] = [:]) async throws -> T {
+        let config = await getXomifyConfig()
+
+        var components = URLComponents(string: "\(config.baseUrl)\(endpoint)")!
+        if !queryParams.isEmpty {
+            components.queryItems = queryParams.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        guard let url = components.url else {
+            throw NetworkError.unknown(NSError(domain: "Invalid URL", code: 0))
+        }
+
+        print("🌐 XomifyAPI DELETE: \(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(config.token, forHTTPHeaderField: "Authorization")
+
+        return try await performXomifyRequest(request, allowEmpty: true)
+    }
     
-    /// Perform Xomify API request
-    private func performXomifyRequest<T: Decodable>(_ request: URLRequest) async throws -> T {
+    /// Perform Xomify API request. `allowEmpty` covers 204-style endpoints
+    /// (group delete, remove-member, remove-song) where the server
+    /// legitimately returns no body — we synthesise `{}` so the generic
+    /// `T` decoder can still materialise a `SuccessResponse`-like struct
+    /// with all-optional fields.
+    private func performXomifyRequest<T: Decodable>(_ request: URLRequest, allowEmpty: Bool = false) async throws -> T {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            
+
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw NetworkError.unknown(NSError(domain: "Invalid response", code: 0))
             }
-            
+
             print("🌐 XomifyAPI Response: \(httpResponse.statusCode)")
-            
+
             guard (200...299).contains(httpResponse.statusCode) else {
                 let message = String(data: data, encoding: .utf8) ?? "Unknown error"
                 print("❌ XomifyAPI Error: \(message)")
                 throw NetworkError.serverError(statusCode: httpResponse.statusCode, message: message)
             }
-            
+
+            let payload: Data = (allowEmpty && data.isEmpty) ? Data("{}".utf8) : data
+
             do {
                 let decoder = JSONDecoder()
                 decoder.keyDecodingStrategy = .convertFromSnakeCase
-                return try decoder.decode(T.self, from: data)
+                return try decoder.decode(T.self, from: payload)
             } catch {
                 print("❌ NetworkService: Xomify decoding error - \(error)")
-                if let jsonString = String(data: data, encoding: .utf8) {
+                if let jsonString = String(data: payload, encoding: .utf8) {
                     print("Raw JSON: \(jsonString.prefix(500))")
                 }
                 throw NetworkError.decodingError(error)
             }
-            
+
         } catch let error as NetworkError {
             throw error
         } catch {

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -312,19 +312,22 @@ actor XomifyService {
         return try await network.xomifyPost("/groups/create", body: body)
     }
 
-    /// Update a group's name / description.
+    /// Update a group's name / description. Backend route is `PUT
+    /// /groups/update` — sending POST here would be rejected by API Gateway
+    /// before reaching the lambda.
     @discardableResult
     func updateGroup(email: String, groupId: String, name: String? = nil, description: String? = nil) async throws -> SuccessResponse {
         var body: [String: Any] = ["email": email, "groupId": groupId]
         if let name = name { body["name"] = name }
         if let description = description { body["description"] = description }
-        return try await network.xomifyPost("/groups/update", body: body)
+        return try await network.xomifyPut("/groups/update", body: body)
     }
 
-    /// Delete a group (owner only).
+    /// Delete a group (owner only). Backend route is `DELETE
+    /// /groups/remove` and reads identifiers from query params (not body).
     @discardableResult
     func removeGroup(email: String, groupId: String) async throws -> SuccessResponse {
-        try await network.xomifyPost("/groups/remove", body: [
+        try await network.xomifyDelete("/groups/remove", queryParams: [
             "email": email,
             "groupId": groupId
         ])
@@ -349,10 +352,11 @@ actor XomifyService {
         ])
     }
 
-    /// Remove a member from a group.
+    /// Remove a member from a group. Backend is `DELETE
+    /// /groups/remove-member` with query params.
     @discardableResult
     func removeMember(email: String, groupId: String, memberEmail: String) async throws -> SuccessResponse {
-        try await network.xomifyPost("/groups/remove-member", body: [
+        try await network.xomifyDelete("/groups/remove-member", queryParams: [
             "email": email,
             "groupId": groupId,
             "memberEmail": memberEmail
@@ -404,13 +408,15 @@ actor XomifyService {
         ])
     }
 
-    /// Remove a track by its composite id.
+    /// Remove a track by its composite id. Backend is `DELETE
+    /// /groups/remove-song` and reads `songId` (not `trackIdTimestamp`)
+    /// from query params.
     @discardableResult
     func removeSong(email: String, groupId: String, trackIdTimestamp: String) async throws -> SuccessResponse {
-        try await network.xomifyPost("/groups/remove-song", body: [
+        try await network.xomifyDelete("/groups/remove-song", queryParams: [
             "email": email,
             "groupId": groupId,
-            "trackIdTimestamp": trackIdTimestamp
+            "songId": trackIdTimestamp
         ])
     }
 


### PR DESCRIPTION
## Summary
- `PUT /groups/update` with JSON body (backend reads `parse_body`)
- `DELETE /groups/remove`, `/groups/remove-member`, `/groups/remove-song` with query params (backend reads `get_query_params`)
- All DELETE endpoints return 204 with empty body — NetworkService synthesises \`{}\` so \`SuccessResponse\` decoding still succeeds
- Align remove-song param name with backend (\`songId\`, not \`trackIdTimestamp\`)

Fixes edit + delete group silently failing in the app (#55). API Gateway 403'd POST on these routes before the lambda ever ran.

## Test plan
- [ ] Owner can rename a group from the Edit sheet
- [ ] Owner can delete a group and it disappears from the list
- [ ] Owner can remove a member
- [ ] Owner can remove a song from a group