### PR TITLE
fix(feed,player): decode shares w/ email fallback + richer track actions

### DIFF
--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -222,12 +222,19 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         return URL(string: s)
     }
 
-    /// Custom decoding — enrichment fields are optional on the wire because the
-    /// backend may omit them for cold-cache responses. Default to safe zeros.
+    /// Custom decoding — the backend stores the author as `email` on the
+    /// `shares` table but some paths also emit `sharedBy`. Accept either so
+    /// the feed doesn't hard-fail on the live payload. Enrichment fields are
+    /// optional because cold-cache responses may omit them.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         shareId         = try c.decode(String.self, forKey: .shareId)
-        sharedBy        = try c.decode(String.self, forKey: .sharedBy)
+        if let author = try c.decodeIfPresent(String.self, forKey: .sharedBy) {
+            sharedBy = author
+        } else {
+            let fallback = try decoder.container(keyedBy: FallbackAuthorKey.self)
+            sharedBy = try fallback.decode(String.self, forKey: .email)
+        }
         sharedAt        = try c.decode(String.self, forKey: .sharedAt)
         trackId         = try c.decode(String.self, forKey: .trackId)
         trackUri        = try c.decode(String.self, forKey: .trackUri)
@@ -243,6 +250,10 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         viewerHasQueued = try c.decodeIfPresent(Bool.self, forKey: .viewerHasQueued) ?? false
         viewerRating    = try c.decodeIfPresent(Int.self, forKey: .viewerRating)
         sharerRating    = try c.decodeIfPresent(Int.self, forKey: .sharerRating)
+    }
+
+    private enum FallbackAuthorKey: String, CodingKey {
+        case email
     }
 
     /// Memberwise initializer for tests and optimistic-update copies.

--- a/Xomify-iOS/Services/QueueActionController.swift
+++ b/Xomify-iOS/Services/QueueActionController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// Shared controller that powers every "Add to Spotify queue" button in the app.
 ///
@@ -56,10 +57,54 @@ final class QueueActionController {
             } else {
                 toast = "Queued on Spotify"
             }
+        } catch SpotifyServiceError.noActiveDevice {
+            handleNoDevice(uri: uri, action: "queue")
         } catch let error as SpotifyServiceError {
             toast = error.errorDescription
         } catch {
             toast = error.localizedDescription
+        }
+    }
+
+    /// Start playback on the user's active Spotify device. Falls back to
+    /// deep-linking into the Spotify app when no device is active so the user
+    /// can trivially resume a session.
+    func play(uri: String, trackName: String? = nil) async {
+        guard !uri.isEmpty else {
+            toast = "Couldn't play — missing track URI."
+            return
+        }
+        guard !inFlight.contains(uri) else { return }
+
+        inFlight.insert(uri)
+        defer { inFlight.remove(uri) }
+
+        do {
+            try await spotifyService.playTrack(uri: uri)
+            if let name = trackName, !name.isEmpty {
+                toast = "Playing \(name)"
+            } else {
+                toast = "Playing on Spotify"
+            }
+        } catch SpotifyServiceError.noActiveDevice {
+            handleNoDevice(uri: uri, action: "play")
+        } catch let error as SpotifyServiceError {
+            toast = error.errorDescription
+        } catch {
+            toast = error.localizedDescription
+        }
+    }
+
+    /// When the Web API reports no active device, the user simply hasn't
+    /// opened Spotify yet. Deep-link them into the track page so Spotify
+    /// launches and they can tap Play — the next action will then hit a
+    /// live device.
+    private func handleNoDevice(uri: String, action: String) {
+        if let url = URL(string: uri), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+            toast = "Open Spotify to finish the \(action)."
+        } else {
+            toast = SpotifyServiceError.noActiveDevice.errorDescription
         }
     }
 }

--- a/Xomify-iOS/Services/SpotifyService.swift
+++ b/Xomify-iOS/Services/SpotifyService.swift
@@ -341,6 +341,25 @@ actor SpotifyService {
             throw error
         }
     }
+
+    /// Start playback of a single track on the user's active Spotify device.
+    /// Same failure mapping as `queueTrack` — Premium + active-device required.
+    ///
+    /// Docs: https://developer.spotify.com/documentation/web-api/reference/start-a-users-playback
+    func playTrack(uri: String) async throws {
+        do {
+            try await network.spotifyPut("/me/player/play", body: ["uris": [uri]])
+        } catch let error as NetworkService.NetworkError {
+            if case .serverError(let code, _) = error {
+                switch code {
+                case 403: throw SpotifyServiceError.premiumRequired
+                case 404: throw SpotifyServiceError.noActiveDevice
+                default:  throw SpotifyServiceError.unexpected(statusCode: code)
+                }
+            }
+            throw error
+        }
+    }
 }
 
 // MARK: - Array Extension

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -85,10 +85,11 @@ extension SpotifyService: SpotifyCurrentUserProviding {}
 
 // MARK: - SpotifyQueueing
 
-/// Subset of `SpotifyService` needed to queue a track. Split from the above
-/// so queue-only tests can mock a smaller surface.
+/// Subset of `SpotifyService` needed to queue or start playback. Split from
+/// the full service so player-only tests can mock a smaller surface.
 protocol SpotifyQueueing: Sendable {
     func queueTrack(uri: String) async throws
+    func playTrack(uri: String) async throws
 }
 
 extension SpotifyService: SpotifyQueueing {}

--- a/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
+++ b/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
@@ -4,8 +4,10 @@ import UIKit
 /// Unified track action menu. One ellipsis button that exposes every
 /// action users can perform on a track across the app:
 ///
-/// - **Play now** — opens the track in the Spotify app.
+/// - **Play now** — starts playback on the active Spotify device via the Web
+///   API. Falls back to deep-linking into Spotify when no device is active.
 /// - **Add to queue** — routes to `QueueActionController.shared`.
+/// - **Open in Spotify** — deep-links into the Spotify app/web player.
 /// - **Add to Playlist Builder** — stashes the track in `PlaylistBuilderManager`.
 /// - **Share to Feed** — presents `ShareComposerView` pre-seeded with the track.
 ///
@@ -31,10 +33,11 @@ struct TrackActionsMenu: View {
     var body: some View {
         Menu {
             Button {
-                playNow()
+                Task { await queueAction.play(uri: resolvedUri, trackName: track.name) }
             } label: {
                 Label("Play now", systemImage: "play.circle.fill")
             }
+            .disabled(resolvedUri.isEmpty || queueAction.isQueuing(uri: resolvedUri))
 
             Button {
                 Task { await queueAction.queue(uri: resolvedUri, trackName: track.name) }
@@ -45,6 +48,12 @@ struct TrackActionsMenu: View {
                 )
             }
             .disabled(resolvedUri.isEmpty || queueAction.isQueuing(uri: resolvedUri))
+
+            Button {
+                openInSpotify()
+            } label: {
+                Label("Open in Spotify", systemImage: "arrow.up.right.square")
+            }
 
             Button {
                 playlistBuilder.addTrack(track)
@@ -112,7 +121,7 @@ struct TrackActionsMenu: View {
         track.uri ?? "spotify:track:\(track.id)"
     }
 
-    private func playNow() {
+    private func openInSpotify() {
         if let uri = track.uri, let url = URL(string: uri) {
             UIApplication.shared.open(url)
         } else if let urlString = track.externalUrls?["spotify"], let url = URL(string: urlString) {


### PR DESCRIPTION
## Summary
- **Feed decode:** accept either \`sharedBy\` or fallback \`email\` in \`Share\` decoder — unblocks the main feed and profile feed, which were erroring \"data couldn't be read because it's missing\" because the deployed shares API stores \`email\`.
- **Track actions menu:** adds \"Open in Spotify\" as a distinct item, and wires \"Play now\" to the real \`/me/player/play\` Web API call instead of just opening the URL.
- **No-device recovery:** when Spotify reports no active device on play/queue, we now deep-link into \`spotify:track:<id>\` so the app launches; the next tap hits a live device. Toast tells the user what happened.

## Test plan
- [ ] Feed loads without decode error on home tab
- [ ] Profile feed loads without decode error
- [ ] Track menu shows 5 items: Play now, Add to queue, Open in Spotify, Add to Playlist Builder, Share to Feed
- [ ] Tapping Play now with Spotify closed → opens Spotify + toast
- [ ] Tapping Play now with Spotify playing → starts playback on active device