### PR TITLE
fix(profile): friend taste carousel mirrors self

### DIFF
--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -430,106 +430,393 @@ private struct SelfTasteSummary: View {
 }
 
 // MARK: - Other taste view
+//
+// Mirrors `SelfTasteSummary` — same 9-stage rotating carousel, same row
+// styling, same progress indicator — but sourced from the raw JSON payload
+// attached to `FriendProfile` (Spotify top-tracks / top-artists objects +
+// a `{genre: score}` dict). No "See all" CTA since `TopItemsView` is
+// scoped to the signed-in user.
 
 private struct OtherTasteView: View {
     let viewModel: UserProfileViewModel
 
-    @State private var selectedTerm: TermRange = .mediumTerm
+    @State private var stage: Int = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private enum TermRange: String, CaseIterable, Hashable {
-        case shortTerm  = "short_term"
-        case mediumTerm = "medium_term"
-        case longTerm   = "long_term"
+    private static let stages: [TasteStage] = [
+        .init(term: .shortTerm,  kind: .tracks),
+        .init(term: .shortTerm,  kind: .artists),
+        .init(term: .shortTerm,  kind: .genres),
+        .init(term: .mediumTerm, kind: .tracks),
+        .init(term: .mediumTerm, kind: .artists),
+        .init(term: .mediumTerm, kind: .genres),
+        .init(term: .longTerm,   kind: .tracks),
+        .init(term: .longTerm,   kind: .artists),
+        .init(term: .longTerm,   kind: .genres)
+    ]
 
-        var title: String {
-            switch self {
-            case .shortTerm:  return "Last 4 weeks"
-            case .mediumTerm: return "Last 6 months"
-            case .longTerm:   return "All time"
-            }
-        }
-    }
+    private var currentStage: TasteStage { Self.stages[stage % Self.stages.count] }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Picker("Time range", selection: $selectedTerm) {
-                ForEach(TermRange.allCases, id: \.self) { term in
-                    Text(term.title).tag(term)
-                }
-            }
-            .pickerStyle(.segmented)
-            .accessibilityLabel("Taste time range")
-            .accessibilityHint("Switches between last 4 weeks, last 6 months, and all time")
+        VStack(alignment: .leading, spacing: 14) {
+            header
 
-            let artistNames = names(from: viewModel.friendProfileTopArtists, term: selectedTerm)
-            let songNames = names(from: viewModel.friendProfileTopSongs, term: selectedTerm)
-            let genreNames = names(from: viewModel.friendProfileTopGenres, term: selectedTerm)
-
-            if artistNames.isEmpty && songNames.isEmpty && genreNames.isEmpty {
-                VStack(spacing: 8) {
-                    Image(systemName: "waveform")
-                        .font(.system(size: 32))
-                        .foregroundStyle(.gray.opacity(0.6))
-                    Text("No taste data yet")
-                        .font(.subheadline)
-                        .foregroundStyle(.white)
-                    Text("This user hasn't built up enough listening history in this window.")
-                        .font(.caption)
-                        .foregroundStyle(.gray)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal)
-                }
-                .frame(maxWidth: .infinity, minHeight: 160)
+            if allEmpty {
+                emptyState
             } else {
-                section(title: "Top Artists", items: artistNames)
-                section(title: "Top Songs", items: songNames)
-                section(title: "Top Genres", items: genreNames)
+                stageCard
+                    .frame(maxWidth: .infinity, minHeight: 260, alignment: .top)
+                    .contentShape(Rectangle())
+                    .onTapGesture { advance() }
+                    .gesture(
+                        DragGesture(minimumDistance: 20)
+                            .onEnded { value in
+                                let horizontal = value.translation.width
+                                if horizontal < -40 { advance() }
+                                else if horizontal > 40 { retreat() }
+                            }
+                    )
+                    .accessibilityHint("Swipe left or right to switch stage")
+                progressIndicator
             }
         }
         .padding(.horizontal)
+        .task { await autoAdvanceLoop() }
     }
 
+    // MARK: Header + progress
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(currentStage.kindLabel)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(.white)
+                .contentTransition(.opacity)
+                .id("other-kind-\(stage)")
+            Text("·").foregroundStyle(.white.opacity(0.4))
+            Text(termLabel(currentStage.term))
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.white.opacity(0.7))
+                .contentTransition(.opacity)
+                .id("other-term-\(stage)")
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var progressIndicator: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<Self.stages.count, id: \.self) { idx in
+                Capsule()
+                    .fill(idx == (stage % Self.stages.count)
+                          ? Color.xomifyGreen
+                          : Color.white.opacity(0.18))
+                    .frame(width: idx == (stage % Self.stages.count) ? 18 : 6, height: 4)
+                    .animation(.easeInOut(duration: 0.3), value: stage)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func termLabel(_ term: TimeRange) -> String {
+        switch term {
+        case .shortTerm:  return "1 month"
+        case .mediumTerm: return "6 months"
+        case .longTerm:   return "1 year"
+        }
+    }
+
+    // MARK: Stage card
+
     @ViewBuilder
-    private func section(title: String, items: [String]) -> some View {
-        if !items.isEmpty {
-            VStack(alignment: .leading, spacing: 10) {
-                Text(title).font(.headline).foregroundStyle(.white)
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 10) {
-                        ForEach(Array(items.prefix(20).enumerated()), id: \.offset) { _, item in
-                            tile(item)
-                        }
-                    }
+    private var stageCard: some View {
+        Group {
+            switch currentStage.kind {
+            case .tracks:
+                let items = parsedTracks(for: currentStage.term)
+                if items.isEmpty {
+                    emptyStageState(symbol: "music.note", label: "No tracks yet")
+                } else {
+                    trackSection(items)
+                }
+            case .artists:
+                let items = parsedArtists(for: currentStage.term)
+                if items.isEmpty {
+                    emptyStageState(symbol: "person.2", label: "No artists yet")
+                } else {
+                    artistSection(items)
+                }
+            case .genres:
+                let items = parsedGenres(for: currentStage.term)
+                if items.isEmpty {
+                    emptyStageState(symbol: "music.note.list", label: "No genres yet")
+                } else {
+                    genreSection(items)
                 }
             }
         }
+        .id(stage)
+        .transition(.asymmetric(
+            insertion: .opacity.animation(.easeIn(duration: 0.45)),
+            removal: .opacity.animation(.easeOut(duration: 0.25))
+        ))
     }
 
-    private func tile(_ label: String) -> some View {
-        Text(label)
-            .font(.caption).fontWeight(.medium)
-            .foregroundStyle(.white)
-            .lineLimit(2)
-            .multilineTextAlignment(.center)
-            .frame(width: 110, height: 60)
-            .padding(.horizontal, 8)
-            .background(Color.xomifyCard)
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(label)
-    }
-
-    // MARK: - JSON → names
-
-    private func names(from termMap: [String: JSONValue]?, term: TermRange) -> [String] {
-        guard let termMap else { return [] }
-        let keys = [term.rawValue, camelCase(term.rawValue)]
-        for key in keys {
-            if let entry = termMap[key], let list = entry.arrayValue {
-                return extractNames(from: list)
+    @ViewBuilder
+    private func trackSection(_ tracks: [DisplayTrack]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(tracks.prefix(3).enumerated()), id: \.offset) { index, track in
+                HStack(spacing: 12) {
+                    indexLabel(index)
+                    artworkThumb(url: track.imageUrl)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(track.name)
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                        Text(track.artistNames)
+                            .font(.caption2)
+                            .foregroundStyle(.white.opacity(0.65))
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 0)
+                    if let uri = track.uri {
+                        QueueButton(uri: uri, trackName: track.name)
+                    }
+                    if let uri = track.uri {
+                        openButton(urlString: uri, label: "Open \(track.name) in Spotify")
+                    }
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(Color.xomifyCard)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
         }
+    }
+
+    @ViewBuilder
+    private func artistSection(_ artists: [DisplayArtist]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(artists.prefix(3).enumerated()), id: \.offset) { index, artist in
+                HStack(spacing: 12) {
+                    indexLabel(index)
+                    artworkThumb(url: artist.imageUrl, circular: true)
+                    Text(artist.name)
+                        .font(.subheadline)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    if let id = artist.id {
+                        openButton(urlString: "spotify:artist:\(id)", label: "Open \(artist.name) in Spotify")
+                    }
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(Color.xomifyCard)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func genreSection(_ items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(items.prefix(3).enumerated()), id: \.offset) { index, item in
+                HStack(spacing: 12) {
+                    indexLabel(index)
+                    Text(item)
+                        .font(.subheadline)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 12)
+                .background(Color.xomifyCard)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+        }
+    }
+
+    // MARK: Common row bits
+
+    private func indexLabel(_ index: Int) -> some View {
+        Text("\(index + 1)")
+            .font(.subheadline.monospacedDigit().weight(.bold))
+            .foregroundStyle(Color.xomifyGreen)
+            .frame(width: 20, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func artworkThumb(url: URL?, circular: Bool = false) -> some View {
+        let shape: AnyShape = circular
+            ? AnyShape(Circle())
+            : AnyShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        Group {
+            if let url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let img): img.resizable().scaledToFill()
+                    default: artworkThumbFallback
+                    }
+                }
+            } else {
+                artworkThumbFallback
+            }
+        }
+        .frame(width: 36, height: 36)
+        .clipShape(shape)
+    }
+
+    private var artworkThumbFallback: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyPurple.opacity(0.35), Color.xomifyGreen.opacity(0.25)],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+            Image(systemName: "music.note")
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.85))
+        }
+    }
+
+    private func openButton(urlString: String, label: String) -> some View {
+        Button {
+            if let url = URL(string: urlString) { UIApplication.shared.open(url) }
+        } label: {
+            Image(systemName: "arrow.up.forward.app")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.75))
+                .frame(width: 32, height: 32)
+                .background(Color.white.opacity(0.08), in: Circle())
+        }
+        .accessibilityLabel(label)
+    }
+
+    // MARK: Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "waveform")
+                .font(.system(size: 32))
+                .foregroundStyle(.gray.opacity(0.6))
+            Text("No taste data yet")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+            Text("This user hasn't built up enough listening history.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+        }
+        .frame(maxWidth: .infinity, minHeight: 260)
+    }
+
+    private func emptyStageState(symbol: String, label: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 28))
+                .foregroundStyle(.gray.opacity(0.55))
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, minHeight: 140)
+    }
+
+    // MARK: Rotation
+
+    private func advance() {
+        withAnimation(.easeInOut(duration: 0.35)) {
+            stage = (stage + 1) % Self.stages.count
+        }
+    }
+
+    private func retreat() {
+        withAnimation(.easeInOut(duration: 0.35)) {
+            stage = (stage - 1 + Self.stages.count) % Self.stages.count
+        }
+    }
+
+    private func autoAdvanceLoop() async {
+        while !Task.isCancelled {
+            let delay: UInt64 = reduceMotion ? 8_000_000_000 : 6_000_000_000
+            try? await Task.sleep(nanoseconds: delay)
+            if Task.isCancelled { return }
+            advance()
+        }
+    }
+
+    // MARK: JSON parsing
+
+    private var allEmpty: Bool {
+        TimeRange.allCases.allSatisfy {
+            parsedTracks(for: $0).isEmpty
+            && parsedArtists(for: $0).isEmpty
+            && parsedGenres(for: $0).isEmpty
+        }
+    }
+
+    private func parsedTracks(for term: TimeRange) -> [DisplayTrack] {
+        guard let array = arrayEntry(from: viewModel.friendProfileTopSongs, term: term) else { return [] }
+        return array.compactMap { value -> DisplayTrack? in
+            guard let obj = value.objectValue,
+                  let name = obj["name"]?.stringValue else { return nil }
+            let artistNames = (obj["artists"]?.arrayValue ?? [])
+                .compactMap { $0.objectValue?["name"]?.stringValue }
+                .joined(separator: ", ")
+            let imageUrl = firstImageURL(from: obj["album"]?.objectValue?["images"]?.arrayValue)
+            let uri = obj["uri"]?.stringValue
+                ?? obj["id"]?.stringValue.map { "spotify:track:\($0)" }
+            return DisplayTrack(
+                name: name,
+                artistNames: artistNames.isEmpty ? "—" : artistNames,
+                imageUrl: imageUrl,
+                uri: uri
+            )
+        }
+    }
+
+    private func parsedArtists(for term: TimeRange) -> [DisplayArtist] {
+        guard let array = arrayEntry(from: viewModel.friendProfileTopArtists, term: term) else { return [] }
+        return array.compactMap { value -> DisplayArtist? in
+            guard let obj = value.objectValue,
+                  let name = obj["name"]?.stringValue else { return nil }
+            let imageUrl = firstImageURL(from: obj["images"]?.arrayValue)
+            let id = obj["id"]?.stringValue
+            return DisplayArtist(name: name, id: id, imageUrl: imageUrl)
+        }
+    }
+
+    private func parsedGenres(for term: TimeRange) -> [String] {
+        guard let termMap = viewModel.friendProfileTopGenres else { return [] }
+        let entry = termEntry(from: termMap, term: term)
+        // Backend ships genres as a `{genre: score}` object (weighted, already
+        // sorted descending). Legacy shape was an array of strings — tolerate
+        // both.
+        if let array = entry?.arrayValue {
+            return array.compactMap { $0.stringValue ?? $0.objectValue?["name"]?.stringValue }
+        }
+        if let obj = entry?.objectValue {
+            // Preserve insertion order — JSONDecoder's default [String: Value]
+            // doesn't, so fall back to score-descending sort.
+            return obj
+                .map { (key: $0.key, score: $0.value.intValue ?? 0) }
+                .sorted { $0.score > $1.score }
+                .map(\.key)
+        }
         return []
+    }
+
+    private func arrayEntry(from termMap: [String: JSONValue]?, term: TimeRange) -> [JSONValue]? {
+        termEntry(from: termMap, term: term)?.arrayValue
+    }
+
+    private func termEntry(from termMap: [String: JSONValue]?, term: TimeRange) -> JSONValue? {
+        guard let termMap else { return nil }
+        let raw = term.rawValue
+        if let v = termMap[raw] { return v }
+        return termMap[camelCase(raw)]
     }
 
     private func camelCase(_ snake: String) -> String {
@@ -538,18 +825,43 @@ private struct OtherTasteView: View {
         return ([String(first)] + parts.dropFirst().map { $0.capitalized }).joined()
     }
 
-    private func extractNames(from list: [JSONValue]) -> [String] {
-        list.compactMap { item -> String? in
-            if let s = item.stringValue { return s }
-            if let obj = item.objectValue {
-                if let name = obj["name"]?.stringValue { return name }
-                if let name = obj["trackName"]?.stringValue { return name }
-                if let name = obj["artistName"]?.stringValue { return name }
+    private func firstImageURL(from images: [JSONValue]?) -> URL? {
+        guard let first = images?.first?.objectValue,
+              let urlString = first["url"]?.stringValue else { return nil }
+        return URL(string: urlString)
+    }
+
+    // MARK: Stage types
+
+    private struct TasteStage {
+        let term: TimeRange
+        let kind: Kind
+
+        enum Kind { case tracks, artists, genres }
+
+        var kindLabel: String {
+            switch kind {
+            case .tracks:  return "Top Tracks"
+            case .artists: return "Top Artists"
+            case .genres:  return "Top Genres"
             }
-            return nil
         }
     }
+
+    private struct DisplayTrack {
+        let name: String
+        let artistNames: String
+        let imageUrl: URL?
+        let uri: String?
+    }
+
+    private struct DisplayArtist {
+        let name: String
+        let id: String?
+        let imageUrl: URL?
+    }
 }
+
 
 // MARK: - Expose FriendProfile top-item dictionaries on UserProfileViewModel
 


### PR DESCRIPTION
## Summary
- `OtherTasteView` now renders the same rotating 9-stage card used for `.me` — 3 terms × 3 kinds, cross-fading every ~6 seconds with tap / swipe to advance manually.
- Parses the Spotify track & artist objects carried on `FriendProfile.topSongs` / `topArtists` into rows with artwork, artist-name subtitle, Spotify deeplink, and add-to-queue button.
- Fixes a latent genres bug — backend ships `topGenres` as `{genre: score}` dict (already sorted by weight), but the old parser only handled arrays and returned empty. Tolerates both shapes.
- Keeps the same empty-bucket / empty-state contract; no "See all" CTA (that surface is scoped to the signed-in user's Taste drawer).

## Test plan
- [ ] Open a friend's profile → Taste tab rotates through the 9 stages (Top Tracks / Artists / Genres × 1mo / 6mo / 1yr).
- [ ] Tracks show album artwork, artist row, tap queue + open in Spotify.
- [ ] Artists show image + open-in-Spotify.
- [ ] Genres list populates (no longer empty).
- [ ] Swipe horizontally on the card changes stage.
- [ ] Own profile Taste tab unchanged.