### PR TITLE
fix(feed): tap share card opens detail reliably

### DIFF
--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -6,6 +6,7 @@ struct FeedView: View {
     @Environment(NavigationStore.self) private var navStore
     @State private var viewModel = FeedViewModel()
     @State private var showingRefinement = false
+    @State private var selectedShare: Share?
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -113,24 +114,18 @@ struct FeedView: View {
         ScrollView {
             LazyVStack(spacing: 12) {
                 ForEach(viewModel.filteredShares) { share in
-                    NavigationLink {
-                        ShareDetailView(
-                            share: share,
-                            viewerEmail: viewModel.userEmail,
-                            sharerIdentity: viewModel.identity(for: share.sharedBy)
-                        )
-                    } label: {
-                        ShareCardView(
-                            share: share,
-                            viewerEmail: viewModel.userEmail,
-                            sharerIdentity: viewModel.identity(for: share.sharedBy),
-                            onDelete: {
-                                Task { await viewModel.deleteShare(share) }
-                            }
-                        )
-                        .padding(.horizontal, 16)
-                    }
-                    .buttonStyle(.plain)
+                    ShareCardView(
+                        share: share,
+                        viewerEmail: viewModel.userEmail,
+                        sharerIdentity: viewModel.identity(for: share.sharedBy),
+                        onDelete: {
+                            Task { await viewModel.deleteShare(share) }
+                        },
+                        onOpenDetail: {
+                            selectedShare = share
+                        }
+                    )
+                    .padding(.horizontal, 16)
                     .onAppear {
                         if share.id == viewModel.shares.last?.id {
                             Task { await viewModel.loadMore() }
@@ -146,6 +141,13 @@ struct FeedView: View {
                 Color.clear.frame(height: 80) // bottom inset for FAB
             }
             .padding(.top, 8)
+        }
+        .navigationDestination(item: $selectedShare) { share in
+            ShareDetailView(
+                share: share,
+                viewerEmail: viewModel.userEmail,
+                sharerIdentity: viewModel.identity(for: share.sharedBy)
+            )
         }
     }
 

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -18,11 +18,19 @@ struct ShareCardView: View {
     /// the delete menu entry is hidden.
     let onDelete: (() -> Void)?
 
+    /// Optional callback fired when the viewer taps the card body (avatar,
+    /// text, or album art — but NOT the action buttons). Wrapping the whole
+    /// card in a NavigationLink swallows taps on the inner action buttons,
+    /// so navigation is wired through this callback and the caller handles
+    /// the push via `navigationDestination(item:)`.
+    let onOpenDetail: (() -> Void)?
+
     init(
         share: Share,
         viewerEmail: String,
         sharerIdentity: SharerIdentity,
-        onDelete: (() -> Void)? = nil
+        onDelete: (() -> Void)? = nil,
+        onOpenDetail: (() -> Void)? = nil
     ) {
         _viewModel = State(initialValue: ShareCardViewModel(
             share: share,
@@ -30,6 +38,7 @@ struct ShareCardView: View {
         ))
         self.sharerIdentity = sharerIdentity
         self.onDelete = onDelete
+        self.onOpenDetail = onOpenDetail
     }
 
     private var isOwnPost: Bool {
@@ -38,16 +47,11 @@ struct ShareCardView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            sharerRow
-            trackBlock
-            if let caption = viewModel.share.caption, !caption.isEmpty {
-                Text(caption)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.white.opacity(0.9))
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            if viewModel.share.moodTag != nil || !(viewModel.share.genreTags ?? []).isEmpty {
-                tagsRow
+            HStack(alignment: .top, spacing: 8) {
+                detailTapZone
+                if isOwnPost, onDelete != nil {
+                    ownPostMenu
+                }
             }
             actionRow
             if let error = viewModel.queueError {
@@ -70,6 +74,41 @@ struct ShareCardView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This will remove your share from the feed. This can't be undone.")
+        }
+    }
+
+    // MARK: - Tap zone
+
+    /// Groups the non-interactive parts of the card (sharer, track, caption,
+    /// tags) into a single accessible button so tapping the body opens the
+    /// detail view. The action row below stays outside this button, so
+    /// queue/rate/delete still fire normally.
+    @ViewBuilder
+    private var detailTapZone: some View {
+        let content = VStack(alignment: .leading, spacing: 12) {
+            sharerRow
+            trackBlock
+            if let caption = viewModel.share.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.white.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if viewModel.share.moodTag != nil || !(viewModel.share.genreTags ?? []).isEmpty {
+                tagsRow
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+
+        if let onOpenDetail {
+            Button(action: onOpenDetail) {
+                content
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("Double-tap to open post details")
+        } else {
+            content
         }
     }
 
@@ -107,10 +146,6 @@ struct ShareCardView: View {
                 .background(Color.white.opacity(0.08))
                 .clipShape(Capsule())
                 .accessibilityLabel("\(sharerIdentity.displayName) rated this \(rating) out of 5")
-            }
-
-            if isOwnPost, onDelete != nil {
-                ownPostMenu
             }
         }
     }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileSharesTab.swift
@@ -14,6 +14,8 @@ struct ProfileSharesTab: View {
     /// card instead of a per-email lookup.
     let sharerIdentity: SharerIdentity
 
+    @State private var selectedShare: Share?
+
     var body: some View {
         Group {
             if viewModel.isRefreshing && viewModel.shares.isEmpty {
@@ -40,23 +42,17 @@ struct ProfileSharesTab: View {
     private var sharesList: some View {
         LazyVStack(spacing: 12) {
             ForEach(viewModel.shares) { share in
-                NavigationLink {
-                    ShareDetailView(
-                        share: share,
-                        viewerEmail: viewerEmail,
-                        sharerIdentity: sharerIdentity
-                    )
-                } label: {
-                    ShareCardView(
-                        share: share,
-                        viewerEmail: viewerEmail,
-                        sharerIdentity: sharerIdentity,
-                        onDelete: context.isSelf ? {
-                            Task { await viewModel.deleteShare(share) }
-                        } : nil
-                    )
-                }
-                .buttonStyle(.plain)
+                ShareCardView(
+                    share: share,
+                    viewerEmail: viewerEmail,
+                    sharerIdentity: sharerIdentity,
+                    onDelete: context.isSelf ? {
+                        Task { await viewModel.deleteShare(share) }
+                    } : nil,
+                    onOpenDetail: {
+                        selectedShare = share
+                    }
+                )
                 .onAppear {
                     if share.id == viewModel.shares.last?.id {
                         Task { await viewModel.loadMore() }
@@ -70,6 +66,13 @@ struct ProfileSharesTab: View {
             }
         }
         .padding(.horizontal)
+        .navigationDestination(item: $selectedShare) { share in
+            ShareDetailView(
+                share: share,
+                viewerEmail: viewerEmail,
+                sharerIdentity: sharerIdentity
+            )
+        }
     }
 
     // MARK: - States


### PR DESCRIPTION
## Summary
- Wrapping each card in a NavigationLink (PR #65) swallowed taps on the inner queue/rate/delete buttons and never pushed the detail view
- Swap to `onOpenDetail` callback + `.navigationDestination(item:)` — only the non-interactive body (sharer, track, caption, tags) fires the callback; action buttons keep working
- Mirror the change in `ProfileSharesTab`

## Test plan
- [x] Build succeeds (`xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build`)
- [ ] Feed: tap the card body → pushes `ShareDetailView`
- [ ] Feed: tap Queue / Rate → still works, does not push
- [ ] Profile Shares tab: tap a post → pushes detail