### PR TITLE
feat(tracks): unified action menu + share-to-feed

### DIFF
--- a/Xomify-iOS/Views/AlbumView.swift
+++ b/Xomify-iOS/Views/AlbumView.swift
@@ -244,22 +244,7 @@ struct AlbumView: View {
                 .font(.caption)
                 .foregroundColor(.gray)
             
-            QueueButton(
-                uri: track.uri ?? "spotify:track:\(track.id)",
-                trackName: track.name
-            )
-
-            // Add to playlist builder
-            AddToPlaylistButton(track: track)
-
-            // Play button
-            Button {
-                playTrack(track)
-            } label: {
-                Image(systemName: "play.circle.fill")
-                    .font(.title2)
-                    .foregroundColor(.xomifyGreen)
-            }
+            TrackActionsMenu(track: track)
         }
         .padding(.horizontal)
         .padding(.vertical, 10)

--- a/Xomify-iOS/Views/ArtistView.swift
+++ b/Xomify-iOS/Views/ArtistView.swift
@@ -337,22 +337,7 @@ struct ArtistView: View {
             
             Spacer()
 
-            QueueButton(
-                uri: track.uri ?? "spotify:track:\(track.id)",
-                trackName: track.name
-            )
-
-            // Add to playlist builder
-            AddToPlaylistButton(track: track)
-
-            // Play button
-            Button {
-                playTrack(track)
-            } label: {
-                Image(systemName: "play.circle.fill")
-                    .font(.title2)
-                    .foregroundColor(.xomifyGreen)
-            }
+            TrackActionsMenu(track: track)
         }
         .padding(.horizontal)
         .padding(.vertical, 8)

--- a/Xomify-iOS/Views/MoodPicksView.swift
+++ b/Xomify-iOS/Views/MoodPicksView.swift
@@ -194,18 +194,7 @@ struct MoodPicksView: View {
 
             Spacer()
 
-            QueueButton(
-                uri: track.uri ?? "spotify:track:\(track.id)",
-                trackName: track.name
-            )
-
-            if let urlString = track.externalUrls?["spotify"], let url = URL(string: urlString) {
-                Link(destination: url) {
-                    Image(systemName: "play.circle.fill")
-                        .font(.title2)
-                        .foregroundColor(.xomifyGreen)
-                }
-            }
+            TrackActionsMenu(track: track)
         }
         .padding(12)
         .background(Color.xomifyCard)

--- a/Xomify-iOS/Views/PlaylistAnalysisView.swift
+++ b/Xomify-iOS/Views/PlaylistAnalysisView.swift
@@ -225,15 +225,20 @@ struct PlaylistAnalysisView: View {
                 HStack(spacing: 12) {
                     ForEach(tracks) { track in
                         VStack(alignment: .leading, spacing: 6) {
-                            AsyncImage(url: track.imageUrl) { phase in
-                                switch phase {
-                                case .success(let img): img.resizable().scaledToFill()
-                                default:
-                                    LinearGradient.xomifyGradient
+                            ZStack(alignment: .topTrailing) {
+                                AsyncImage(url: track.imageUrl) { phase in
+                                    switch phase {
+                                    case .success(let img): img.resizable().scaledToFill()
+                                    default:
+                                        LinearGradient.xomifyGradient
+                                    }
                                 }
+                                .frame(width: 120, height: 120)
+                                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                                TrackActionsMenu(track: track)
+                                    .padding(6)
                             }
-                            .frame(width: 120, height: 120)
-                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
                             Text(track.name)
                                 .font(.caption.weight(.semibold))

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileTasteTab.swift
@@ -579,11 +579,8 @@ private struct OtherTasteView: View {
                             .lineLimit(1)
                     }
                     Spacer(minLength: 0)
-                    if let uri = track.uri {
-                        QueueButton(uri: uri, trackName: track.name)
-                    }
-                    if let uri = track.uri {
-                        openButton(urlString: uri, label: "Open \(track.name) in Spotify")
+                    if let spotifyTrack = track.asSpotifyTrack {
+                        TrackActionsMenu(track: spotifyTrack)
                     }
                 }
                 .padding(.vertical, 8)
@@ -853,6 +850,52 @@ private struct OtherTasteView: View {
         let artistNames: String
         let imageUrl: URL?
         let uri: String?
+
+        /// Build a synthetic `SpotifyTrack` from the slim fields the taste
+        /// tab has available so the row can hand off to `TrackActionsMenu`.
+        /// Returns `nil` if we can't derive an id from the URI, since every
+        /// menu action needs either the id or uri.
+        var asSpotifyTrack: SpotifyTrack? {
+            guard let uri, let id = uri.split(separator: ":").last.map(String.init), !id.isEmpty else {
+                return nil
+            }
+            let syntheticArtist = SpotifyArtist(
+                id: nil,
+                name: artistNames,
+                uri: nil,
+                genres: nil,
+                popularity: nil,
+                followers: nil,
+                images: nil,
+                externalUrls: nil
+            )
+            let syntheticAlbum: SpotifyAlbum? = imageUrl.map { url in
+                SpotifyAlbum(
+                    id: "",
+                    name: "",
+                    uri: nil,
+                    albumType: nil,
+                    totalTracks: nil,
+                    releaseDate: nil,
+                    releaseDatePrecision: nil,
+                    images: [SpotifyImage(url: url.absoluteString, height: nil, width: nil)],
+                    artists: nil,
+                    externalUrls: nil
+                )
+            }
+            return SpotifyTrack(
+                id: id,
+                name: name,
+                uri: uri,
+                durationMs: 0,
+                explicit: nil,
+                popularity: nil,
+                previewUrl: nil,
+                album: syntheticAlbum,
+                artists: [syntheticArtist],
+                externalUrls: nil
+            )
+        }
     }
 
     private struct DisplayArtist {

--- a/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
+++ b/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import UIKit
+
+/// Unified track action menu. One ellipsis button that exposes every
+/// action users can perform on a track across the app:
+///
+/// - **Play now** — opens the track in the Spotify app.
+/// - **Add to queue** — routes to `QueueActionController.shared`.
+/// - **Add to Playlist Builder** — stashes the track in `PlaylistBuilderManager`.
+/// - **Share to Feed** — presents `ShareComposerView` pre-seeded with the track.
+///
+/// Replaces the scatter of bespoke per-row buttons (play link, queue button,
+/// ad-hoc share entry points). Drop-in: pass a `SpotifyTrack` and an optional
+/// style; the component owns its own sheet presentation.
+struct TrackActionsMenu: View {
+
+    enum Style {
+        /// 32pt ellipsis glyph over a translucent circle. Use in dense rows.
+        case icon
+        /// Labelled pill matching `QueueButton.pill`. Use in card UIs.
+        case pill
+    }
+
+    let track: SpotifyTrack
+    var style: Style = .icon
+
+    @State private var queueAction = QueueActionController.shared
+    @State private var playlistBuilder = PlaylistBuilderManager.shared
+    @State private var isComposerShown = false
+
+    var body: some View {
+        Menu {
+            Button {
+                playNow()
+            } label: {
+                Label("Play now", systemImage: "play.circle.fill")
+            }
+
+            Button {
+                Task { await queueAction.queue(uri: resolvedUri, trackName: track.name) }
+            } label: {
+                Label(
+                    queueAction.isQueuing(uri: resolvedUri) ? "Queueing…" : "Add to queue",
+                    systemImage: "text.badge.plus"
+                )
+            }
+            .disabled(resolvedUri.isEmpty || queueAction.isQueuing(uri: resolvedUri))
+
+            Button {
+                playlistBuilder.addTrack(track)
+            } label: {
+                Label(
+                    playlistBuilder.contains(track) ? "In Playlist Builder" : "Add to Playlist Builder",
+                    systemImage: playlistBuilder.contains(track) ? "checkmark.circle.fill" : "plus.square.on.square"
+                )
+            }
+            .disabled(playlistBuilder.contains(track))
+
+            Button {
+                isComposerShown = true
+            } label: {
+                Label("Share to Feed", systemImage: "bubble.left.and.bubble.right.fill")
+            }
+        } label: {
+            switch style {
+            case .icon: iconLabel
+            case .pill: pillLabel
+            }
+        }
+        .accessibilityLabel("More actions for \(track.name)")
+        .sheet(isPresented: $isComposerShown) {
+            ShareComposerView(viewModel: makeComposerViewModel()) { _ in
+                // Fire-and-forget: the feed refreshes on its own next appearance.
+                // Surfacing a global toast would require plumbing we don't have
+                // at this call-site, and the post is visible in Spotify anyway.
+            }
+        }
+    }
+
+    // MARK: - Labels
+
+    private var iconLabel: some View {
+        ZStack {
+            Circle()
+                .fill(Color.white.opacity(0.08))
+                .frame(width: 32, height: 32)
+            Image(systemName: "ellipsis")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.85))
+        }
+        .frame(minWidth: 44, minHeight: 44)
+    }
+
+    private var pillLabel: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "ellipsis.circle")
+            Text("Actions")
+        }
+        .font(.caption)
+        .fontWeight(.medium)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.08))
+        .foregroundStyle(.white)
+        .clipShape(.rect(cornerRadius: 16))
+        .frame(minHeight: 44)
+    }
+
+    // MARK: - Actions
+
+    private var resolvedUri: String {
+        track.uri ?? "spotify:track:\(track.id)"
+    }
+
+    private func playNow() {
+        if let uri = track.uri, let url = URL(string: uri) {
+            UIApplication.shared.open(url)
+        } else if let urlString = track.externalUrls?["spotify"], let url = URL(string: urlString) {
+            UIApplication.shared.open(url)
+        } else if let url = URL(string: "spotify:track:\(track.id)") {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func makeComposerViewModel() -> ShareComposerViewModel {
+        let vm = ShareComposerViewModel()
+        vm.selectTrack(track)
+        return vm
+    }
+}

--- a/Xomify-iOS/Views/TopItemsView.swift
+++ b/Xomify-iOS/Views/TopItemsView.swift
@@ -347,23 +347,7 @@ struct TopItemsContent: View {
 
             Spacer()
 
-            // Add to Spotify queue
-            QueueButton(
-                uri: track.uri ?? "spotify:track:\(track.id)",
-                trackName: track.name
-            )
-
-            // Add to playlist builder
-            AddToPlaylistButton(track: track)
-
-            // Play button
-            Button {
-                playTrack(track)
-            } label: {
-                Image(systemName: "play.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(Color.xomifyGreen)
-            }
+            TrackActionsMenu(track: track)
         }
         .padding(12)
         .background(Color.white.opacity(0.03))

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -340,23 +340,7 @@ struct WrappedContent: View {
 
             Spacer()
 
-            QueueButton(
-                uri: track.uri ?? "spotify:track:\(track.id)",
-                trackName: track.name
-            )
-
-            // Add to playlist builder
-            Button {
-                if playlistBuilder.contains(track) {
-                    playlistBuilder.removeTrack(track)
-                } else {
-                    playlistBuilder.addTrack(track)
-                }
-            } label: {
-                Image(systemName: playlistBuilder.contains(track) ? "checkmark.circle.fill" : "plus.circle")
-                    .font(.title3)
-                    .foregroundStyle(playlistBuilder.contains(track) ? Color.xomifyGreen : Color.xomifyPurple)
-            }
+            TrackActionsMenu(track: track)
         }
         .padding(.horizontal)
         .padding(.vertical, 10)


### PR DESCRIPTION
## Summary
- New `TrackActionsMenu` consolidates every track action behind one ellipsis button — **Play now**, **Add to queue**, **Add to Playlist Builder**, and a new **Share to Feed** entry that opens `ShareComposerView` pre-seeded with the track.
- Retrofits track rows across MoodPicks, PlaylistAnalysis sample strip, Profile Taste tab, TopItems, Album, Artist, and Wrapped to use the new menu instead of per-row icon buttons.
- Keeps `QueueActionController` / `PlaylistBuilderManager` as the single source of truth for state — the menu items surface in-flight + contains states automatically.

## Test plan
- [ ] Tap ellipsis on a track row in MoodPicks → all 4 actions listed
- [ ] Share to Feed opens composer with the track preselected; Post lands in feed
- [ ] Add to queue shows "Queueing…" and fires the global toast
- [ ] Add to Playlist Builder flips to "In Playlist Builder" on second open
- [ ] Menu appears on PlaylistAnalysis sample cards and Profile Taste rows