### PR TITLE
feat(composer): multi-target shares (public + groups)

### DIFF
--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -188,6 +188,11 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
     let viewerRating: Int?
     let sharerRating: Int?
 
+    // Target audience (xomify-backend#138). Legacy rows omit both fields and
+    // are treated as public shares with no group targets.
+    let groupIds: [String]
+    let isPublic: Bool
+
     var id: String { shareId }
 
     /// Parse sharedAt ("2025-04-17 14:30:00" UTC) into a Date. Falls back to ISO8601.
@@ -250,6 +255,8 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         viewerHasQueued = try c.decodeIfPresent(Bool.self, forKey: .viewerHasQueued) ?? false
         viewerRating    = try c.decodeIfPresent(Int.self, forKey: .viewerRating)
         sharerRating    = try c.decodeIfPresent(Int.self, forKey: .sharerRating)
+        groupIds        = try c.decodeIfPresent([String].self, forKey: .groupIds) ?? []
+        isPublic        = try c.decodeIfPresent(Bool.self, forKey: .isPublic) ?? true
     }
 
     private enum FallbackAuthorKey: String, CodingKey {
@@ -274,7 +281,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         ratedCount: Int = 0,
         viewerHasQueued: Bool = false,
         viewerRating: Int? = nil,
-        sharerRating: Int? = nil
+        sharerRating: Int? = nil,
+        groupIds: [String] = [],
+        isPublic: Bool = true
     ) {
         self.shareId = shareId
         self.sharedBy = sharedBy
@@ -293,6 +302,8 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         self.viewerHasQueued = viewerHasQueued
         self.viewerRating = viewerRating
         self.sharerRating = sharerRating
+        self.groupIds = groupIds
+        self.isPublic = isPublic
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -300,6 +311,8 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         case trackId, trackUri, trackName, artistName, albumName, albumArtUrl
         case caption, moodTag, genreTags
         case queuedCount, ratedCount, viewerHasQueued, viewerRating, sharerRating
+        case groupIds
+        case isPublic = "public"
     }
 }
 

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -75,6 +75,10 @@ actor XomifyService {
     // feed renders without a follow-up Spotify fetch per card.
 
     /// Create a new share in the feed. Track fields are denormalized.
+    ///
+    /// `groupIds` + `isPublic` drive multi-target routing (xomify-backend#138).
+    /// Defaults preserve legacy behavior: public-only, no group targets.
+    /// Backend rejects `public=false` with empty `groupIds`.
     @discardableResult
     func createShare(
         email: String,
@@ -86,7 +90,9 @@ actor XomifyService {
         albumArtUrl: String? = nil,
         caption: String? = nil,
         moodTag: MoodTag? = nil,
-        genreTags: [String]? = nil
+        genreTags: [String]? = nil,
+        groupIds: [String]? = nil,
+        isPublic: Bool? = nil
     ) async throws -> ShareCreateResponse {
         var body: [String: Any] = [
             "email": email,
@@ -100,6 +106,8 @@ actor XomifyService {
         if let caption = caption, !caption.isEmpty { body["caption"] = caption }
         if let moodTag = moodTag { body["moodTag"] = moodTag.rawValue }
         if let genreTags = genreTags, !genreTags.isEmpty { body["genreTags"] = genreTags }
+        if let groupIds = groupIds, !groupIds.isEmpty { body["groupIds"] = groupIds }
+        if let isPublic = isPublic { body["public"] = isPublic }
 
         return try await network.xomifyPost("/shares/create", body: body)
     }

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -20,7 +20,9 @@ protocol XomifyServiceProtocol: Sendable {
         albumArtUrl: String?,
         caption: String?,
         moodTag: MoodTag?,
-        genreTags: [String]?
+        genreTags: [String]?,
+        groupIds: [String]?,
+        isPublic: Bool?
     ) async throws -> ShareCreateResponse
 
     func getFeed(

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -1,29 +1,23 @@
 import Foundation
 
-// MARK: - Composer Audience
+// MARK: - Composer Targets
+//
+// Multi-target routing (xomify-backend#138). A share can hit the public
+// friends feed, one-or-more groups, or both. Backend rejects
+// `public=false` with no groups.
 
-/// Audience selection shown in the composer. Backend `shares_create` currently
-/// accepts no audience scoping at write time; we ship the picker anyway so the
-/// UI is ready when the backend splits by audience.
-enum ComposerAudience: Hashable, Sendable {
-    case all
-    case friendsOnly
-    case group(XomifyGroup)
+/// Validation state for the composer's target selection. Kept as a small
+/// enum so the submit button can disable + show an inline hint without the
+/// view duplicating the check.
+enum ComposerTargetState: Equatable {
+    case ok
+    case noTargets  // public off AND no groups → backend would 400
 
-    var label: String {
+    var hint: String? {
         switch self {
-        case .all:               return "Everyone"
-        case .friendsOnly:       return "Friends only"
-        case .group(let group):  return group.displayName
+        case .ok:         return nil
+        case .noTargets:  return "Pick at least one target."
         }
-    }
-
-    /// For future wire-parity. Currently unused (the backend ignores audience
-    /// on write and enforces it at read time via the friend-graph + group
-    /// filter in `shares_feed`).
-    var groupId: String? {
-        if case .group(let g) = self { return g.groupId }
-        return nil
     }
 }
 
@@ -64,7 +58,11 @@ final class ShareComposerViewModel {
     var caption: String = ""
     var selectedMood: MoodTag?
     var selectedGenres: [String] = []
-    var selectedAudience: ComposerAudience = .all
+    /// Whether to publish to the public friends feed. Defaults to true —
+    /// matches the legacy single-target behavior.
+    var shareToPublic: Bool = true
+    /// Group ids the user has picked as additional (or exclusive) targets.
+    var selectedGroupIds: Set<String> = []
     var availableGroups: [XomifyGroup] = []
 
     // MARK: - Submit state
@@ -126,11 +124,30 @@ final class ShareComposerViewModel {
         selectedGenres.count <= Self.maxGenreTags
     }
 
+    /// Backend rejects `public=false` with no groupIds — catch it client-side
+    /// so the Post button can stay disabled instead of firing a 400.
+    var targetState: ComposerTargetState {
+        if !shareToPublic && selectedGroupIds.isEmpty { return .noTargets }
+        return .ok
+    }
+
     var canSubmit: Bool {
         selectedTrack != nil
             && isCaptionValid
             && isGenreCountValid
+            && targetState == .ok
             && !isSubmitting
+    }
+
+    /// User-visible summary of the target selection — drives the small
+    /// subtitle under the Targets section header.
+    var targetSummary: String {
+        switch (shareToPublic, selectedGroupIds.count) {
+        case (true, 0):      return "Friends feed"
+        case (true, let n):  return "Friends feed + \(n) group\(n == 1 ? "" : "s")"
+        case (false, 0):     return "No targets"
+        case (false, let n): return "\(n) group\(n == 1 ? "" : "s")"
+        }
     }
 
     // MARK: - Search
@@ -187,6 +204,15 @@ final class ShareComposerViewModel {
         selectedTrack = nil
     }
 
+    /// Toggle membership of a group in the target set.
+    func toggleGroup(_ groupId: String) {
+        if selectedGroupIds.contains(groupId) {
+            selectedGroupIds.remove(groupId)
+        } else {
+            selectedGroupIds.insert(groupId)
+        }
+    }
+
     /// Toggle a genre tag. Refuses to add a 4th tag.
     func toggleGenre(_ tag: String) {
         let normalized = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -223,6 +249,8 @@ final class ShareComposerViewModel {
         let trimmedCaption = caption.trimmingCharacters(in: .whitespacesAndNewlines)
         let capturedCaption: String? = trimmedCaption.isEmpty ? nil : trimmedCaption
         let capturedGenres: [String]? = selectedGenres.isEmpty ? nil : selectedGenres
+        let capturedGroupIds: [String] = Array(selectedGroupIds)
+        let capturedIsPublic: Bool = shareToPublic
 
         do {
             let response = try await xomifyService.createShare(
@@ -235,7 +263,9 @@ final class ShareComposerViewModel {
                 albumArtUrl: track.album?.imageUrl?.absoluteString,
                 caption: capturedCaption,
                 moodTag: selectedMood,
-                genreTags: capturedGenres
+                genreTags: capturedGenres,
+                groupIds: capturedGroupIds.isEmpty ? nil : capturedGroupIds,
+                isPublic: capturedIsPublic
             )
 
             // Value-moment trigger for the APNs permission prompt — fire-and-forget.
@@ -266,7 +296,9 @@ final class ShareComposerViewModel {
                 ratedCount: 0,
                 viewerHasQueued: false,
                 viewerRating: nil,
-                sharerRating: nil
+                sharerRating: nil,
+                groupIds: capturedGroupIds,
+                isPublic: capturedIsPublic
             )
         } catch {
             submitError = error.localizedDescription

--- a/Xomify-iOS/Views/Feed/ShareComposerView.swift
+++ b/Xomify-iOS/Views/Feed/ShareComposerView.swift
@@ -22,7 +22,7 @@ struct ShareComposerView: View {
                         captionSection
                         moodSection
                         genreSection
-                        audienceSection
+                        targetsSection
                     }
 
                     if let error = viewModel.submitError {
@@ -282,48 +282,128 @@ struct ShareComposerView: View {
         .disabled(isAtCap)
     }
 
-    private var audienceSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private var targetsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text("Audience")
+                Text("Post to")
                     .font(.caption)
                     .foregroundStyle(.gray)
                 Spacer()
-                // Cosmetic disclosure — backend doesn't scope by audience at
-                // write time yet (see plan Open Questions).
-                Image(systemName: "info.circle")
+                Text(viewModel.targetSummary)
                     .font(.caption2)
-                    .foregroundStyle(.gray)
-                    .accessibilityLabel("Audience currently shown to anyone with access.")
+                    .foregroundStyle(viewModel.targetState == .ok ? .gray : Color.orange)
             }
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    audienceChip(.all)
-                    audienceChip(.friendsOnly)
+            publicToggleRow
+
+            if viewModel.availableGroups.isEmpty {
+                emptyGroupsRow
+            } else {
+                VStack(spacing: 6) {
                     ForEach(viewModel.availableGroups) { group in
-                        audienceChip(.group(group))
+                        groupToggleRow(group)
                     }
                 }
+            }
+
+            if let hint = viewModel.targetState.hint {
+                Text(hint)
+                    .font(.caption2)
+                    .foregroundStyle(Color.orange)
             }
         }
     }
 
-    private func audienceChip(_ audience: ComposerAudience) -> some View {
-        let isSelected = viewModel.selectedAudience == audience
-        return Button {
-            viewModel.selectedAudience = audience
+    private var publicToggleRow: some View {
+        Button {
+            viewModel.shareToPublic.toggle()
         } label: {
-            Text(audience.label)
-                .font(.subheadline)
-                .foregroundStyle(isSelected ? Color.black : .white)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .frame(minHeight: 44)
-                .background(isSelected ? Color.xomifyGreen : Color.xomifyCard)
-                .clipShape(Capsule())
+            HStack(spacing: 12) {
+                checkbox(isOn: viewModel.shareToPublic)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Friends feed")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                    Text("Anyone who follows you")
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+                }
+                Spacer()
+                Image(systemName: "globe")
+                    .font(.subheadline)
+                    .foregroundStyle(.gray)
+            }
+            .padding(12)
+            .frame(minHeight: 44)
+            .background(Color.xomifyCard)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
+        .accessibilityAddTraits(viewModel.shareToPublic ? .isSelected : [])
+        .accessibilityLabel(viewModel.shareToPublic ? "Friends feed selected" : "Friends feed")
+    }
+
+    private func groupToggleRow(_ group: XomifyGroup) -> some View {
+        let isSelected = viewModel.selectedGroupIds.contains(group.groupId)
+        return Button {
+            viewModel.toggleGroup(group.groupId)
+        } label: {
+            HStack(spacing: 12) {
+                checkbox(isOn: isSelected)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(group.displayName)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    if let memberCount = group.memberCount {
+                        Text("\(memberCount) member\(memberCount == 1 ? "" : "s")")
+                            .font(.caption2)
+                            .foregroundStyle(.gray)
+                    }
+                }
+                Spacer()
+                Image(systemName: "person.3.fill")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+            }
+            .padding(12)
+            .frame(minHeight: 44)
+            .background(Color.xomifyCard)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var emptyGroupsRow: some View {
+        Text("Join a group to post to it here.")
+            .font(.caption)
+            .foregroundStyle(.gray)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.xomifyCard.opacity(0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func checkbox(isOn: Bool) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(isOn ? Color.xomifyGreen : Color.clear)
+                .frame(width: 22, height: 22)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(isOn ? Color.xomifyGreen : Color.white.opacity(0.3), lineWidth: 1.5)
+                )
+            if isOn {
+                Image(systemName: "checkmark")
+                    .font(.caption2)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.black)
+            }
+        }
+        .accessibilityHidden(true)
     }
 
     // MARK: - Submit

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -62,7 +62,8 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     func createShare(
         email: String, trackId: String, trackUri: String, trackName: String,
         artistName: String, albumName: String?, albumArtUrl: String?,
-        caption: String?, moodTag: MoodTag?, genreTags: [String]?
+        caption: String?, moodTag: MoodTag?, genreTags: [String]?,
+        groupIds: [String]?, isPublic: Bool?
     ) async throws -> ShareCreateResponse {
         throw NSError(domain: "mock", code: -1)
     }


### PR DESCRIPTION
## Summary
- Composer now supports sharing to the friends feed, one-or-more groups, or any combination
- Pairs with [xomify-backend#138](https://github.com/Xomware/xomify-backend/pull/138) — `groupIds: []` + `public: Bool` on `/shares/create`
- Client-side gate: Post button disables when user toggles public off and picks zero groups, matching the backend 400 contract

## Changes
- `Share` gains `groupIds` + `isPublic` (decoded with legacy-safe defaults: `[]` / `true`)
- `XomifyService.createShare` + protocol + test mock take optional `groupIds` / `isPublic`
- Replaces `ComposerAudience` single-select chip with `shareToPublic: Bool` + `selectedGroupIds: Set<String>`
- New Targets section UI: checkbox row for "Friends feed" + checkbox row per group

## Test plan
- [x] Build succeeds (`xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build`)
- [ ] Composer → default (public on, no groups) → posts land on friends feed
- [ ] Composer → toggle public off + pick a group → post appears only in that group feed, not friends feed
- [ ] Composer → public on + pick two groups → post in friends feed AND both group feeds
- [ ] Composer → public off + no groups → Post button disabled with hint
- [ ] User with zero groups → sees "Join a group to post to it here." placeholder