### PR TITLE
feat(ui): unify headers on Wrapped/Release Radar/Mood/Analysis/Builder

### DIFF
--- a/Xomify-iOS/Views/MoodPicksView.swift
+++ b/Xomify-iOS/Views/MoodPicksView.swift
@@ -10,13 +10,18 @@ struct MoodPicksView: View {
         ZStack {
             Color.xomifyDark.ignoresSafeArea()
             VStack(spacing: 12) {
+                BrandGradientHeader(
+                    "Mood Picks",
+                    subtitle: viewModel.selectedMood.map { "VIBE · \($0.rawValue.uppercased())" } ?? "PICK A VIBE, WE'LL BUILD THE LIST",
+                    systemImage: "sparkles"
+                )
+
                 moodChips
                 createPlaylistCTA
                 content
             }
         }
-        .navigationTitle("Mood Picks")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .tint(Color.xomifyGreen)
     }
 

--- a/Xomify-iOS/Views/PlaylistAnalysisView.swift
+++ b/Xomify-iOS/Views/PlaylistAnalysisView.swift
@@ -8,10 +8,16 @@ struct PlaylistAnalysisView: View {
     var body: some View {
         ZStack {
             Color.xomifyDark.ignoresSafeArea()
-            content
+            VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Playlist Analysis",
+                    subtitle: viewModel.selectedPlaylist.map { "ANALYZING · \($0.name.uppercased())" } ?? "DEEP DIVE ON ANY PLAYLIST",
+                    systemImage: "chart.bar.xaxis"
+                )
+                content
+            }
         }
-        .navigationTitle("Playlist Analysis")
-        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .navigationBar)
         .task {
             if viewModel.playlists.isEmpty {
                 await viewModel.loadPlaylists()

--- a/Xomify-iOS/Views/PlaylistBuilderTabView.swift
+++ b/Xomify-iOS/Views/PlaylistBuilderTabView.swift
@@ -10,6 +10,29 @@ struct PlaylistBuilderTabView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Playlist Builder",
+                    subtitle: viewModel.trackCount > 0
+                        ? "\(viewModel.trackCount) TRACKS QUEUED"
+                        : "BUILD A PLAYLIST FROM ANYWHERE",
+                    systemImage: "plus.square.on.square"
+                ) {
+                    if selectedTab == 0 && !viewModel.isEmpty {
+                        Button {
+                            viewModel.clear()
+                        } label: {
+                            Text("Clear")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(
+                                    Capsule().fill(Color.white.opacity(0.18))
+                                )
+                        }
+                    }
+                }
+
                 // Tab picker
                 tabPicker
 
@@ -21,20 +44,7 @@ struct PlaylistBuilderTabView: View {
                 }
             }
             .background(Color.xomifyDark.ignoresSafeArea())
-            .navigationTitle("Playlist Builder")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    if selectedTab == 0 && !viewModel.isEmpty {
-                        Button {
-                            viewModel.clear()
-                        } label: {
-                            Text("Clear")
-                                .foregroundColor(.red)
-                        }
-                    }
-                }
-            }
+            .toolbar(.hidden, for: .navigationBar)
             .sheet(isPresented: $showingCreateSheet) {
                 createPlaylistSheet
             }

--- a/Xomify-iOS/Views/ReleaseRadarView.swift
+++ b/Xomify-iOS/Views/ReleaseRadarView.swift
@@ -12,14 +12,50 @@ struct ReleaseRadarView: View {
         NavigationStack {
             ZStack {
                 VStack(spacing: 0) {
+                    BrandGradientHeader(
+                        "Release Radar",
+                        subtitle: "NEW DROPS · \(viewModel.displayWeekName.uppercased())",
+                        systemImage: "antenna.radiowaves.left.and.right"
+                    ) {
+                        HStack(spacing: 12) {
+                            Button {
+                                Task { await viewModel.refresh() }
+                            } label: {
+                                if viewModel.isRefreshing {
+                                    ProgressView().tint(.white)
+                                } else {
+                                    Image(systemName: "arrow.clockwise")
+                                        .font(.title3)
+                                        .foregroundStyle(.white)
+                                }
+                            }
+                            .disabled(viewModel.isRefreshing || isLoadingUser)
+
+                            if viewModel.selectedWeek != nil || !viewModel.historyWeeks.isEmpty {
+                                ShareLink(
+                                    item: URL(string: "https://xomify.xomware.com/release-radar")!,
+                                    subject: Text("My Release Radar"),
+                                    message: Text(shareCaption)
+                                ) {
+                                    Image(systemName: "square.and.arrow.up")
+                                        .font(.title3)
+                                        .foregroundStyle(.white)
+                                }
+                                .simultaneousGesture(TapGesture().onEnded {
+                                    Task { await publishReleaseRadarShare() }
+                                })
+                            }
+                        }
+                    }
+
                     // Week selector header
                     weekHeader
-                    
+
                     // Stats bar
                     if let stats = viewModel.displayStats {
                         statsBar(stats)
                     }
-                    
+
                     // Content
                     ScrollView {
                         if isLoadingUser || viewModel.isLoading {
@@ -45,7 +81,7 @@ struct ReleaseRadarView: View {
                         }
                     }
                 }
-                
+
                 // Floating playlist builder button
                 VStack {
                     Spacer()
@@ -58,36 +94,7 @@ struct ReleaseRadarView: View {
                 }
             }
             .background(Color.xomifyDark.ignoresSafeArea())
-            .navigationTitle("Release Radar")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        Task { await viewModel.refresh() }
-                    } label: {
-                        if viewModel.isRefreshing {
-                            ProgressView()
-                        } else {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                    }
-                    .disabled(viewModel.isRefreshing || isLoadingUser)
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    if viewModel.selectedWeek != nil || !viewModel.historyWeeks.isEmpty {
-                        ShareLink(
-                            item: URL(string: "https://xomify.xomware.com/release-radar")!,
-                            subject: Text("My Release Radar"),
-                            message: Text(shareCaption)
-                        ) {
-                            Image(systemName: "square.and.arrow.up")
-                        }
-                        .simultaneousGesture(TapGesture().onEnded {
-                            Task { await publishReleaseRadarShare() }
-                        })
-                    }
-                }
-            }
+            .toolbar(.hidden, for: .navigationBar)
             .task {
                 await loadUserAndData()
             }

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -34,6 +34,27 @@ struct WrappedContent: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
+                BrandGradientHeader(
+                    "Wrapped",
+                    subtitle: currentWrap.map { "MONTHLY RECAP · \($0.displayName.uppercased())" } ?? "YOUR MONTHLY RECAP",
+                    systemImage: "gift.fill"
+                ) {
+                    if let wrap = currentWrap, let shareURL = URL(string: "https://xomify.xomware.com/wrapped") {
+                        ShareLink(
+                            item: shareURL,
+                            subject: Text("My \(wrap.displayName) Wrap"),
+                            message: Text("My top tracks from \(wrap.displayName)")
+                        ) {
+                            Image(systemName: "square.and.arrow.up")
+                                .font(.title3)
+                                .foregroundStyle(.white)
+                        }
+                        .simultaneousGesture(TapGesture().onEnded {
+                            Task { await publishWrappedShare() }
+                        })
+                    }
+                }
+
                 // Month selector header
                 if !wraps.isEmpty {
                     monthHeader
@@ -82,24 +103,7 @@ struct WrappedContent: View {
             }
         }
         .background(Color.xomifyDark.ignoresSafeArea())
-        .navigationTitle("Wrapped")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                if let wrap = currentWrap, let shareURL = URL(string: "https://xomify.xomware.com/wrapped") {
-                    ShareLink(
-                        item: shareURL,
-                        subject: Text("My \(wrap.displayName) Wrap"),
-                        message: Text("My top tracks from \(wrap.displayName)")
-                    ) {
-                        Image(systemName: "square.and.arrow.up")
-                    }
-                    .simultaneousGesture(TapGesture().onEnded {
-                        Task { await publishWrappedShare() }
-                    })
-                }
-            }
-        }
+        .toolbar(.hidden, for: .navigationBar)
         .task {
             await loadData()
         }


### PR DESCRIPTION
## Summary
- Retrofits 5 screens (Wrapped, Release Radar, Mood Picks, Playlist Analysis, Playlist Builder) to use \`BrandGradientHeader\` instead of the stock \`.navigationTitle\`, matching Feed / Profile / Ratings / Top Items / Friends / Groups.
- Each header keeps its previous trailing controls (ShareLink, refresh, Clear) by moving them into the header's trailing slot.
- Hides the system nav bar so the gradient tile owns the top.

## Test plan
- [ ] Open each tab: Wrapped, Release Radar, Mood Picks, Playlist Analysis, Playlist Builder
- [ ] Confirm the gradient header renders with icon + uppercase subtitle
- [ ] Release Radar share + refresh still work
- [ ] Wrapped share link still fires
- [ ] Playlist Builder Clear button still works when list has tracks
- [ ] No stacked \"double header\" on any screen