### PR TITLE
fix(nav): restore back button on pushed detail views

### DIFF
--- a/Xomify-iOS/Views/AlbumView.swift
+++ b/Xomify-iOS/Views/AlbumView.swift
@@ -48,6 +48,9 @@ struct AlbumView: View {
         .background(Color.xomifyDark.ignoresSafeArea())
         .navigationTitle(album?.name ?? "Album")
         .navigationBarTitleDisplayMode(.inline)
+        // Pushed from tabs that hide the system nav bar. Re-assert visibility
+        // so the back button renders.
+        .toolbar(.visible, for: .navigationBar)
         .task {
             await loadAlbum()
         }

--- a/Xomify-iOS/Views/ArtistView.swift
+++ b/Xomify-iOS/Views/ArtistView.swift
@@ -59,6 +59,9 @@ struct ArtistView: View {
         .background(Color.xomifyDark.ignoresSafeArea())
         .navigationTitle(artist?.name ?? "Artist")
         .navigationBarTitleDisplayMode(.inline)
+        // Pushed from tabs that hide the system nav bar (TopItems, Wrapped,
+        // ReleaseRadar). Re-assert visibility so the back button renders.
+        .toolbar(.visible, for: .navigationBar)
         .task {
             await loadArtist()
         }

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -19,6 +19,10 @@ struct ProfileView: View {
         }
         .navigationTitle(viewModel.displayName.isEmpty ? "Profile" : viewModel.displayName)
         .navigationBarTitleDisplayMode(.inline)
+        // Force the system nav bar visible so pushed destinations (friend
+        // profile from FriendsView) surface the default back button even
+        // though the parent tab view (`.toolbar(.hidden)`) suppresses it.
+        .toolbar(.visible, for: .navigationBar)
         .task {
             await viewModel.loadHeader()
         }


### PR DESCRIPTION
## Summary
- Friend profile (pushed from Friends), Artist, and Album detail pages weren't rendering the system back button because the parent tab views apply `.toolbar(.hidden, for: .navigationBar)` and the hidden state propagated into the pushed destinations.
- Fix: re-assert `.toolbar(.visible, for: .navigationBar)` on those three destinations so the back chevron is present.

## Test plan
- [ ] Friends tab → tap a friend → friend profile shows back button top-left
- [ ] TopItems → tap an artist → ArtistView shows back button
- [ ] Artist → tap an album → AlbumView shows back button