### PR TITLE
feat: add comments and reactions to feed posts

### DIFF
--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -193,6 +193,13 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
     let groupIds: [String]
     let isPublic: Bool
 
+    // Comments + emoji reactions (xomify-backend#139). Surfaced by
+    // `/shares/detail`; `/shares/feed` may omit these for now — defaults
+    // keep the row decodable either way.
+    let commentCount: Int
+    let reactionCounts: [String: Int]
+    let viewerReactions: [String]
+
     var id: String { shareId }
 
     /// Parse sharedAt ("2025-04-17 14:30:00" UTC) into a Date. Falls back to ISO8601.
@@ -257,6 +264,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         sharerRating    = try c.decodeIfPresent(Int.self, forKey: .sharerRating)
         groupIds        = try c.decodeIfPresent([String].self, forKey: .groupIds) ?? []
         isPublic        = try c.decodeIfPresent(Bool.self, forKey: .isPublic) ?? true
+        commentCount    = try c.decodeIfPresent(Int.self, forKey: .commentCount) ?? 0
+        reactionCounts  = try c.decodeIfPresent([String: Int].self, forKey: .reactionCounts) ?? [:]
+        viewerReactions = try c.decodeIfPresent([String].self, forKey: .viewerReactions) ?? []
     }
 
     private enum FallbackAuthorKey: String, CodingKey {
@@ -283,7 +293,10 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         viewerRating: Int? = nil,
         sharerRating: Int? = nil,
         groupIds: [String] = [],
-        isPublic: Bool = true
+        isPublic: Bool = true,
+        commentCount: Int = 0,
+        reactionCounts: [String: Int] = [:],
+        viewerReactions: [String] = []
     ) {
         self.shareId = shareId
         self.sharedBy = sharedBy
@@ -304,6 +317,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         self.sharerRating = sharerRating
         self.groupIds = groupIds
         self.isPublic = isPublic
+        self.commentCount = commentCount
+        self.reactionCounts = reactionCounts
+        self.viewerReactions = viewerReactions
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -313,6 +329,42 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         case queuedCount, ratedCount, viewerHasQueued, viewerRating, sharerRating
         case groupIds
         case isPublic = "public"
+        case commentCount, reactionCounts, viewerReactions
+    }
+
+    /// Convenience for optimistic UI patches — produce a new Share with the
+    /// reaction summary swapped out, leaving every other field intact.
+    func withReactionSummary(counts: [String: Int], viewerReactions: [String]) -> Share {
+        Share(
+            shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt,
+            trackId: trackId, trackUri: trackUri, trackName: trackName,
+            artistName: artistName, albumName: albumName, albumArtUrl: albumArtUrl,
+            caption: caption, moodTag: moodTag, genreTags: genreTags,
+            queuedCount: queuedCount, ratedCount: ratedCount,
+            viewerHasQueued: viewerHasQueued, viewerRating: viewerRating,
+            sharerRating: sharerRating,
+            groupIds: groupIds, isPublic: isPublic,
+            commentCount: commentCount,
+            reactionCounts: counts,
+            viewerReactions: viewerReactions
+        )
+    }
+
+    /// Same idea for comment count adjustments.
+    func withCommentCount(_ newCount: Int) -> Share {
+        Share(
+            shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt,
+            trackId: trackId, trackUri: trackUri, trackName: trackName,
+            artistName: artistName, albumName: albumName, albumArtUrl: albumArtUrl,
+            caption: caption, moodTag: moodTag, genreTags: genreTags,
+            queuedCount: queuedCount, ratedCount: ratedCount,
+            viewerHasQueued: viewerHasQueued, viewerRating: viewerRating,
+            sharerRating: sharerRating,
+            groupIds: groupIds, isPublic: isPublic,
+            commentCount: newCount,
+            reactionCounts: reactionCounts,
+            viewerReactions: viewerReactions
+        )
     }
 }
 
@@ -746,4 +798,120 @@ struct ShareDetailResponse: Codable, Sendable {
     let share: Share
     let interactions: [ShareInteractionEntry]
     let friendRatings: [ShareFriendRating]
+}
+
+// MARK: - Reactions
+//
+// Backend contract: xomify-backend#139. Six fixed emoji slugs; per (user,
+// share, slug) toggle. Multiple emoji per user is allowed.
+
+enum ShareReaction: String, Codable, Sendable, CaseIterable, Identifiable {
+    case fire
+    case heart
+    case laugh
+    case mindBlown = "mind_blown"
+    case sad
+    case thumbsUp = "thumbs_up"
+
+    var id: String { rawValue }
+
+    var emoji: String {
+        switch self {
+        case .fire:       return "🔥"
+        case .heart:      return "❤️"
+        case .laugh:      return "😂"
+        case .mindBlown:  return "🤯"
+        case .sad:        return "😢"
+        case .thumbsUp:   return "👍"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .fire:       return "Fire"
+        case .heart:      return "Heart"
+        case .laugh:      return "Laugh"
+        case .mindBlown:  return "Mind blown"
+        case .sad:        return "Sad"
+        case .thumbsUp:   return "Thumbs up"
+        }
+    }
+}
+
+/// Response for POST `/shares/reactions`.
+struct ReactionToggleResponse: Codable, Sendable {
+    let active: Bool
+    let reaction: String
+    let counts: [String: Int]
+    let viewerReactions: [String]
+}
+
+/// Response for GET `/shares/reactions`.
+struct ReactionsListResponse: Codable, Sendable {
+    let counts: [String: Int]
+    let viewerReactions: [String]
+}
+
+// MARK: - Comments
+//
+// Backend contract: xomify-backend#139. POST/GET/DELETE `/shares/comments`.
+
+struct ShareComment: Codable, Sendable, Identifiable, Hashable {
+    let commentId: String
+    let shareId: String
+    let email: String
+    let displayName: String?
+    let avatar: String?
+    let body: String
+    let createdAt: String?
+
+    var id: String { commentId }
+
+    var avatarURL: URL? {
+        guard let s = avatar, !s.isEmpty else { return nil }
+        return URL(string: s)
+    }
+
+    var resolvedName: String {
+        if let n = displayName, !n.isEmpty { return n }
+        return email
+    }
+
+    var createdAtDate: Date? {
+        guard let createdAt else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = iso.date(from: createdAt) { return d }
+        iso.formatOptions = [.withInternetDateTime]
+        if let d = iso.date(from: createdAt) { return d }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.date(from: createdAt)
+    }
+
+    var relativeTime: String {
+        guard let date = createdAtDate else { return "" }
+        let interval = Date().timeIntervalSince(date)
+        if interval < 60 { return "just now" }
+        if interval < 3_600 { return "\(Int(interval / 60))m ago" }
+        if interval < 86_400 { return "\(Int(interval / 3_600))h ago" }
+        if interval < 604_800 { return "\(Int(interval / 86_400))d ago" }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+/// Response for GET `/shares/comments`.
+struct CommentsListResponse: Codable, Sendable {
+    let comments: [ShareComment]
+    let nextBefore: String?
+}
+
+/// Response for DELETE `/shares/comments`.
+struct CommentDeleteResponse: Codable, Sendable {
+    let deleted: Bool
+    let commentId: String
 }

--- a/Xomify-iOS/Services/NetworkService.swift
+++ b/Xomify-iOS/Services/NetworkService.swift
@@ -264,6 +264,25 @@ actor NetworkService {
         return try await performXomifyRequest(request)
     }
 
+    /// DELETE with a JSON body. Some newer endpoints (e.g. `/shares/comments`)
+    /// parse identifiers from the body so the path stays clean. URLSession
+    /// happily sends a body on DELETE — API Gateway forwards it through.
+    func xomifyDelete<T: Decodable>(_ endpoint: String, body: [String: Any]) async throws -> T {
+        let config = await getXomifyConfig()
+
+        let url = URL(string: "\(config.baseUrl)\(endpoint)")!
+
+        print("🌐 XomifyAPI DELETE: \(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(config.token, forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        return try await performXomifyRequest(request, allowEmpty: true)
+    }
+
     /// DELETE request to Xomify API. Backend DELETE handlers read
     /// `queryStringParameters`, not a JSON body — pass identifiers via
     /// `queryParams`. Most DELETE endpoints return `204 No Content`, so

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -467,6 +467,94 @@ actor XomifyService {
         ])
     }
 
+    // MARK: - Social — Comments (xomify-backend#139)
+    //
+    // The deployed paths are verb-disambiguated (`/shares/comments-create`
+    // etc.) because the `api-gateway-service` Terraform module keys API GW
+    // resources by `path_part` and doesn't share a node across HTTP verbs
+    // yet. xomify-infrastructure#72 has the follow-up to collapse them into
+    // RESTful `/shares/comments` later — when that lands, just rename here.
+
+    /// Post a new comment on a share. Backend trims + caps at 500 chars and
+    /// rejects whitespace-only bodies. Returns the persisted, profile-hydrated
+    /// row so the UI can render it without a follow-up fetch.
+    @discardableResult
+    func createComment(
+        email: String,
+        shareId: String,
+        body: String
+    ) async throws -> ShareComment {
+        try await network.xomifyPost("/shares/comments-create", body: [
+            "email": email,
+            "shareId": shareId,
+            "body": body
+        ])
+    }
+
+    /// Page through the comment thread on a share. Newest first. `before`
+    /// is the `createdAt` cursor from the previous page; nil for the first
+    /// page. `limit` is capped at 100 server-side.
+    func listComments(
+        email: String,
+        shareId: String,
+        limit: Int = 20,
+        before: String? = nil
+    ) async throws -> CommentsListResponse {
+        var params: [String: String] = [
+            "email": email,
+            "shareId": shareId,
+            "limit": String(limit)
+        ]
+        if let before = before { params["before"] = before }
+        return try await network.xomifyGet("/shares/comments-list", queryParams: params)
+    }
+
+    /// Delete a single comment. Backend allows the comment author OR the
+    /// share author to delete; everyone else gets 403.
+    @discardableResult
+    func deleteComment(
+        email: String,
+        shareId: String,
+        commentId: String
+    ) async throws -> CommentDeleteResponse {
+        try await network.xomifyDelete("/shares/comments-delete", body: [
+            "email": email,
+            "shareId": shareId,
+            "commentId": commentId
+        ])
+    }
+
+    // MARK: - Social — Reactions (xomify-backend#139)
+    //
+    // Distinct from `/shares/react` (Spotify queued/rated). These are emoji
+    // reactions: fire / heart / laugh / mind_blown / sad / thumbs_up.
+
+    /// Toggle one reaction. If active for (viewer, share, slug) it's removed,
+    /// otherwise added. Multiple slugs per viewer per share is allowed.
+    @discardableResult
+    func toggleReaction(
+        email: String,
+        shareId: String,
+        reaction: ShareReaction
+    ) async throws -> ReactionToggleResponse {
+        try await network.xomifyPost("/shares/reactions-toggle", body: [
+            "email": email,
+            "shareId": shareId,
+            "reaction": reaction.rawValue
+        ])
+    }
+
+    /// Read-only fetch of the full reaction summary for a share.
+    func listReactions(
+        email: String,
+        shareId: String
+    ) async throws -> ReactionsListResponse {
+        try await network.xomifyGet("/shares/reactions-list", queryParams: [
+            "email": email,
+            "shareId": shareId
+        ])
+    }
+
     // MARK: - Ratings
 
     /// Publish (create or update) a rating for a track. Rating is 1-5.

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -83,6 +83,38 @@ protocol XomifyServiceProtocol: Sendable {
     /// Full friends payload for the caller. Used by the self-profile header
     /// (friend count) and the Friends drawer.
     func getAllFriends(email: String) async throws -> FriendsAllResponse
+
+    // MARK: - Comments + Reactions (xomify-backend#139)
+
+    func createComment(
+        email: String,
+        shareId: String,
+        body: String
+    ) async throws -> ShareComment
+
+    func listComments(
+        email: String,
+        shareId: String,
+        limit: Int,
+        before: String?
+    ) async throws -> CommentsListResponse
+
+    func deleteComment(
+        email: String,
+        shareId: String,
+        commentId: String
+    ) async throws -> CommentDeleteResponse
+
+    func toggleReaction(
+        email: String,
+        shareId: String,
+        reaction: ShareReaction
+    ) async throws -> ReactionToggleResponse
+
+    func listReactions(
+        email: String,
+        shareId: String
+    ) async throws -> ReactionsListResponse
 }
 
 extension XomifyService: XomifyServiceProtocol {}

--- a/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
@@ -28,6 +28,27 @@ final class ShareDetailViewModel {
     var isRating: Bool = false
     var rateError: String?
 
+    // Comments thread (xomify-backend#139). Newest-first; loaded lazily on
+    // detail open and after the viewer posts a new comment.
+    var comments: [ShareComment] = []
+    var nextCommentBefore: String?
+    var isLoadingComments: Bool = false
+    var commentsError: String?
+
+    /// Composer state for the inline reply box.
+    var commentDraft: String = ""
+    var isPostingComment: Bool = false
+    var postCommentError: String?
+
+    /// IDs currently being deleted, so the per-row destructive button can
+    /// disable individually instead of blocking the whole thread.
+    var deletingCommentIds: Set<String> = []
+
+    // Reactions (xomify-backend#139). Slugs in flight so a fast double-tap
+    // doesn't fire two competing toggles for the same emoji.
+    var reactingSlugs: Set<String> = []
+    var reactError: String?
+
     // MARK: - Dependencies
 
     private let xomifyService: XomifyServiceProtocol
@@ -117,6 +138,142 @@ final class ShareDetailViewModel {
         } catch {
             myRating = previous
             rateError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Comments
+
+    /// Load (or reload) the comment thread. First page only — pagination
+    /// support is wired but not exposed in the UI yet.
+    func loadComments() async {
+        guard !isLoadingComments else { return }
+        isLoadingComments = true
+        commentsError = nil
+        defer { isLoadingComments = false }
+
+        do {
+            let resp = try await xomifyService.listComments(
+                email: viewerEmail,
+                shareId: share.shareId,
+                limit: 50,
+                before: nil
+            )
+            comments = resp.comments
+            nextCommentBefore = resp.nextBefore
+            // Keep the cached commentCount in sync with what the thread shows
+            // — useful when the value on the parent feed is stale.
+            share = share.withCommentCount(comments.count)
+        } catch {
+            commentsError = error.localizedDescription
+        }
+    }
+
+    /// Post the current draft. On success: clears the draft, prepends the
+    /// newly-returned (hydrated) comment, and bumps the cached count.
+    func postComment() async {
+        let trimmed = commentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isPostingComment else { return }
+        isPostingComment = true
+        postCommentError = nil
+        defer { isPostingComment = false }
+
+        do {
+            let comment = try await xomifyService.createComment(
+                email: viewerEmail,
+                shareId: share.shareId,
+                body: trimmed
+            )
+            comments.insert(comment, at: 0)
+            share = share.withCommentCount(share.commentCount + 1)
+            commentDraft = ""
+        } catch {
+            postCommentError = error.localizedDescription
+        }
+    }
+
+    /// Whether the viewer is allowed to delete `comment` — author of the
+    /// comment, or author of the share.
+    func canDelete(_ comment: ShareComment) -> Bool {
+        comment.email == viewerEmail || share.sharedBy == viewerEmail
+    }
+
+    /// Optimistically remove the comment from the local list; rollback on
+    /// failure. Backend re-checks the delete authorization rule.
+    func deleteComment(_ comment: ShareComment) async {
+        guard canDelete(comment), !deletingCommentIds.contains(comment.commentId) else { return }
+        deletingCommentIds.insert(comment.commentId)
+        defer { deletingCommentIds.remove(comment.commentId) }
+
+        guard let removeIndex = comments.firstIndex(where: { $0.commentId == comment.commentId }) else { return }
+        let removed = comments.remove(at: removeIndex)
+        share = share.withCommentCount(max(0, share.commentCount - 1))
+
+        do {
+            _ = try await xomifyService.deleteComment(
+                email: viewerEmail,
+                shareId: share.shareId,
+                commentId: comment.commentId
+            )
+        } catch {
+            comments.insert(removed, at: removeIndex)
+            share = share.withCommentCount(share.commentCount + 1)
+            commentsError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Reactions
+
+    /// Has the viewer toggled this reaction on?
+    func viewerHasReacted(_ reaction: ShareReaction) -> Bool {
+        share.viewerReactions.contains(reaction.rawValue)
+    }
+
+    /// Count for a given reaction slug (0 when missing).
+    func count(for reaction: ShareReaction) -> Int {
+        share.reactionCounts[reaction.rawValue] ?? 0
+    }
+
+    /// Toggle a reaction on/off. Optimistic patch via `withReactionSummary`,
+    /// rollback on failure.
+    func toggleReaction(_ reaction: ShareReaction) async {
+        let slug = reaction.rawValue
+        guard !reactingSlugs.contains(slug) else { return }
+        reactingSlugs.insert(slug)
+        defer { reactingSlugs.remove(slug) }
+
+        let previousCounts = share.reactionCounts
+        let previousViewer = share.viewerReactions
+
+        // Optimistic patch
+        var nextCounts = previousCounts
+        var nextViewer = previousViewer
+        if previousViewer.contains(slug) {
+            nextViewer.removeAll { $0 == slug }
+            nextCounts[slug] = max(0, (nextCounts[slug] ?? 0) - 1)
+            if nextCounts[slug] == 0 { nextCounts.removeValue(forKey: slug) }
+        } else {
+            nextViewer.append(slug)
+            nextCounts[slug] = (nextCounts[slug] ?? 0) + 1
+        }
+        share = share.withReactionSummary(counts: nextCounts, viewerReactions: nextViewer)
+
+        do {
+            let resp = try await xomifyService.toggleReaction(
+                email: viewerEmail,
+                shareId: share.shareId,
+                reaction: reaction
+            )
+            // Trust server — it just walked DynamoDB for the canonical counts.
+            share = share.withReactionSummary(
+                counts: resp.counts,
+                viewerReactions: resp.viewerReactions
+            )
+        } catch {
+            share = share.withReactionSummary(
+                counts: previousCounts,
+                viewerReactions: previousViewer
+            )
+            reactError = error.localizedDescription
         }
     }
 }

--- a/Xomify-iOS/Views/Feed/ShareDetailView.swift
+++ b/Xomify-iOS/Views/Feed/ShareDetailView.swift
@@ -34,11 +34,13 @@ struct ShareDetailView: View {
                     sharerBlock
                     statsRow
                     actionRow
+                    reactionBar
                     if let caption = viewModel.share.caption, !caption.isEmpty {
                         captionBlock(caption)
                     }
                     friendRatingsSection
                     listenersSection
+                    commentsSection
                     if let error = viewModel.errorMessage {
                         inlineErrorBanner(error)
                     }
@@ -53,9 +55,11 @@ struct ShareDetailView: View {
         .tint(Color.xomifyGreen)
         .task {
             await viewModel.load()
+            await viewModel.loadComments()
         }
         .refreshable {
             await viewModel.load()
+            await viewModel.loadComments()
         }
         .sheet(isPresented: $showRateSheet) {
             DetailRateSheet(viewModel: viewModel, isPresented: $showRateSheet)
@@ -433,6 +437,192 @@ struct ShareDetailView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
+        .background(Color.xomifyCard)
+        .clipShape(.rect(cornerRadius: 10))
+    }
+
+    // MARK: - Reactions
+
+    /// Six-emoji bar. Each chip shows the count when > 0; tapping toggles
+    /// the viewer's reaction. The chip background flips green when active so
+    /// the viewer can see what they've already reacted with.
+    private var reactionBar: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                ForEach(ShareReaction.allCases) { reaction in
+                    reactionChip(reaction)
+                }
+            }
+            if let error = viewModel.reactError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func reactionChip(_ reaction: ShareReaction) -> some View {
+        let active = viewModel.viewerHasReacted(reaction)
+        let count = viewModel.count(for: reaction)
+        let inFlight = viewModel.reactingSlugs.contains(reaction.rawValue)
+        return Button {
+            Task { await viewModel.toggleReaction(reaction) }
+        } label: {
+            HStack(spacing: 4) {
+                Text(reaction.emoji)
+                    .font(.system(size: 18))
+                if count > 0 {
+                    Text("\(count)")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(active ? Color.xomifyGreen : .white)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(minHeight: 36)
+            .background(active
+                ? Color.xomifyGreen.opacity(0.18)
+                : Color.white.opacity(0.08))
+            .overlay(
+                Capsule().strokeBorder(
+                    active ? Color.xomifyGreen.opacity(0.6) : Color.clear,
+                    lineWidth: 1
+                )
+            )
+            .clipShape(Capsule())
+            .opacity(inFlight ? 0.55 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(inFlight)
+        .accessibilityLabel(reaction.accessibilityLabel)
+        .accessibilityValue(active ? "On, \(count)" : "Off, \(count)")
+    }
+
+    // MARK: - Comments
+
+    private var commentsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(
+                title: "Comments",
+                icon: "bubble.left",
+                count: viewModel.share.commentCount
+            )
+
+            commentComposer
+
+            if viewModel.isLoadingComments && viewModel.comments.isEmpty {
+                sectionPlaceholder(message: "Loading comments…")
+            } else if viewModel.comments.isEmpty {
+                Text("No comments yet. Be the first.")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(Color.xomifyCard.opacity(0.5))
+                    .clipShape(.rect(cornerRadius: 10))
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(viewModel.comments) { comment in
+                        commentRow(comment)
+                    }
+                }
+            }
+
+            if let error = viewModel.commentsError {
+                inlineErrorBanner(error)
+            }
+        }
+    }
+
+    private var commentComposer: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .bottom, spacing: 8) {
+                TextField(
+                    "",
+                    text: Binding(
+                        get: { viewModel.commentDraft },
+                        set: { viewModel.commentDraft = $0 }
+                    ),
+                    prompt: Text("Add a comment").foregroundStyle(.gray),
+                    axis: .vertical
+                )
+                .lineLimit(1...4)
+                .textInputAutocapitalization(.sentences)
+                .foregroundStyle(.white)
+                .padding(10)
+                .background(Color.white.opacity(0.06))
+                .clipShape(.rect(cornerRadius: 10))
+
+                Button {
+                    Task { await viewModel.postComment() }
+                } label: {
+                    if viewModel.isPostingComment {
+                        ProgressView().tint(.white)
+                    } else {
+                        Image(systemName: "paperplane.fill")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.white)
+                    }
+                }
+                .frame(width: 44, height: 44)
+                .background(canPostComment ? LinearGradient.xomifyGradient : LinearGradient(
+                    colors: [Color.gray.opacity(0.4)], startPoint: .leading, endPoint: .trailing
+                ))
+                .clipShape(.rect(cornerRadius: 10))
+                .disabled(!canPostComment)
+                .accessibilityLabel("Post comment")
+            }
+            if let error = viewModel.postCommentError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var canPostComment: Bool {
+        !viewModel.isPostingComment
+            && !viewModel.commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func commentRow(_ comment: ShareComment) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            avatarView(url: comment.avatarURL, initial: comment.resolvedName.prefix(1))
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(comment.resolvedName)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Text(comment.relativeTime)
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+                    Spacer(minLength: 0)
+                    if viewModel.canDelete(comment) {
+                        Button(role: .destructive) {
+                            Task { await viewModel.deleteComment(comment) }
+                        } label: {
+                            Image(systemName: "trash")
+                                .font(.caption2)
+                                .foregroundStyle(.red.opacity(0.85))
+                                .frame(width: 28, height: 28)
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(viewModel.deletingCommentIds.contains(comment.commentId))
+                        .accessibilityLabel("Delete comment")
+                    }
+                }
+                Text(comment.body)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.white.opacity(0.92))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(10)
         .background(Color.xomifyCard)
         .clipShape(.rect(cornerRadius: 10))
     }

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -129,6 +129,86 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
             totalCount: 0
         )
     }
+
+    // MARK: - Comments + Reactions (xomify-backend#139)
+    //
+    // Stub default returns; specific tests can prime the response/error.
+
+    var createCommentResponse: ShareComment?
+    var createCommentError: Error?
+
+    func createComment(
+        email: String,
+        shareId: String,
+        body: String
+    ) async throws -> ShareComment {
+        if let createCommentError { throw createCommentError }
+        return createCommentResponse ?? ShareComment(
+            commentId: UUID().uuidString,
+            shareId: shareId,
+            email: email,
+            displayName: nil,
+            avatar: nil,
+            body: body,
+            createdAt: nil
+        )
+    }
+
+    var listCommentsResponse: CommentsListResponse = CommentsListResponse(
+        comments: [], nextBefore: nil
+    )
+    var listCommentsError: Error?
+
+    func listComments(
+        email: String,
+        shareId: String,
+        limit: Int,
+        before: String?
+    ) async throws -> CommentsListResponse {
+        if let listCommentsError { throw listCommentsError }
+        return listCommentsResponse
+    }
+
+    var deleteCommentError: Error?
+
+    func deleteComment(
+        email: String,
+        shareId: String,
+        commentId: String
+    ) async throws -> CommentDeleteResponse {
+        if let deleteCommentError { throw deleteCommentError }
+        return CommentDeleteResponse(deleted: true, commentId: commentId)
+    }
+
+    var toggleReactionResponse: ReactionToggleResponse?
+    var toggleReactionError: Error?
+
+    func toggleReaction(
+        email: String,
+        shareId: String,
+        reaction: ShareReaction
+    ) async throws -> ReactionToggleResponse {
+        if let toggleReactionError { throw toggleReactionError }
+        return toggleReactionResponse ?? ReactionToggleResponse(
+            active: true,
+            reaction: reaction.rawValue,
+            counts: [reaction.rawValue: 1],
+            viewerReactions: [reaction.rawValue]
+        )
+    }
+
+    var listReactionsResponse: ReactionsListResponse = ReactionsListResponse(
+        counts: [:], viewerReactions: []
+    )
+    var listReactionsError: Error?
+
+    func listReactions(
+        email: String,
+        shareId: String
+    ) async throws -> ReactionsListResponse {
+        if let listReactionsError { throw listReactionsError }
+        return listReactionsResponse
+    }
 }
 
 // MARK: - SpotifyCurrentUserProviding mock


### PR DESCRIPTION
## Summary
Wires the iOS client to the comments + reactions endpoints shipped in xomify-backend#139 and xomify-infrastructure#72.

- **Models** — `Share` now carries `commentCount`, `reactionCounts`, `viewerReactions`. New `ShareComment` and `ShareReaction` types.
- **Service** — 5 new methods on `XomifyService` against the deployed hyphenated paths (`/shares/comments-{create,list,delete}`, `/shares/reactions-{toggle,list}`). Mirrored on `XomifyServiceProtocol` and the test mock.
- **NetworkService** — adds a DELETE-with-body overload because the backend's `shares_comments_delete` reads `parse_body`, not query params.
- **ShareDetailViewModel** — optimistic comment post/delete and reaction toggle with rollback; trusts server-returned reaction counts.
- **ShareDetailView** — 6-emoji reaction bar after the action row; inline comment composer + thread with delete affordance for the author or share owner.

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` — green
- [ ] Open a share's detail view, post a comment, see it prepended; refresh, still there
- [ ] Tap a reaction emoji → chip activates with count bump; tap again → toggles off
- [ ] Author and share owner see delete buttons on comments; non-author non-owner does not
- [ ] Pull-to-refresh reloads share, listeners, friend ratings, **and** comments