### PR TITLE
feat(profile): show friend playlists tab

### DIFF
--- a/Xomify-iOS/ViewModels/ProfilePlaylistsViewModel.swift
+++ b/Xomify-iOS/ViewModels/ProfilePlaylistsViewModel.swift
@@ -1,21 +1,35 @@
 import Foundation
 
-/// Drives the Playlists tab on the signed-in user's profile. Fetches
-/// `/me/playlists` from Spotify and holds a simple search filter — mirrors
-/// the web app's My Playlists page at a profile-tab scope.
+/// Drives the Playlists tab on the signed-in user's profile. Two modes:
+/// - `.self`: fetches `/me/playlists` from Spotify on first `load()`.
+/// - `.preloaded`: hydrated from the `FriendProfile.playlists` payload —
+///   read-only, `load()` is a no-op.
 @Observable
 @MainActor
 final class ProfilePlaylistsViewModel {
+
+    enum Mode: Sendable, Equatable {
+        case me
+        case preloaded
+    }
 
     var playlists: [SpotifyPlaylist] = []
     var isLoading: Bool = false
     var errorMessage: String?
     var searchQuery: String = ""
 
+    let mode: Mode
     private let spotify: SpotifyService
 
     init(spotify: SpotifyService = .shared) {
+        self.mode = .me
         self.spotify = spotify
+    }
+
+    init(preloaded: [SpotifyPlaylist]) {
+        self.mode = .preloaded
+        self.spotify = .shared
+        self.playlists = preloaded
     }
 
     /// Playlists filtered by the current `searchQuery`. Empty query -> all.
@@ -30,6 +44,7 @@ final class ProfilePlaylistsViewModel {
     }
 
     func load() async {
+        guard mode == .me else { return }
         guard !isLoading else { return }
         isLoading = true
         errorMessage = nil

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -83,12 +83,12 @@ final class UserProfileViewModel {
     private var _playlistsVM: ProfilePlaylistsViewModel?
 
     /// Tabs visible for this profile's context. `.playlists` surfaces the
-    /// signed-in user's Spotify playlists — we don't have a reliable fetch
-    /// path for other users yet, so hide the tab for `.other`.
+    /// signed-in user's Spotify playlists for `.me`, and the friend's public
+    /// playlists for `.other` once the `FriendProfile` payload has loaded.
     var visibleTabs: [ProfileTab] {
         switch context {
         case .me:    return [.shares, .ratings, .taste, .playlists]
-        case .other: return [.shares, .ratings, .taste]
+        case .other: return [.shares, .ratings, .taste, .playlists]
         }
     }
 
@@ -113,13 +113,51 @@ final class UserProfileViewModel {
         return vm
     }
 
-    /// Lazy accessor for the Playlists tab view model. Only meaningful for
-    /// `.me` — callers should gate on `visibleTabs` before asking.
+    /// Lazy accessor for the Playlists tab view model. In `.me` context
+    /// returns a fetch-backed VM; in `.other` context, seeds the VM from
+    /// `FriendProfile.playlists` and runs in read-only mode.
     func playlistsViewModel() -> ProfilePlaylistsViewModel {
         if let existing = _playlistsVM { return existing }
-        let vm = ProfilePlaylistsViewModel()
+        let vm: ProfilePlaylistsViewModel
+        switch context {
+        case .me:
+            vm = ProfilePlaylistsViewModel()
+        case .other:
+            let preloaded = friendProfile?.playlists.flatMap(parsePreloadedPlaylists) ?? []
+            vm = ProfilePlaylistsViewModel(preloaded: preloaded)
+        }
         _playlistsVM = vm
         return vm
+    }
+
+    /// Convert the slim `FriendProfile.playlists` JSON payload (shape:
+    /// `{ id, name, description, imageUrl, trackCount, uri, externalUrl }`)
+    /// into `SpotifyPlaylist` values the shared Playlists tab can render.
+    private func parsePreloadedPlaylists(_ values: [JSONValue]) -> [SpotifyPlaylist] {
+        values.compactMap { value -> SpotifyPlaylist? in
+            guard let obj = value.objectValue,
+                  let id = obj["id"]?.stringValue,
+                  let name = obj["name"]?.stringValue else { return nil }
+
+            let imageUrl = obj["imageUrl"]?.stringValue
+            let images: [SpotifyImage]? = imageUrl.map { [SpotifyImage(url: $0, height: nil, width: nil)] }
+            let trackCount = obj["trackCount"]?.intValue ?? 0
+            let external = obj["externalUrl"]?.stringValue
+            let externalUrls: [String: String]? = external.map { ["spotify": $0] }
+
+            return SpotifyPlaylist(
+                id: id,
+                name: name,
+                description: obj["description"]?.stringValue,
+                uri: obj["uri"]?.stringValue,
+                images: images,
+                owner: nil,
+                tracks: SpotifyPlaylist.PlaylistTracks(total: trackCount),
+                isPublic: true,
+                collaborative: nil,
+                externalUrls: externalUrls
+            )
+        }
     }
 
     // MARK: - Init


### PR DESCRIPTION
## Summary
- Friend profiles now include a Playlists tab backed by `FriendProfile.playlists` from the backend.
- `ProfilePlaylistsViewModel` gains a `preloaded` mode so it can be seeded from a JSON payload without hitting `/me/playlists`.
- JSONValue adapter maps the slim backend shape (`id / name / description / imageUrl / trackCount / uri / externalUrl`) into `SpotifyPlaylist` so the existing tab UI renders unchanged (artwork, row, external Spotify link).

## Dependencies
Backend PR: Xomware/xomify-backend#135 — adds `playlists` field to `friends_profile`. Until that deploys, the tab shows the existing empty state.

## Test plan
- [ ] Own profile Playlists tab still fetches `/me/playlists` and renders as before.
- [ ] Friend profile shows the Playlists tab.
- [ ] Before backend deploy: friend Playlists tab is empty (graceful).
- [ ] After backend deploy: friend's public playlists appear with artwork + track count; tap opens in Spotify.