### PR TITLE
fix: group Add Track jumps to Feed; drawer swipe-to-close

### DIFF
--- a/Xomify-iOS/Views/GroupDetailView.swift
+++ b/Xomify-iOS/Views/GroupDetailView.swift
@@ -172,6 +172,11 @@ struct GroupDetailView: View {
     /// content here.
     private var addTrackPill: some View {
         Button {
+            // Pop GroupDetailView off the navigation stack first, *then* swap
+            // the root destination. Without the dismiss, SwiftUI keeps the
+            // pushed detail view on top of the new Feed root and the user
+            // never sees the destination change.
+            dismiss()
             navStore.select(.feed)
         } label: {
             HStack(spacing: 6) {

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -61,10 +61,25 @@ struct DrawerView: View {
         GeometryReader { _ in
             HStack(spacing: 0) {
                 drawerPanel
+                    .gesture(closeDragGesture)
                 Spacer()
             }
         }
         .offset(x: navStore.isDrawerOpen ? 0 : -drawerWidth)
+    }
+
+    /// Drag the open drawer leftward to dismiss. Mirrors `MainShell`'s edge
+    /// swipe to open: requires a clearly horizontal drag past a small threshold
+    /// so it doesn't fight scrolls inside the drawer's row list.
+    private var closeDragGesture: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onEnded { value in
+                guard navStore.isDrawerOpen else { return }
+                let pulledLeft = value.translation.width < -60
+                let mostlyHorizontal = abs(value.translation.width) > abs(value.translation.height) * 1.5
+                guard pulledLeft, mostlyHorizontal else { return }
+                navStore.closeDrawer()
+            }
     }
 
     // MARK: - Drawer panel


### PR DESCRIPTION
## Summary
- **Add Track on group page now actually navigates to Feed.** Was a no-op — calling \`navStore.select(.feed)\` while a pushed view sits on top of the NavigationStack swaps the root underneath but leaves the detail pushed, so the user saw nothing change. Now we \`dismiss()\` the GroupDetailView first, then switch destinations.
- **Swipe-left on the open drawer closes it.** Mirrors PR B's edge-swipe-to-open with the same horizontal-bias / threshold checks so it doesn't conflict with scrolls inside the drawer's row list.

## Test plan
- [ ] Open a group → tap Stats → tap \"Add track\" pill → lands on Feed (no detail still on screen)
- [ ] Swipe right from left edge → drawer opens; swipe left on the open drawer → drawer closes
- [ ] Tapping the scrim still closes the drawer (no regression)