### PR TITLE
feat: shares v2 — reaction pills + comment badge + inline note

### DIFF
--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -25,6 +25,11 @@ final class ShareCardViewModel {
     var isRating: Bool = false
     var rateError: String?
 
+    // Reaction state — slugs in flight so a fast double-tap doesn't fire two
+    // competing toggles for the same emoji.
+    var reactingSlugs: Set<String> = []
+    var reactError: String?
+
     // MARK: - Dependencies
 
     private let xomifyService: XomifyServiceProtocol
@@ -125,6 +130,51 @@ final class ShareCardViewModel {
         } catch {
             myRating = previous
             rateError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Reactions
+
+    /// Toggle a reaction on/off. Optimistic patch via `withReactionSummary`,
+    /// rollback on failure. Mirrors `ShareDetailViewModel.toggleReaction` so
+    /// the feed card and detail screen stay in sync without sharing state.
+    func toggleReaction(_ reaction: ShareReaction) async {
+        let slug = reaction.rawValue
+        guard !reactingSlugs.contains(slug) else { return }
+        reactingSlugs.insert(slug)
+        defer { reactingSlugs.remove(slug) }
+
+        let previousCounts = share.reactionCounts
+        let previousViewer = share.viewerReactions
+
+        var nextCounts = previousCounts
+        var nextViewer = previousViewer
+        if previousViewer.contains(slug) {
+            nextViewer.removeAll { $0 == slug }
+            nextCounts[slug] = max(0, (nextCounts[slug] ?? 0) - 1)
+            if nextCounts[slug] == 0 { nextCounts.removeValue(forKey: slug) }
+        } else {
+            nextViewer.append(slug)
+            nextCounts[slug] = (nextCounts[slug] ?? 0) + 1
+        }
+        share = share.withReactionSummary(counts: nextCounts, viewerReactions: nextViewer)
+
+        do {
+            let resp = try await xomifyService.toggleReaction(
+                email: viewerEmail,
+                shareId: share.shareId,
+                reaction: reaction
+            )
+            share = share.withReactionSummary(
+                counts: resp.counts,
+                viewerReactions: resp.viewerReactions
+            )
+        } catch {
+            share = share.withReactionSummary(
+                counts: previousCounts,
+                viewerReactions: previousViewer
+            )
+            reactError = error.localizedDescription
         }
     }
 }

--- a/Xomify-iOS/Views/Feed/ReactionsBar.swift
+++ b/Xomify-iOS/Views/Feed/ReactionsBar.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// Shared reactions row used on both `ShareCardView` (feed) and
+/// `ShareDetailView`. Renders a pill for every reaction the post has at least
+/// one of (active when the viewer has reacted), then a smiley menu button at
+/// the end that lets the viewer pick from any of the supported emojis.
+///
+/// The owning view model decides what happens on toggle — this component is
+/// purely presentational + closure-driven.
+struct ReactionsBar: View {
+
+    let counts: [String: Int]
+    let viewerReactions: [String]
+    let inFlightSlugs: Set<String>
+    let onToggle: (ShareReaction) -> Void
+
+    /// Order pills appear in. Reactions with count > 0 stick to the front in
+    /// `ShareReaction.allCases` order so the row stays stable as counts shift.
+    private var activeReactions: [ShareReaction] {
+        ShareReaction.allCases.filter { (counts[$0.rawValue] ?? 0) > 0 }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(activeReactions) { reaction in
+                pill(reaction)
+            }
+            addMenu
+        }
+    }
+
+    private func pill(_ reaction: ShareReaction) -> some View {
+        let active = viewerReactions.contains(reaction.rawValue)
+        let count = counts[reaction.rawValue] ?? 0
+        let inFlight = inFlightSlugs.contains(reaction.rawValue)
+        return Button {
+            onToggle(reaction)
+        } label: {
+            HStack(spacing: 4) {
+                Text(reaction.emoji)
+                    .font(.system(size: 16))
+                Text("\(count)")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(active ? Color.xomifyGreen : .white)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(minHeight: 32)
+            .background(active ? Color.xomifyGreen.opacity(0.18) : Color.white.opacity(0.08))
+            .overlay(
+                Capsule().strokeBorder(
+                    active ? Color.xomifyGreen.opacity(0.6) : Color.clear,
+                    lineWidth: 1
+                )
+            )
+            .clipShape(Capsule())
+            .opacity(inFlight ? 0.55 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(inFlight)
+        .accessibilityLabel(reaction.accessibilityLabel)
+        .accessibilityValue(active ? "On, \(count)" : "Off, \(count)")
+    }
+
+    private var addMenu: some View {
+        Menu {
+            ForEach(ShareReaction.allCases) { reaction in
+                Button {
+                    onToggle(reaction)
+                } label: {
+                    Label(reaction.accessibilityLabel, systemImage: "")
+                    Text(reaction.emoji)
+                }
+            }
+        } label: {
+            Image(systemName: "face.smiling")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.85))
+                .frame(width: 36, height: 32)
+                .background(Color.white.opacity(0.08))
+                .clipShape(Capsule())
+        }
+        .accessibilityLabel("Add a reaction")
+    }
+}

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -54,7 +54,11 @@ struct ShareCardView: View {
                 }
             }
             actionRow
+            socialRow
             if let error = viewModel.queueError {
+                errorBanner(error)
+            }
+            if let error = viewModel.reactError {
                 errorBanner(error)
             }
         }
@@ -281,9 +285,64 @@ struct ShareCardView: View {
         HStack(spacing: 10) {
             queueButton
             rateButton
+            commentButton
             Spacer()
             if viewModel.displayedQueueCount > 0 {
                 queueCountChip
+            }
+        }
+    }
+
+    /// Compact comment-thread shortcut. Mirrors how Instagram/Twitter surface
+    /// reply counts on a card — tap goes to detail (which auto-loads comments).
+    private var commentButton: some View {
+        Button {
+            onOpenDetail?()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "bubble.left")
+                Text("\(viewModel.share.commentCount)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(minHeight: 44)
+            .background(Color.white.opacity(0.08))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(viewModel.share.commentCount) comments. Tap to open.")
+    }
+
+    /// Reactions row — only renders pills for reactions with count ≥ 1, plus
+    /// the smiley menu to add a new one.
+    @ViewBuilder
+    private var socialRow: some View {
+        let counts = viewModel.share.reactionCounts
+        let viewer = viewModel.share.viewerReactions
+        if !counts.isEmpty || !viewer.isEmpty {
+            ReactionsBar(
+                counts: counts,
+                viewerReactions: viewer,
+                inFlightSlugs: viewModel.reactingSlugs,
+                onToggle: { reaction in
+                    Task { await viewModel.toggleReaction(reaction) }
+                }
+            )
+        } else {
+            // Empty state: just show the add button so a viewer can react first.
+            HStack {
+                ReactionsBar(
+                    counts: [:],
+                    viewerReactions: [],
+                    inFlightSlugs: viewModel.reactingSlugs,
+                    onToggle: { reaction in
+                        Task { await viewModel.toggleReaction(reaction) }
+                    }
+                )
+                Spacer()
             }
         }
     }

--- a/Xomify-iOS/Views/Feed/ShareDetailView.swift
+++ b/Xomify-iOS/Views/Feed/ShareDetailView.swift
@@ -35,9 +35,6 @@ struct ShareDetailView: View {
                     statsRow
                     actionRow
                     reactionBar
-                    if let caption = viewModel.share.caption, !caption.isEmpty {
-                        captionBlock(caption)
-                    }
                     friendRatingsSection
                     listenersSection
                     commentsSection
@@ -151,37 +148,50 @@ struct ShareDetailView: View {
     // MARK: - Sharer block
 
     private var sharerBlock: some View {
-        HStack(spacing: 12) {
-            avatarView(url: sharerIdentity.avatarURL, initial: sharerIdentity.displayName.prefix(1))
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Shared by \(sharerIdentity.displayName)")
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                Text(viewModel.share.relativeTime)
-                    .font(.caption2)
-                    .foregroundStyle(.gray)
-            }
-
-            Spacer(minLength: 8)
-
-            if let rating = viewModel.share.sharerRating {
-                HStack(spacing: 4) {
-                    Image(systemName: "star.fill")
-                        .font(.caption)
-                        .foregroundStyle(Color.xomifyGreen)
-                    Text("\(rating)/5")
-                        .font(.caption)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                avatarView(url: sharerIdentity.avatarURL, initial: sharerIdentity.displayName.prefix(1))
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Shared by \(sharerIdentity.displayName)")
+                        .font(.subheadline)
                         .fontWeight(.semibold)
                         .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Text(viewModel.share.relativeTime)
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(Color.white.opacity(0.08))
-                .clipShape(Capsule())
-                .accessibilityLabel("\(sharerIdentity.displayName) rated this \(rating) out of 5")
+
+                Spacer(minLength: 8)
+
+                if let rating = viewModel.share.sharerRating {
+                    HStack(spacing: 4) {
+                        Image(systemName: "star.fill")
+                            .font(.caption)
+                            .foregroundStyle(Color.xomifyGreen)
+                        Text("\(rating)/5")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.white)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(Capsule())
+                    .accessibilityLabel("\(sharerIdentity.displayName) rated this \(rating) out of 5")
+                }
+            }
+
+            // Inline note — sits in the same card as the sharer so the post
+            // reads like a single utterance ("Dom shared this and said …")
+            // instead of a separate "Note from …" block further down.
+            if let caption = viewModel.share.caption, !caption.isEmpty {
+                Text(caption)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.white.opacity(0.92))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(12)
@@ -316,25 +326,6 @@ struct ShareDetailView: View {
         )
     }
 
-    // MARK: - Caption
-
-    private func captionBlock(_ caption: String) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Note from \(sharerIdentity.displayName)")
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(Color.xomifyGreen)
-            Text(caption)
-                .font(.subheadline)
-                .foregroundStyle(Color.white.opacity(0.92))
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.xomifyCard)
-        .clipShape(.rect(cornerRadius: 12))
-    }
-
     // MARK: - Friend ratings
 
     @ViewBuilder
@@ -443,60 +434,25 @@ struct ShareDetailView: View {
 
     // MARK: - Reactions
 
-    /// Six-emoji bar. Each chip shows the count when > 0; tapping toggles
-    /// the viewer's reaction. The chip background flips green when active so
-    /// the viewer can see what they've already reacted with.
+    /// Active reactions render as pills; smiley menu lets the viewer add any
+    /// of the six supported emojis. Empty state still shows the smiley so the
+    /// affordance is always discoverable.
     private var reactionBar: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                ForEach(ShareReaction.allCases) { reaction in
-                    reactionChip(reaction)
+            ReactionsBar(
+                counts: viewModel.share.reactionCounts,
+                viewerReactions: viewModel.share.viewerReactions,
+                inFlightSlugs: viewModel.reactingSlugs,
+                onToggle: { reaction in
+                    Task { await viewModel.toggleReaction(reaction) }
                 }
-            }
+            )
             if let error = viewModel.reactError {
                 Text(error)
                     .font(.caption2)
                     .foregroundStyle(.orange)
             }
         }
-    }
-
-    private func reactionChip(_ reaction: ShareReaction) -> some View {
-        let active = viewModel.viewerHasReacted(reaction)
-        let count = viewModel.count(for: reaction)
-        let inFlight = viewModel.reactingSlugs.contains(reaction.rawValue)
-        return Button {
-            Task { await viewModel.toggleReaction(reaction) }
-        } label: {
-            HStack(spacing: 4) {
-                Text(reaction.emoji)
-                    .font(.system(size: 18))
-                if count > 0 {
-                    Text("\(count)")
-                        .font(.caption)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(active ? Color.xomifyGreen : .white)
-                }
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .frame(minHeight: 36)
-            .background(active
-                ? Color.xomifyGreen.opacity(0.18)
-                : Color.white.opacity(0.08))
-            .overlay(
-                Capsule().strokeBorder(
-                    active ? Color.xomifyGreen.opacity(0.6) : Color.clear,
-                    lineWidth: 1
-                )
-            )
-            .clipShape(Capsule())
-            .opacity(inFlight ? 0.55 : 1)
-        }
-        .buttonStyle(.plain)
-        .disabled(inFlight)
-        .accessibilityLabel(reaction.accessibilityLabel)
-        .accessibilityValue(active ? "On, \(count)" : "Off, \(count)")
     }
 
     // MARK: - Comments


### PR DESCRIPTION
## Summary
Reworks the share UX based on screenshot feedback so it reads like a real social app.

**Detail screen**
- Caption/note moves into the sharer card (one utterance, not a separate "Note from …" block down the page)
- Drops the always-visible 6-emoji bar; replaced with a shared `ReactionsBar`: pills for reactions that have ≥1 count, and a single smiley menu button to add any of the six

**Feed card**
- New comment-count button (bubble + count) — tap routes to detail, which auto-loads comments
- Same `ReactionsBar` underneath the action row so reactions are first-class on the card, not buried in detail

**Plumbing**
- `ShareCardViewModel` mirrors `ShareDetailViewModel`'s reaction state + optimistic toggle so the card updates without bouncing through the feed VM

## Note for testing
Reactions/comments still 500 until xomify-infrastructure#72 is `terraform apply`'d and the 5 lambdas are deployed via `deploy-backend.yml`. UI works in isolation; the network calls will start succeeding once those run.

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` — green
- [ ] Open detail: caption sits in sharer card; only reactions with ≥1 count render as pills; smiley opens a menu of 6
- [ ] Feed card: comment bubble shows count, tap pushes detail; reactions row renders; tap a reaction → optimistic flip