### PR TITLE
feat(feed): client-side filters (date, author, unlistened, sort)

### DIFF
--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -33,6 +33,86 @@ enum FeedFilter: Hashable, Sendable {
     }
 }
 
+// MARK: - FeedRefinement
+
+/// Client-side refinement on top of the currently loaded shares. These are
+/// pure filtering + sorting knobs — the backend feed query itself doesn't
+/// change when the user flips them. That's intentional: refinement runs
+/// locally so switching a filter is instant and round-trip free.
+struct FeedRefinement: Equatable, Sendable {
+
+    /// Time window for `sharedAt`. Nothing outside the window renders.
+    enum DateWindow: String, CaseIterable, Identifiable, Sendable {
+        case anytime
+        case today
+        case past7Days
+        case past30Days
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .anytime:     return "Anytime"
+            case .today:       return "Today"
+            case .past7Days:   return "Past 7 days"
+            case .past30Days:  return "Past 30 days"
+            }
+        }
+
+        /// Lower-bound `Date` the window admits; `nil` for `.anytime`.
+        fileprivate func minDate(now: Date = Date()) -> Date? {
+            let cal = Calendar.current
+            switch self {
+            case .anytime:    return nil
+            case .today:      return cal.startOfDay(for: now)
+            case .past7Days:  return cal.date(byAdding: .day, value: -7, to: now)
+            case .past30Days: return cal.date(byAdding: .day, value: -30, to: now)
+            }
+        }
+    }
+
+    enum SortOrder: String, CaseIterable, Identifiable, Sendable {
+        case newest
+        case oldest
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .newest: return "Newest first"
+            case .oldest: return "Oldest first"
+            }
+        }
+    }
+
+    /// Selected authors (emails). Empty set = no author filter.
+    var authors: Set<String> = []
+    var dateWindow: DateWindow = .anytime
+    /// When true, hide shares the viewer has already queued on Spotify.
+    var onlyUnlistened: Bool = false
+    var sortOrder: SortOrder = .newest
+
+    /// True when any non-default refinement is active. Drives the "Filters"
+    /// chip accent so the user can tell at a glance.
+    var isActive: Bool {
+        !authors.isEmpty || dateWindow != .anytime || onlyUnlistened || sortOrder != .newest
+    }
+
+    /// Short summary for the chip label when active.
+    var activeCount: Int {
+        var n = 0
+        if !authors.isEmpty { n += 1 }
+        if dateWindow != .anytime { n += 1 }
+        if onlyUnlistened { n += 1 }
+        if sortOrder != .newest { n += 1 }
+        return n
+    }
+
+    mutating func reset() {
+        self = FeedRefinement()
+    }
+}
+
 // MARK: - SharerIdentity
 
 /// Resolved display name + avatar for a share author. Feed batches these
@@ -64,6 +144,10 @@ final class FeedViewModel {
 
     var selectedFilter: FeedFilter = .friends
     var groups: [XomifyGroup] = []
+
+    /// Client-side refinement (date window, authors, unlistened, sort).
+    /// Bound by the refinement sheet; consumed by `filteredShares`.
+    var refinement: FeedRefinement = FeedRefinement()
 
     /// displayName + avatar keyed by email. Populated on bootstrap from the
     /// viewer's own profile + all accepted friends. Falls back to email when
@@ -310,6 +394,47 @@ final class FeedViewModel {
     func prependShareAndRefresh(_ share: Share) async {
         shares.insert(share, at: 0)
         await refresh()
+    }
+
+    // MARK: - Refinement
+
+    /// Shares after the current refinement (date window, authors,
+    /// unlistened, sort) is applied. The raw `shares` array is preserved
+    /// so pagination continues to work against the full list.
+    var filteredShares: [Share] {
+        let window = refinement.dateWindow.minDate()
+        let authors = refinement.authors
+        let onlyUnlistened = refinement.onlyUnlistened
+
+        var result = shares.filter { share in
+            if !authors.isEmpty, !authors.contains(share.sharedBy) {
+                return false
+            }
+            if onlyUnlistened, share.viewerHasQueued {
+                return false
+            }
+            if let minDate = window, let shareDate = share.sharedAtDate, shareDate < minDate {
+                return false
+            }
+            return true
+        }
+
+        if refinement.sortOrder == .oldest {
+            result.sort { ($0.sharedAtDate ?? .distantPast) < ($1.sharedAtDate ?? .distantPast) }
+        }
+
+        return result
+    }
+
+    /// Distinct authors visible in the currently loaded shares — powers the
+    /// author picker so users only see people who've actually posted.
+    var availableAuthors: [String] {
+        let unique = Set(shares.map { $0.sharedBy })
+        return unique.sorted { a, b in
+            identity(for: a).displayName.localizedCaseInsensitiveCompare(
+                identity(for: b).displayName
+            ) == .orderedAscending
+        }
     }
 
     // MARK: - Share deletion

--- a/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
+++ b/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
@@ -1,0 +1,240 @@
+import SwiftUI
+
+/// Sheet that tunes client-side feed refinement: date window, authors,
+/// unlistened-only, and sort order. All knobs are applied locally — the
+/// backend feed query doesn't re-run when the user changes any of these.
+struct FeedRefinementSheet: View {
+
+    @Bindable var viewModel: FeedViewModel
+    let onDismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        dateSection
+                        authorsSection
+                        unlistenedSection
+                        sortSection
+                    }
+                    .padding()
+                }
+            }
+            .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if viewModel.refinement.isActive {
+                        Button("Clear") {
+                            viewModel.refinement.reset()
+                        }
+                        .foregroundStyle(.white)
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { onDismiss() }
+                        .foregroundStyle(.white)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .tint(Color.xomifyGreen)
+    }
+
+    // MARK: - Date
+
+    private var dateSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Date", icon: "calendar")
+
+            WrappingChipGrid {
+                ForEach(FeedRefinement.DateWindow.allCases) { window in
+                    pillChip(
+                        label: window.label,
+                        selected: viewModel.refinement.dateWindow == window
+                    ) {
+                        viewModel.refinement.dateWindow = window
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Authors
+
+    @ViewBuilder
+    private var authorsSection: some View {
+        let authors = viewModel.availableAuthors
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                sectionHeader("From", icon: "person.2")
+                Spacer()
+                if !viewModel.refinement.authors.isEmpty {
+                    Button("Clear") {
+                        viewModel.refinement.authors = []
+                    }
+                    .font(.caption)
+                    .foregroundStyle(Color.xomifyGreen)
+                }
+            }
+
+            if authors.isEmpty {
+                Text("No authors in the current feed yet.")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+            } else {
+                WrappingChipGrid {
+                    ForEach(authors, id: \.self) { email in
+                        let name = viewModel.identity(for: email).displayName
+                        let selected = viewModel.refinement.authors.contains(email)
+                        pillChip(label: name, selected: selected) {
+                            if selected {
+                                viewModel.refinement.authors.remove(email)
+                            } else {
+                                viewModel.refinement.authors.insert(email)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Unlistened
+
+    private var unlistenedSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Listening status", icon: "headphones")
+            Toggle(isOn: $viewModel.refinement.onlyUnlistened) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Only show posts I haven't queued")
+                        .font(.subheadline)
+                        .foregroundStyle(.white)
+                    Text("Hides anything you've already added to your Spotify queue.")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                }
+            }
+            .tint(Color.xomifyGreen)
+            .padding(12)
+            .background(Color.xomifyCard)
+            .clipShape(.rect(cornerRadius: 10))
+        }
+    }
+
+    // MARK: - Sort
+
+    private var sortSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("Sort", icon: "arrow.up.arrow.down")
+            WrappingChipGrid {
+                ForEach(FeedRefinement.SortOrder.allCases) { order in
+                    pillChip(
+                        label: order.label,
+                        selected: viewModel.refinement.sortOrder == order
+                    ) {
+                        viewModel.refinement.sortOrder = order
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String, icon: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(Color.xomifyGreen)
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(.white)
+        }
+    }
+
+    private func pillChip(label: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.subheadline)
+                .fontWeight(selected ? .semibold : .regular)
+                .foregroundStyle(selected ? Color.black : Color.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .frame(minHeight: 44)
+                .background(selected ? Color.xomifyGreen : Color.xomifyCard)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(Color.white.opacity(selected ? 0 : 0.08), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+}
+
+// MARK: - Wrapping chip grid
+
+/// Minimal flow-layout so chips wrap onto multiple rows in the filter sheet.
+private struct WrappingChipGrid<Content: View>: View {
+
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        ChipFlow { content }
+    }
+}
+
+private struct ChipFlow: Layout {
+
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var maxRowWidth: CGFloat = 0
+
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth && rowWidth > 0 {
+                totalHeight += rowHeight + spacing
+                maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+                rowWidth = 0
+                rowHeight = 0
+            }
+            rowWidth += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        totalHeight += rowHeight
+        maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+        return CGSize(width: maxRowWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxWidth = bounds.width
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX && x > bounds.minX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            view.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: .unspecified)
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+            _ = maxWidth
+        }
+    }
+}

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -5,6 +5,7 @@ struct FeedView: View {
 
     @Environment(NavigationStore.self) private var navStore
     @State private var viewModel = FeedViewModel()
+    @State private var showingRefinement = false
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -17,7 +18,10 @@ struct FeedView: View {
                     systemImage: "sparkles"
                 )
 
-                FilterChipsView(viewModel: viewModel)
+                FilterChipsView(
+                    viewModel: viewModel,
+                    onTapRefine: { showingRefinement = true }
+                )
 
                 mainContent
             }
@@ -45,6 +49,10 @@ struct FeedView: View {
                 Task { await viewModel.prependShareAndRefresh(share) }
             }
         }
+        .sheet(isPresented: $showingRefinement) {
+            FeedRefinementSheet(viewModel: viewModel) { showingRefinement = false }
+                .presentationDetents([.medium, .large])
+        }
     }
 
     // MARK: - Content
@@ -63,15 +71,48 @@ struct FeedView: View {
             .overlay(alignment: .bottomTrailing) {
                 ComposerFAB { openComposer() }
             }
+        } else if viewModel.filteredShares.isEmpty {
+            filteredEmptyState
         } else {
             feedList
         }
     }
 
+    private var filteredEmptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 40))
+                .foregroundStyle(Color.xomifyPurple.opacity(0.7))
+                .accessibilityHidden(true)
+            Text("No posts match your filters")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text("Try widening the date window or clearing authors.")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button {
+                viewModel.refinement.reset()
+            } label: {
+                Text("Clear filters")
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .frame(minHeight: 44)
+                    .background(Color.white.opacity(0.08))
+                    .foregroundStyle(.white)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var feedList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                ForEach(viewModel.shares) { share in
+                ForEach(viewModel.filteredShares) { share in
                     ShareCardView(
                         share: share,
                         viewerEmail: viewModel.userEmail,

--- a/Xomify-iOS/Views/Feed/FilterChipsView.swift
+++ b/Xomify-iOS/Views/Feed/FilterChipsView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
-/// Horizontal scroll of filter chips: `All` / `Friends only` / per-group.
-/// Selection is driven by `FeedViewModel.selectedFilter`.
+/// Horizontal scroll of filter chips: `Friends` / per-group / per-refinement.
+/// Backend-scope selection is driven by `FeedViewModel.selectedFilter`;
+/// the "Filters" chip opens a sheet that tunes client-side refinement.
 struct FilterChipsView: View {
 
     @Bindable var viewModel: FeedViewModel
+    let onTapRefine: () -> Void
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -14,6 +16,13 @@ struct FilterChipsView: View {
                 ForEach(viewModel.groups) { group in
                     chip(for: .group(group))
                 }
+
+                Divider()
+                    .frame(height: 18)
+                    .overlay(Color.white.opacity(0.1))
+                    .padding(.horizontal, 2)
+
+                refineChip
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -21,7 +30,7 @@ struct FilterChipsView: View {
         .background(Color.xomifyDark)
     }
 
-    // MARK: - Chip
+    // MARK: - Backend-scope chip
 
     private func chip(for filter: FeedFilter) -> some View {
         let isSelected = viewModel.selectedFilter == filter
@@ -46,5 +55,37 @@ struct FilterChipsView: View {
         .buttonStyle(.plain)
         .accessibilityLabel(filter.label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    // MARK: - Refine chip
+
+    private var refineChip: some View {
+        let active = viewModel.refinement.isActive
+        let count = viewModel.refinement.activeCount
+
+        return Button {
+            onTapRefine()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "line.3.horizontal.decrease.circle\(active ? ".fill" : "")")
+                    .font(.caption)
+                Text(active ? "Filters (\(count))" : "Filters")
+                    .font(.subheadline)
+                    .fontWeight(active ? .semibold : .regular)
+            }
+            .foregroundStyle(active ? Color.black : Color.white)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .frame(minHeight: 32)
+            .background(active ? Color.xomifyGreen : Color.xomifyCard)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(Color.white.opacity(active ? 0 : 0.08), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(active ? "Filters, \(count) active" : "Filters")
+        .accessibilityHint("Opens filter options")
     }
 }


### PR DESCRIPTION
## Summary
- Adds a new "Filters" chip at the end of the feed chip row that opens a sheet with four local filters.
- All four run client-side on the already-loaded shares — the backend feed query is unchanged, so toggling filters is instant and round-trip free.

## Filters
- **Date window** — Anytime / Today / Past 7 days / Past 30 days.
- **Authors** — multi-select, scoped to authors present in the currently loaded feed (resolved to display names via `FeedViewModel.identity(for:)`).
- **Only unlistened** — hides shares where `viewerHasQueued == true`.
- **Sort** — Newest first (default) or Oldest first.

The Filters chip shows an active count badge when any non-default filter is set, and the feed renders a "No posts match your filters" empty state with a Clear button when the filter hides every loaded share.

## Changes
- `FeedViewModel`: new `FeedRefinement` struct + `refinement` state + `filteredShares` computed view + `availableAuthors`.
- `FeedView`: plumbs `showingRefinement` + renders the refinement sheet; feed list now iterates `filteredShares`.
- `FilterChipsView`: new trailing "Filters" chip with active count badge.
- New: `FeedRefinementSheet.swift` with a small custom flow layout for wrapping chip rows.

## Test plan
- [ ] Open Feed → tap Filters → flip Date to "Today" → list narrows instantly; chip reads "Filters (1)".
- [ ] Select one author → only their posts render.
- [ ] Toggle "Only unlistened" → anything you've queued disappears.
- [ ] Switch sort to "Oldest first" → order inverts.
- [ ] Pick filters that match nothing → empty state with Clear filters; Clear restores list.
- [ ] Switch backend filter (Friends → a group) while refinement is active → refinement persists across the switch.
- [ ] Pull-to-refresh while a filter is active → list re-populates and re-applies the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)