### PR TITLE
feat: groups v2 — stats tab + leave + sidebar swipe + version 1.1.0

### DIFF
--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "Xomify-iOS.xcodeproj/**"
+  - ".github/workflows/**"
+  - "scripts/bump-version.sh"
+---
+# Versioning Rules
+
+`MARKETING_VERSION` in `Xomify-iOS.xcodeproj/project.pbxproj` is the canonical
+app version (SemVer: MAJOR.MINOR.PATCH). The TestFlight workflow reads it
+directly; build numbers are timestamps so reusing a marketing version across
+builds is fine.
+
+## Bump policy
+
+Use `scripts/bump-version.sh <kind>` -- never hand-edit `MARKETING_VERSION`:
+
+- `feat` -- new feature shipped to users -> `MAJOR.MINOR+1.0`
+- `fix`  -- bug fix or small patch       -> `MAJOR.MINOR.PATCH+1`
+- `epic` -- huge release / breaking      -> `MAJOR+1.0.0`
+
+The script prints the new version on stdout. Bump in the same commit as the
+feature/fix it goes with so the version on `master` always matches what's
+deployed.
+
+## What NOT to do
+
+- Don't always bump the patch digit -- match the kind of change
+- Don't compute the version from git tags / commit count -- pbxproj is the
+  source of truth
+- Don't bump `MARKETING_VERSION` in a docs-only or CI-only PR

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -64,13 +64,16 @@ jobs:
       - name: Compute version and build number
         id: version
         run: |
-          # Marketing version: 1.0.<master-commit-count>. Prefers the latest vX.Y.Z tag when one exists.
-          TAGGED_VERSION=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//' || true)
-          if [ -n "$TAGGED_VERSION" ]; then
-            MARKETING_VERSION="$TAGGED_VERSION"
-          else
-            COMMIT_COUNT=$(git rev-list --count HEAD)
-            MARKETING_VERSION="1.0.${COMMIT_COUNT}"
+          # Marketing version is the SemVer in project.pbxproj — the canonical
+          # source of truth. Bump it via scripts/bump-version.sh when shipping
+          # a feat (minor) / fix (patch) / epic (major). Build number is a
+          # monotonic timestamp so TestFlight always accepts a new upload even
+          # when marketing version is unchanged.
+          PBXPROJ="Xomify-iOS.xcodeproj/project.pbxproj"
+          MARKETING_VERSION=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+          if [ -z "$MARKETING_VERSION" ]; then
+            echo "Could not read MARKETING_VERSION from $PBXPROJ" >&2
+            exit 1
           fi
           BUILD_NUMBER=$(date +%Y%m%d%H%M)
           echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"

--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -12,6 +12,13 @@ final class GroupDetailViewModel {
     var members: [GroupMember] = []
     var tracks: [GroupTrack] = []
 
+    /// Viewer's own display name + avatar — used to enrich the self-row in
+    /// the members tab when the backend's GroupMember payload doesn't carry
+    /// displayName/avatar fields. (Backend follow-up: enrich `/groups/info`
+    /// member list with profile data so this hop isn't needed.)
+    var viewerDisplayName: String?
+    var viewerAvatarURL: URL?
+
     /// Shares posted to this group (the new primary content surface — replaces
     /// the legacy `tracks` list driven by `/groups/add-song`).
     var shares: [Share] = []
@@ -80,6 +87,18 @@ final class GroupDetailViewModel {
             print("❌ GroupDetail: load failed - \(error)")
         }
 
+        // Fetch viewer profile for self-row enrichment. Best-effort; failures
+        // just leave the row showing email + initial.
+        if viewerDisplayName == nil {
+            do {
+                let me = try await spotify.getCurrentUser()
+                viewerDisplayName = me.displayName
+                viewerAvatarURL = me.profileImageUrl
+            } catch {
+                // silent — non-critical
+            }
+        }
+
         isLoading = false
 
         // Group-scoped shares feed lives under a separate request — kick it
@@ -118,6 +137,54 @@ final class GroupDetailViewModel {
             sharesError = error.localizedDescription
             print("❌ GroupDetail: loadShares failed - \(error)")
         }
+    }
+
+    // MARK: - Stats (derived from `shares`)
+
+    /// Per-user breakdown for the Stats tab.
+    struct GroupUserStat: Identifiable, Hashable {
+        let email: String
+        let displayName: String
+        let avatarURL: URL?
+        let shareCount: Int
+        let averageRating: Double?
+        var id: String { email }
+    }
+
+    var totalShareCount: Int { shares.count }
+
+    /// Average sharer-supplied rating across all loaded shares (the rating the
+    /// poster gave when they shared). Nil when nobody rated.
+    var averageSharerRating: Double? {
+        let ratings = shares.compactMap { $0.sharerRating }
+        guard !ratings.isEmpty else { return nil }
+        return Double(ratings.reduce(0, +)) / Double(ratings.count)
+    }
+
+    /// Shares grouped by sharer email with count + average rating, sorted by
+    /// share count desc.
+    var perUserStats: [GroupUserStat] {
+        let grouped = Dictionary(grouping: shares, by: { $0.sharedBy })
+        return grouped.map { (email, posts) in
+            let ratings = posts.compactMap { $0.sharerRating }
+            let avg = ratings.isEmpty ? nil : Double(ratings.reduce(0, +)) / Double(ratings.count)
+            let member = members.first { $0.email == email }
+            let resolvedName: String
+            if email == userEmail, let mine = viewerDisplayName, !mine.isEmpty {
+                resolvedName = mine
+            } else {
+                resolvedName = member?.label ?? email
+            }
+            let avatar = (email == userEmail) ? viewerAvatarURL : nil
+            return GroupUserStat(
+                email: email,
+                displayName: resolvedName,
+                avatarURL: avatar,
+                shareCount: posts.count,
+                averageRating: avg
+            )
+        }
+        .sorted { $0.shareCount > $1.shareCount }
     }
 
     // MARK: - Friends (for add-member picker)

--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -1,35 +1,28 @@
 import SwiftUI
 
-/// Detail view for a single group: Shares + Members tabs.
+/// Detail view for a single group: Stats + Members tabs.
 ///
-/// "Add song" routes through the standard composer pre-targeted at this
-/// group (no public, just this groupId). The legacy `/groups/add-song`
-/// flow has been retired from the UI; the shares stream below is sourced
-/// from `/shares/feed?groupId=…`.
+/// The Shares card list is gone — the Feed is the place for that. The "Add
+/// track" pill at the top of either tab pops the user back to the Feed
+/// destination so they can use the standard composer (and optionally include
+/// this group from the picker).
 struct GroupDetailView: View {
 
     let groupId: String
     let viewerEmail: String
 
     @State private var viewModel = GroupDetailViewModel()
-    @State private var selectedTab: Tab = .shares
+    @State private var selectedTab: Tab = .stats
     @State private var showingAddMembers = false
-    @State private var showingComposer = false
     @State private var showingEditGroup = false
     @State private var showLeaveConfirm = false
     @State private var showDeleteConfirm = false
 
-    /// Composer VM is owned at the screen level so we can prefill it with the
-    /// current group + reset it on dismiss.
-    @State private var composerVM: ShareComposerViewModel?
-
-    /// Drives the push to ShareDetailView when a card body is tapped.
-    @State private var selectedShare: Share?
-
     @Environment(\.dismiss) private var dismiss
+    @Environment(NavigationStore.self) private var navStore
 
     enum Tab: String, CaseIterable, Identifiable {
-        case shares = "Shares"
+        case stats = "Stats"
         case members = "Members"
         var id: String { rawValue }
     }
@@ -52,7 +45,7 @@ struct GroupDetailView: View {
                 .padding()
 
                 switch selectedTab {
-                case .shares:  sharesSection
+                case .stats:   statsSection
                 case .members: membersSection
                 }
             }
@@ -76,31 +69,11 @@ struct GroupDetailView: View {
                     .background(Color.red.opacity(0.15))
             }
         }
-        .navigationDestination(item: $selectedShare) { share in
-            ShareDetailView(
-                share: share,
-                viewerEmail: viewerEmail,
-                sharerIdentity: identity(for: share.sharedBy)
-            )
-        }
         .sheet(isPresented: $showingAddMembers) {
             AddMemberSheet(
                 viewModel: viewModel,
                 onDismiss: { showingAddMembers = false }
             )
-        }
-        .sheet(isPresented: $showingComposer, onDismiss: {
-            composerVM = nil
-        }) {
-            if let composerVM {
-                ShareComposerView(
-                    viewModel: composerVM,
-                    onSubmitted: { _ in
-                        showingComposer = false
-                        Task { await viewModel.loadShares() }
-                    }
-                )
-            }
         }
         .sheet(isPresented: $showingEditGroup) {
             EditGroupSheet(
@@ -186,70 +159,190 @@ struct GroupDetailView: View {
 
     private func tabTitle(_ tab: Tab) -> String {
         switch tab {
-        case .shares:  return "Shares (\(viewModel.shares.count))"
+        case .stats:   return "Stats"
         case .members: return "Members (\(viewModel.members.count))"
         }
     }
 
-    // MARK: - Shares
+    // MARK: - Stats
 
-    private var sharesSection: some View {
-        VStack(spacing: 0) {
-            addSongButton
-
-            if viewModel.isLoadingShares && viewModel.shares.isEmpty {
-                XomifyLoaderPulse()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = viewModel.sharesError, viewModel.shares.isEmpty {
-                emptyTab(icon: "exclamationmark.triangle",
-                         title: "Couldn't load shares",
-                         message: error)
-            } else if viewModel.shares.isEmpty {
-                emptyTab(icon: "music.note", title: "No shares yet",
-                         message: "Tap Add song to post the first one to this group.")
-            } else {
-                sharesList
-            }
-        }
-    }
-
-    private var addSongButton: some View {
+    /// Compact "+ track" pill — kicks the user back to the Feed where they
+    /// can compose a share and optionally include this group from the picker.
+    /// Smaller than a full-width CTA on purpose; the Stats tab is the primary
+    /// content here.
+    private var addTrackPill: some View {
         Button {
-            presentComposer()
+            navStore.select(.feed)
         } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "plus.circle.fill")
-                Text("Add song")
+            HStack(spacing: 6) {
+                Image(systemName: "plus")
+                Text("Add track")
             }
-            .font(.subheadline)
+            .font(.caption)
             .fontWeight(.semibold)
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(minHeight: 32)
             .background(LinearGradient.xomifyGradient)
             .foregroundStyle(.white)
-            .clipShape(.rect(cornerRadius: 22))
+            .clipShape(Capsule())
         }
-        .padding(.horizontal)
-        .padding(.bottom, 8)
-        .accessibilityLabel("Add song")
-        .accessibilityHint("Opens the share composer pre-targeted at this group")
+        .accessibilityLabel("Add a track")
+        .accessibilityHint("Switches to the Feed where you can share and target this group")
     }
 
-    private var sharesList: some View {
+    private var statsSection: some View {
         ScrollView {
-            LazyVStack(spacing: 12) {
-                ForEach(viewModel.shares) { share in
-                    ShareCardView(
-                        share: share,
-                        viewerEmail: viewerEmail,
-                        sharerIdentity: identity(for: share.sharedBy),
-                        onDelete: nil,
-                        onOpenDetail: { selectedShare = share }
-                    )
+            VStack(spacing: 12) {
+                HStack {
+                    Spacer()
+                    addTrackPill
+                }
+                .padding(.horizontal)
+
+                if viewModel.isLoadingShares && viewModel.shares.isEmpty {
+                    XomifyLoaderPulse()
+                        .frame(maxWidth: .infinity, minHeight: 120)
+                } else if let error = viewModel.sharesError, viewModel.shares.isEmpty {
+                    emptyTab(icon: "exclamationmark.triangle",
+                             title: "Couldn't load stats",
+                             message: error)
+                } else if viewModel.shares.isEmpty {
+                    emptyTab(icon: "chart.bar",
+                             title: "No shares yet",
+                             message: "Once members start sharing, totals and breakdowns will appear here.")
+                } else {
+                    statsContent
+                }
+            }
+            .padding(.bottom, 16)
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+
+    @ViewBuilder
+    private var statsContent: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 10) {
+                statTile(
+                    value: "\(viewModel.totalShareCount)",
+                    label: viewModel.totalShareCount == 1 ? "song shared" : "songs shared",
+                    icon: "music.note.list"
+                )
+                statTile(
+                    value: viewModel.averageSharerRating
+                        .map { String(format: "%.1f", $0) } ?? "—",
+                    label: "avg rating",
+                    icon: "star.fill"
+                )
+            }
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Image(systemName: "person.3.fill")
+                        .font(.caption)
+                        .foregroundStyle(Color.xomifyGreen)
+                    Text("By member")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                    Spacer()
+                }
+                ForEach(viewModel.perUserStats) { stat in
+                    perUserRow(stat)
                 }
             }
             .padding(.horizontal)
-            .padding(.bottom, 16)
+        }
+    }
+
+    private func statTile(value: String, label: String, icon: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(Color.xomifyGreen)
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, minHeight: 88)
+        .padding(10)
+        .background(Color.xomifyCard)
+        .clipShape(.rect(cornerRadius: 12))
+    }
+
+    private func perUserRow(_ stat: GroupDetailViewModel.GroupUserStat) -> some View {
+        HStack(spacing: 12) {
+            avatarCircle(url: stat.avatarURL, initial: stat.displayName.prefix(1))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(stat.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text("\(stat.shareCount) share\(stat.shareCount == 1 ? "" : "s")")
+                    .font(.caption2)
+                    .foregroundStyle(.gray)
+            }
+            Spacer(minLength: 8)
+            if let avg = stat.averageRating {
+                HStack(spacing: 4) {
+                    Image(systemName: "star.fill")
+                        .font(.caption2)
+                        .foregroundStyle(Color.xomifyGreen)
+                    Text(String(format: "%.1f", avg))
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.white)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.white.opacity(0.08))
+                .clipShape(Capsule())
+            }
+        }
+        .padding(10)
+        .background(Color.xomifyCard)
+        .clipShape(.rect(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private func avatarCircle(url: URL?, initial: Substring) -> some View {
+        if let url {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    avatarFallbackCircle(initial: initial)
+                }
+            }
+            .frame(width: 36, height: 36)
+            .clipShape(Circle())
+        } else {
+            avatarFallbackCircle(initial: initial)
+        }
+    }
+
+    private func avatarFallbackCircle(initial: Substring) -> some View {
+        ZStack {
+            Circle()
+                .fill(LinearGradient.xomifyGradient)
+                .frame(width: 36, height: 36)
+            Text(String(initial).uppercased())
+                .font(.subheadline)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
         }
     }
 
@@ -305,24 +398,38 @@ struct GroupDetailView: View {
     }
 
     private func memberRow(_ member: GroupMember) -> some View {
-        HStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(LinearGradient.xomifyGradient)
-                    .frame(width: 40, height: 40)
-                Text(String(member.label.prefix(1)).uppercased())
-                    .font(.subheadline)
-                    .fontWeight(.bold)
-                    .foregroundStyle(.white)
+        let isSelf = member.email == viewerEmail
+        // Self-row uses the viewer's known display name + avatar — the
+        // backend's GroupMember payload doesn't currently carry profile
+        // info, so without this every self-row would show as the email.
+        let displayName: String = {
+            if isSelf, let mine = viewModel.viewerDisplayName, !mine.isEmpty {
+                return mine
             }
+            return member.label
+        }()
+        let avatarURL: URL? = isSelf ? viewModel.viewerAvatarURL : nil
+
+        return HStack(spacing: 12) {
+            avatarCircle(url: avatarURL, initial: displayName.prefix(1))
+                .frame(width: 40, height: 40)
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(member.label)
+                    Text(displayName)
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .foregroundStyle(.white)
                         .lineLimit(1)
+                    if isSelf {
+                        Text("YOU")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Color.xomifyGreen.opacity(0.18))
+                            .foregroundStyle(Color.xomifyGreen)
+                            .clipShape(.rect(cornerRadius: 4))
+                    }
                     if member.isOwner == true {
                         Text("OWNER")
                             .font(.caption2)
@@ -342,7 +449,27 @@ struct GroupDetailView: View {
 
             Spacer()
 
-            if member.isOwner != true, isOwner {
+            // Self + non-owner → Leave. Owner sees a remove button on others.
+            if isSelf, member.isOwner != true {
+                Button(role: .destructive) {
+                    showLeaveConfirm = true
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "rectangle.portrait.and.arrow.right")
+                        Text("Leave")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                    }
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .frame(minHeight: 32)
+                    .background(Color.red.opacity(0.12))
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Leave this group")
+            } else if !isSelf, member.isOwner != true, isOwner {
                 Button(role: .destructive) {
                     Task { await viewModel.removeMember(member) }
                 } label: {
@@ -358,27 +485,6 @@ struct GroupDetailView: View {
         .padding(12)
         .background(Color.xomifyCard)
         .clipShape(.rect(cornerRadius: 10))
-    }
-
-    // MARK: - Composer plumbing
-
-    /// Spin up a composer VM pre-targeted at this group and present the sheet.
-    private func presentComposer() {
-        composerVM = ShareComposerViewModel(
-            prefilledGroupIds: [groupId],
-            defaultShareToPublic: false
-        )
-        showingComposer = true
-    }
-
-    /// Best-effort identity for a member email — falls back to the email.
-    /// Group detail doesn't have access to the friends-graph map FeedViewModel
-    /// builds, so we resolve from the loaded `members` list.
-    private func identity(for email: String) -> SharerIdentity {
-        if let member = viewModel.members.first(where: { $0.email == email }) {
-            return SharerIdentity(displayName: member.label, avatarURL: nil)
-        }
-        return SharerIdentity(displayName: email, avatarURL: nil)
     }
 
     // MARK: - Empty helper
@@ -403,4 +509,5 @@ struct GroupDetailView: View {
     NavigationStack {
         GroupDetailView(groupId: "demo", viewerEmail: "me@me.com")
     }
+    .environment(NavigationStore())
 }

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -51,6 +51,7 @@ struct MainShell: View {
         }
         .environment(navStore)
         .ignoresSafeArea(edges: .bottom)
+        .gesture(edgeDragGesture)
         .task {
             // Share the nav store with the push pipeline so push-open handlers
             // can call `select(.feed)`.
@@ -97,6 +98,26 @@ struct MainShell: View {
         case .settings:
             SettingsView()
         }
+    }
+
+    // MARK: - Edge swipe → drawer
+
+    /// Edge swipe: a horizontal drag started near the leading edge that pulls
+    /// the drawer open, mirroring the system-wide left-edge gesture you'd
+    /// expect on iOS. We require the gesture to *start* in the leftmost ~30pt
+    /// so it doesn't fight horizontal scrolls inside content (carousels, etc).
+    private var edgeDragGesture: some Gesture {
+        DragGesture(minimumDistance: 12, coordinateSpace: .global)
+            .onEnded { value in
+                let startedAtEdge = value.startLocation.x < 30
+                let pulledRight = value.translation.width > 60
+                let mostlyHorizontal = abs(value.translation.width) > abs(value.translation.height) * 1.5
+                guard !navStore.isDrawerOpen,
+                      startedAtEdge,
+                      pulledRight,
+                      mostlyHorizontal else { return }
+                navStore.openDrawer()
+            }
     }
 
     // MARK: - Avatar fetch

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Bumps MARKETING_VERSION in Xomify-iOS.xcodeproj/project.pbxproj.
+#
+# Usage:
+#   scripts/bump-version.sh feat   # MAJOR.MINOR+1.0   (new feature)
+#   scripts/bump-version.sh fix    # MAJOR.MINOR.PATCH+1 (bug fix)
+#   scripts/bump-version.sh epic   # MAJOR+1.0.0       (huge release)
+#
+# The new version is printed to stdout. Exits non-zero if the kind is
+# missing/unknown or if the current version isn't valid SemVer.
+
+set -euo pipefail
+
+KIND="${1:-}"
+PBXPROJ="Xomify-iOS.xcodeproj/project.pbxproj"
+
+if [[ -z "$KIND" ]]; then
+  echo "usage: scripts/bump-version.sh <feat|fix|epic>" >&2
+  exit 2
+fi
+
+CURRENT=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+
+if ! [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "MARKETING_VERSION '$CURRENT' is not MAJOR.MINOR.PATCH — fix manually first." >&2
+  exit 3
+fi
+
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+case "$KIND" in
+  feat)  MINOR=$((MINOR + 1)); PATCH=0 ;;
+  fix)   PATCH=$((PATCH + 1)) ;;
+  epic)  MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  *)     echo "unknown kind: $KIND (expected feat|fix|epic)" >&2; exit 2 ;;
+esac
+
+NEW="${MAJOR}.${MINOR}.${PATCH}"
+
+# macOS sed lacks -i without an arg; portable form:
+sed -i.bak -E "s/MARKETING_VERSION = [^;]+;/MARKETING_VERSION = ${NEW};/g" "$PBXPROJ"
+rm "${PBXPROJ}.bak"
+
+echo "$NEW"


### PR DESCRIPTION
## Summary
- **Groups page rebuild**: drop Shares tab, add Stats tab (totals, avg sharer rating, per-user breakdown of shares + avg ratings)
- **Self-row hydration**: members list pulls viewer name/avatar via SpotifyService so self no longer renders as bare \"D\" with email duplicated
- **Self vs others**: self-row shows YOU badge + red Leave pill (non-owners); others keep existing remove behavior for owners
- **Add Track pill**: shrunk and now routes to the Feed tab (composer there) instead of in-page composer
- **Sidebar swipe**: MainShell adds an edge-anchored DragGesture (start <30pt, drag right >60pt, mostly horizontal) to open the drawer
- **Versioning policy**: pbxproj `MARKETING_VERSION` is canonical (bumped 1.0 → 1.1.0 for this minor feature), TestFlight workflow now reads it directly, and a `scripts/bump-version.sh feat|fix|epic` helper enforces the policy. Build numbers stay timestamp-based so reusing a marketing version across builds is fine. Documented in `.claude/rules/versioning.md`.

## Test plan
- [ ] Open a group → Members tab shows self with real name + avatar + YOU + Leave button
- [ ] Tap Stats tab → totals and per-user rows render with correct counts/avgs
- [ ] Tap Add Track → lands on Feed tab
- [ ] From any screen, swipe right from the very-left edge → drawer opens
- [ ] TestFlight workflow uses 1.1.0 as marketing version on next deploy
- [ ] `scripts/bump-version.sh fix` produces 1.1.1 (try-and-revert to verify regex)