### PR TITLE
feat(feed,groups): own-share delete + in-app group song search

### DIFF
--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -37,6 +37,12 @@ protocol XomifyServiceProtocol: Sendable {
         before: String?
     ) async throws -> FeedResponse
 
+    func deleteShare(
+        email: String,
+        shareId: String,
+        sharedAt: String
+    ) async throws -> SuccessResponse
+
     // MARK: - Friend profile (used by UserProfileViewModel)
 
     func getFriendProfile(

--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -311,4 +311,29 @@ final class FeedViewModel {
         shares.insert(share, at: 0)
         await refresh()
     }
+
+    // MARK: - Share deletion
+
+    /// Delete a share authored by the current viewer. Optimistically removes
+    /// the row from the feed + cache, then hits the backend. On failure the
+    /// row is restored and an error surfaces.
+    func deleteShare(_ share: Share) async {
+        guard share.sharedBy == userEmail else { return }
+        guard let index = shares.firstIndex(where: { $0.shareId == share.shareId }) else { return }
+
+        let removed = shares.remove(at: index)
+        await cacheService.save(shares, forKey: selectedFilter.cacheKey)
+
+        do {
+            _ = try await xomifyService.deleteShare(
+                email: userEmail,
+                shareId: share.shareId,
+                sharedAt: share.sharedAt
+            )
+        } catch {
+            shares.insert(removed, at: min(index, shares.count))
+            await cacheService.save(shares, forKey: selectedFilter.cacheKey)
+            errorMessage = "Failed to delete post: \(error.localizedDescription)"
+        }
+    }
 }

--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -20,9 +20,24 @@ final class GroupDetailViewModel {
     var addMemberEmail: String = ""
     var isAddingMember = false
 
-    /// Spotify URL input for adding by URL.
+    /// Spotify URL input for adding by URL (legacy paste-URL flow, still
+    /// supported as a fallback on the Add Song sheet).
     var addSongUrl: String = ""
     var isAddingSong = false
+
+    /// Search state for the Add Song sheet.
+    var songSearchQuery: String = ""
+    var songSearchResults: [SpotifyTrack] = []
+    var isSearchingSongs = false
+    var songSearchError: String?
+
+    /// Track IDs currently being added from the search results — used to
+    /// disable the individual row while the network call is in flight.
+    var addingTrackIds: Set<String> = []
+
+    /// Monotonic counter on search task IDs so a stale query response can't
+    /// overwrite results from a newer query.
+    private var songSearchToken: Int = 0
 
     /// Edit-group form state (owner-only).
     var isSavingEdit = false
@@ -33,6 +48,7 @@ final class GroupDetailViewModel {
     var friendsError: String?
 
     private let xomify = XomifyService.shared
+    private let spotify = SpotifyService.shared
 
     // MARK: - Load
 
@@ -249,6 +265,69 @@ final class GroupDetailViewModel {
     }
 
     // MARK: - Songs
+
+    /// Run a Spotify track search for the Add Song sheet. Guards against
+    /// stale completions — only the most recent query's results are applied.
+    func searchSongs() async {
+        let query = songSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            songSearchResults = []
+            songSearchError = nil
+            return
+        }
+
+        songSearchToken &+= 1
+        let token = songSearchToken
+        isSearchingSongs = true
+        songSearchError = nil
+
+        do {
+            let results = try await spotify.searchTracks(query: query, limit: 25)
+            guard token == songSearchToken else { return }
+            songSearchResults = results
+        } catch {
+            guard token == songSearchToken else { return }
+            songSearchError = error.localizedDescription
+            songSearchResults = []
+        }
+
+        if token == songSearchToken {
+            isSearchingSongs = false
+        }
+    }
+
+    /// Clear search state when the Add Song sheet closes.
+    func resetSongSearch() {
+        songSearchQuery = ""
+        songSearchResults = []
+        songSearchError = nil
+        addingTrackIds = []
+        isSearchingSongs = false
+    }
+
+    /// Add a track from a Spotify search result. Shows a per-row spinner
+    /// via `addingTrackIds` so the rest of the list stays tappable.
+    func addSong(_ track: SpotifyTrack) async {
+        guard !addingTrackIds.contains(track.id) else { return }
+        addingTrackIds.insert(track.id)
+        defer { addingTrackIds.remove(track.id) }
+
+        do {
+            _ = try await xomify.addSong(
+                email: userEmail,
+                groupId: groupId,
+                trackId: track.id,
+                trackName: track.name,
+                artistName: track.artistNames,
+                albumName: track.album?.name,
+                imageUrl: track.album?.images?.first?.url
+            )
+            await refresh()
+        } catch {
+            errorMessage = "Failed to add song: \(error.localizedDescription)"
+            print("❌ GroupDetail: addSong failed - \(error)")
+        }
+    }
 
     func addSongByUrl() async {
         let url = addSongUrl.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
+++ b/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
@@ -76,6 +76,28 @@ final class SharesByUserViewModel {
         isRefreshing = false
     }
 
+    // MARK: - Deletion
+
+    /// Delete a share authored by the caller. Optimistic removal with
+    /// rollback on failure. No-op when the share isn't the caller's own.
+    func deleteShare(_ share: Share) async {
+        guard share.sharedBy == callerEmail else { return }
+        guard let index = shares.firstIndex(where: { $0.shareId == share.shareId }) else { return }
+
+        let removed = shares.remove(at: index)
+
+        do {
+            _ = try await xomifyService.deleteShare(
+                email: callerEmail,
+                shareId: share.shareId,
+                sharedAt: share.sharedAt
+            )
+        } catch {
+            shares.insert(removed, at: min(index, shares.count))
+            errorMessage = "Failed to delete post: \(error.localizedDescription)"
+        }
+    }
+
     /// Fetch the next page. No-op when already loading or no more pages.
     func loadMore() async {
         guard hasMorePages, !isLoading, !isRefreshing else { return }

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -75,7 +75,10 @@ struct FeedView: View {
                     ShareCardView(
                         share: share,
                         viewerEmail: viewModel.userEmail,
-                        sharerIdentity: viewModel.identity(for: share.sharedBy)
+                        sharerIdentity: viewModel.identity(for: share.sharedBy),
+                        onDelete: {
+                            Task { await viewModel.deleteShare(share) }
+                        }
                     )
                     .padding(.horizontal, 16)
                     .onAppear {

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -6,18 +6,34 @@ struct ShareCardView: View {
 
     @State private var viewModel: ShareCardViewModel
     @State private var showRateSheet: Bool = false
+    @State private var showDeleteConfirm: Bool = false
 
     /// Resolved sharer identity (display name + avatar). Falls back to the
     /// email when unresolved — `FeedViewModel.identity(for:)` always returns
     /// a value, so the fallback tree is handled upstream.
     let sharerIdentity: SharerIdentity
 
-    init(share: Share, viewerEmail: String, sharerIdentity: SharerIdentity) {
+    /// Optional callback fired when the viewer confirms deletion of their
+    /// own post. When `nil` (or the share wasn't authored by the viewer)
+    /// the delete menu entry is hidden.
+    let onDelete: (() -> Void)?
+
+    init(
+        share: Share,
+        viewerEmail: String,
+        sharerIdentity: SharerIdentity,
+        onDelete: (() -> Void)? = nil
+    ) {
         _viewModel = State(initialValue: ShareCardViewModel(
             share: share,
             viewerEmail: viewerEmail
         ))
         self.sharerIdentity = sharerIdentity
+        self.onDelete = onDelete
+    }
+
+    private var isOwnPost: Bool {
+        viewModel.share.sharedBy == viewModel.viewerEmail
     }
 
     var body: some View {
@@ -44,6 +60,16 @@ struct ShareCardView: View {
         .sheet(isPresented: $showRateSheet) {
             RateSheet(viewModel: viewModel, isPresented: $showRateSheet)
                 .presentationDetents([.medium])
+        }
+        .confirmationDialog(
+            "Delete this post?",
+            isPresented: $showDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { onDelete?() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This will remove your share from the feed. This can't be undone.")
         }
     }
 
@@ -82,7 +108,28 @@ struct ShareCardView: View {
                 .clipShape(Capsule())
                 .accessibilityLabel("\(sharerIdentity.displayName) rated this \(rating) out of 5")
             }
+
+            if isOwnPost, onDelete != nil {
+                ownPostMenu
+            }
         }
+    }
+
+    private var ownPostMenu: some View {
+        Menu {
+            Button(role: .destructive) {
+                showDeleteConfirm = true
+            } label: {
+                Label("Delete post", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.subheadline)
+                .foregroundStyle(.gray)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel("Post options")
     }
 
     @ViewBuilder

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -9,6 +9,7 @@ struct GroupDetailView: View {
     @State private var viewModel = GroupDetailViewModel()
     @State private var selectedTab: Tab = .tracks
     @State private var showingAddMembers = false
+    @State private var showingAddSong = false
     @State private var showingEditGroup = false
     @State private var showLeaveConfirm = false
     @State private var showDeleteConfirm = false
@@ -67,6 +68,14 @@ struct GroupDetailView: View {
             AddMemberSheet(
                 viewModel: viewModel,
                 onDismiss: { showingAddMembers = false }
+            )
+        }
+        .sheet(isPresented: $showingAddSong, onDismiss: {
+            viewModel.resetSongSearch()
+        }) {
+            AddSongSheet(
+                viewModel: viewModel,
+                onDismiss: { showingAddSong = false }
             )
         }
         .sheet(isPresented: $showingEditGroup) {
@@ -162,48 +171,40 @@ struct GroupDetailView: View {
 
     private var tracksSection: some View {
         VStack(spacing: 0) {
-            addSongBar
+            addSongButton
 
             if viewModel.isLoading && viewModel.tracks.isEmpty {
                 XomifyLoaderPulse()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if viewModel.tracks.isEmpty {
                 emptyTab(icon: "music.note", title: "No tracks yet",
-                         message: "Paste a Spotify URL above to add one.")
+                         message: "Tap Add song to search Spotify.")
             } else {
                 tracksList
             }
         }
     }
 
-    private var addSongBar: some View {
-        HStack(spacing: 8) {
-            TextField("Paste Spotify track URL", text: $viewModel.addSongUrl)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .padding()
-                .background(Color.white.opacity(0.05))
-                .clipShape(.rect(cornerRadius: 10))
-                .foregroundStyle(.white)
-
-            Button {
-                Task { await viewModel.addSongByUrl() }
-            } label: {
-                if viewModel.isAddingSong {
-                    ProgressView().tint(.white)
-                        .frame(width: 44, height: 44)
-                } else {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(Color.xomifyGreen)
-                        .frame(width: 44, height: 44)
-                }
+    private var addSongButton: some View {
+        Button {
+            showingAddSong = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                Text("Add song")
             }
-            .disabled(viewModel.isAddingSong || viewModel.addSongUrl.isEmpty)
-            .accessibilityLabel("Add track from URL")
+            .font(.subheadline)
+            .fontWeight(.semibold)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.vertical, 10)
+            .background(LinearGradient.xomifyGradient)
+            .foregroundStyle(.white)
+            .clipShape(.rect(cornerRadius: 22))
         }
         .padding(.horizontal)
         .padding(.bottom, 8)
+        .accessibilityLabel("Add song")
+        .accessibilityHint("Opens search to add a Spotify track to this group")
     }
 
     private var tracksList: some View {

--- a/Xomify-iOS/Views/Groups/AddSongSheet.swift
+++ b/Xomify-iOS/Views/Groups/AddSongSheet.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+
+/// Sheet presented from `GroupDetailView` to add a track to the group.
+/// Primary path: search Spotify and tap a result to add. Secondary (opt-in)
+/// fallback: paste a Spotify URL — kept behind a disclosure so it doesn't
+/// clutter the primary UX.
+struct AddSongSheet: View {
+
+    @Bindable var viewModel: GroupDetailViewModel
+    let onDismiss: () -> Void
+
+    @State private var showByUrl = false
+    @State private var searchDebounceTask: Task<Void, Never>?
+
+    /// Track IDs already on the group, to dim "already added" results.
+    private var existingTrackIds: Set<String> {
+        Set(viewModel.tracks.compactMap { $0.trackId })
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+
+                VStack(spacing: 12) {
+                    searchField
+                    resultsArea
+                    urlFallback
+                }
+                .padding(.top, 8)
+            }
+            .navigationTitle("Add Song")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { onDismiss() }
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .tint(Color.xomifyGreen)
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.gray)
+            TextField("Search tracks on Spotify", text: $viewModel.songSearchQuery)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .foregroundStyle(.white)
+                .onChange(of: viewModel.songSearchQuery) { _, _ in
+                    scheduleSearch()
+                }
+
+            if !viewModel.songSearchQuery.isEmpty {
+                Button {
+                    viewModel.songSearchQuery = ""
+                    viewModel.songSearchResults = []
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.gray)
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color.white.opacity(0.06))
+        .clipShape(.rect(cornerRadius: 10))
+        .padding(.horizontal)
+    }
+
+    @ViewBuilder
+    private var resultsArea: some View {
+        if viewModel.isSearchingSongs && viewModel.songSearchResults.isEmpty {
+            VStack { XomifyLoaderPulse() }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.songSearchError {
+            errorState(error)
+        } else if viewModel.songSearchQuery.isEmpty {
+            emptyPrompt
+        } else if viewModel.songSearchResults.isEmpty {
+            emptyResults
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(viewModel.songSearchResults) { track in
+                        resultRow(track)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    private func resultRow(_ track: SpotifyTrack) -> some View {
+        let alreadyAdded = existingTrackIds.contains(track.id)
+        let isAdding = viewModel.addingTrackIds.contains(track.id)
+
+        return HStack(spacing: 12) {
+            AsyncImage(url: track.imageUrl) { image in
+                image.resizable()
+            } placeholder: {
+                Rectangle().fill(Color.gray.opacity(0.3))
+            }
+            .frame(width: 48, height: 48)
+            .clipShape(.rect(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(track.artistNames)
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            if alreadyAdded {
+                Label("Added", systemImage: "checkmark")
+                    .labelStyle(.iconOnly)
+                    .foregroundStyle(Color.xomifyGreen)
+                    .font(.title3)
+                    .frame(width: 44, height: 44)
+                    .accessibilityLabel("Already in group")
+            } else {
+                Button {
+                    Task { await viewModel.addSong(track) }
+                } label: {
+                    if isAdding {
+                        ProgressView().tint(.white)
+                            .frame(width: 44, height: 44)
+                    } else {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.xomifyGreen)
+                            .frame(width: 44, height: 44)
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(isAdding)
+                .accessibilityLabel("Add \(track.name)")
+            }
+        }
+        .padding(10)
+        .background(Color.xomifyCard)
+        .clipShape(.rect(cornerRadius: 10))
+        .opacity(alreadyAdded ? 0.6 : 1)
+    }
+
+    // MARK: - URL fallback
+
+    @ViewBuilder
+    private var urlFallback: some View {
+        VStack(spacing: 8) {
+            Button {
+                withAnimation { showByUrl.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: showByUrl ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                    Text("Paste a Spotify URL instead")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+                .foregroundStyle(.gray)
+                .frame(minHeight: 44)
+            }
+            .buttonStyle(.plain)
+
+            if showByUrl {
+                HStack(spacing: 8) {
+                    TextField("https://open.spotify.com/track/...", text: $viewModel.addSongUrl)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .padding()
+                        .background(Color.white.opacity(0.05))
+                        .clipShape(.rect(cornerRadius: 10))
+                        .foregroundStyle(.white)
+
+                    Button {
+                        Task {
+                            await viewModel.addSongByUrl()
+                            if viewModel.errorMessage == nil {
+                                onDismiss()
+                            }
+                        }
+                    } label: {
+                        if viewModel.isAddingSong {
+                            ProgressView().tint(.white)
+                                .frame(width: 44, height: 44)
+                        } else {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.title2)
+                                .foregroundStyle(Color.xomifyGreen)
+                                .frame(width: 44, height: 44)
+                        }
+                    }
+                    .disabled(viewModel.isAddingSong || viewModel.addSongUrl.isEmpty)
+                    .accessibilityLabel("Add track from URL")
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Empty / error states
+
+    private var emptyPrompt: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 36))
+                .foregroundStyle(.gray.opacity(0.6))
+            Text("Search Spotify")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Type a track or artist to start.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyResults: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "music.note")
+                .font(.system(size: 36))
+                .foregroundStyle(.gray.opacity(0.6))
+            Text("No matches")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Try a different search term.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange.opacity(0.8))
+            Text("Search failed")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Debounce
+
+    /// Debounce typed input so we don't hammer Spotify on every keystroke.
+    private func scheduleSearch() {
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            if Task.isCancelled { return }
+            await viewModel.searchSongs()
+        }
+    }
+}

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
@@ -43,7 +43,10 @@ struct ProfileSharesTab: View {
                 ShareCardView(
                     share: share,
                     viewerEmail: viewerEmail,
-                    sharerIdentity: sharerIdentity
+                    sharerIdentity: sharerIdentity,
+                    onDelete: context.isSelf ? {
+                        Task { await viewModel.deleteShare(share) }
+                    } : nil
                 )
                     .onAppear {
                         if share.id == viewModel.shares.last?.id {


### PR DESCRIPTION
## Summary
- Delete own posts from the Feed and profile Shares tabs via a "..." menu on cards where `sharedBy == viewerEmail`. Optimistic removal with rollback on failure.
- Replace the broken "+" URL-paste bar in the Group detail screen with an Add Song sheet that searches Spotify and adds tracks through the existing `/groups/add-song` endpoint.
- Search results dim + show a checkmark when a track is already in the group; URL-paste is preserved as a secondary disclosure.

## Changes
- New: `Xomify-iOS/Views/Groups/AddSongSheet.swift`
- `XomifyServiceProtocol` now exposes `deleteShare` so Feed tests can mock it.
- `FeedViewModel` + `SharesByUserViewModel` gain `deleteShare(_:)`.
- `ShareCardView` accepts an `onDelete` callback and renders the options menu when the viewer authored the post.
- `GroupDetailViewModel` gains `searchSongs` / `addSong(_:)` / `resetSongSearch` + state.
- `GroupDetailView` swaps `addSongBar` for `addSongButton` → `AddSongSheet`.

## Test plan
- [ ] Open Feed → long-press/tap menu on your own post → Delete → confirm → post vanishes instantly; reopen to confirm server-side delete.
- [ ] Delete fails (airplane mode) → card re-appears and an error banner surfaces.
- [ ] Profile → My Shares → same delete menu works; other user's profile shows no menu.
- [ ] Group detail → Add song → type "Blinding Lights" → tap + → track appears in list.
- [ ] Search a track already in the group → row shows "Added" checkmark, + button hidden.
- [ ] Tap "Paste a Spotify URL instead" disclosure → paste a track URL → adds and closes sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)