### PR TITLE
feat: track-actions menu on feed cards + fix own-post delete (1.2.0)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -36,8 +36,11 @@ final class ShareCardViewModel {
     private let spotifyService: SpotifyQueueing
 
     /// The authenticated viewer's email. Pushed down from the parent VM so the
-    /// card doesn't need to re-resolve it on every interaction.
-    let viewerEmail: String
+    /// card doesn't need to re-resolve it on every interaction. Stored as `var`
+    /// so `ShareCardView` can re-sync it once the parent's async email lookup
+    /// resolves — otherwise rate/queue/react/delete would fire with an empty
+    /// email and the own-post menu would never appear.
+    var viewerEmail: String
 
     // MARK: - Init
 

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -8,6 +8,13 @@ struct ShareCardView: View {
     @State private var showRateSheet: Bool = false
     @State private var showDeleteConfirm: Bool = false
 
+    /// Live viewer email plumbed from the parent feed. Held as a view-level
+    /// `let` (not just stashed in the VM at init) because the parent resolves
+    /// the email asynchronously — when it later flips from `""` → real value,
+    /// SwiftUI re-renders this view and the `.task(id:)` below re-syncs it
+    /// into the VM so own-post detection and write paths actually work.
+    let viewerEmail: String
+
     /// Resolved sharer identity (display name + avatar). Falls back to the
     /// email when unresolved — `FeedViewModel.identity(for:)` always returns
     /// a value, so the fallback tree is handled upstream.
@@ -32,6 +39,7 @@ struct ShareCardView: View {
         onDelete: (() -> Void)? = nil,
         onOpenDetail: (() -> Void)? = nil
     ) {
+        self.viewerEmail = viewerEmail
         _viewModel = State(initialValue: ShareCardViewModel(
             share: share,
             viewerEmail: viewerEmail
@@ -42,16 +50,18 @@ struct ShareCardView: View {
     }
 
     private var isOwnPost: Bool {
-        viewModel.share.sharedBy == viewModel.viewerEmail
+        !viewerEmail.isEmpty && viewModel.share.sharedBy == viewerEmail
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 8) {
                 detailTapZone
-                if isOwnPost, onDelete != nil {
-                    ownPostMenu
-                }
+                TrackActionsMenu(
+                    track: makeTrackForActions(),
+                    style: .icon,
+                    onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil
+                )
             }
             actionRow
             socialRow
@@ -65,6 +75,12 @@ struct ShareCardView: View {
         .padding(14)
         .background(Color.xomifyCard)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .task(id: viewerEmail) {
+            // Parent feed resolves `userEmail` asynchronously; once it lands,
+            // re-sync the VM so write paths and own-post detection use the
+            // real email instead of the empty string captured at init.
+            viewModel.viewerEmail = viewerEmail
+        }
         .sheet(isPresented: $showRateSheet) {
             RateSheet(viewModel: viewModel, isPresented: $showRateSheet)
                 .presentationDetents([.medium])
@@ -154,21 +170,49 @@ struct ShareCardView: View {
         }
     }
 
-    private var ownPostMenu: some View {
-        Menu {
-            Button(role: .destructive) {
-                showDeleteConfirm = true
-            } label: {
-                Label("Delete post", systemImage: "trash")
-            }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.subheadline)
-                .foregroundStyle(.gray)
-                .frame(width: 44, height: 44)
-                .contentShape(Rectangle())
-        }
-        .accessibilityLabel("Post options")
+    /// Synthesize a minimal `SpotifyTrack` from the share so the shared
+    /// `TrackActionsMenu` can drive play / queue / playlist-builder /
+    /// share-to-feed without a round-trip to `/v1/tracks`. Mirrors the
+    /// helper in `ShareDetailView`.
+    private func makeTrackForActions() -> SpotifyTrack {
+        let images: [SpotifyImage] = {
+            guard let url = viewModel.share.albumArtUrl, !url.isEmpty else { return [] }
+            return [SpotifyImage(url: url, height: nil, width: nil)]
+        }()
+        let album = SpotifyAlbum(
+            id: "",
+            name: viewModel.share.albumName ?? "",
+            uri: nil,
+            albumType: nil,
+            totalTracks: nil,
+            releaseDate: nil,
+            releaseDatePrecision: nil,
+            images: images,
+            artists: nil,
+            externalUrls: nil
+        )
+        let artist = SpotifyArtist(
+            id: nil,
+            name: viewModel.share.artistName,
+            uri: nil,
+            genres: nil,
+            popularity: nil,
+            followers: nil,
+            images: nil,
+            externalUrls: nil
+        )
+        return SpotifyTrack(
+            id: viewModel.share.trackId,
+            name: viewModel.share.trackName,
+            uri: viewModel.share.trackUri,
+            durationMs: 0,
+            explicit: nil,
+            popularity: nil,
+            previewUrl: nil,
+            album: album,
+            artists: [artist],
+            externalUrls: nil
+        )
     }
 
     @ViewBuilder

--- a/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
+++ b/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
@@ -26,6 +26,11 @@ struct TrackActionsMenu: View {
     let track: SpotifyTrack
     var style: Style = .icon
 
+    /// When non-nil, a destructive "Delete post" entry is appended to the menu.
+    /// Used by `ShareCardView` so own-post deletion lives in the same ellipsis
+    /// affordance as the standard track actions instead of a second button.
+    var onDelete: (() -> Void)? = nil
+
     @State private var queueAction = QueueActionController.shared
     @State private var playlistBuilder = PlaylistBuilderManager.shared
     @State private var isComposerShown = false
@@ -69,6 +74,13 @@ struct TrackActionsMenu: View {
                 isComposerShown = true
             } label: {
                 Label("Share to Feed", systemImage: "bubble.left.and.bubble.right.fill")
+            }
+
+            if let onDelete {
+                Divider()
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete post", systemImage: "trash")
+                }
             }
         } label: {
             switch style {


### PR DESCRIPTION
## Summary
- Adds `TrackActionsMenu` (.icon style) to every `ShareCardView` so users can play now / add to queue / open in Spotify / add to Playlist Builder / share to feed straight from the card — Dom's request: *\"add the action dots that have option to do all things we want with song\"*.
- Extends `TrackActionsMenu` with an optional `onDelete` callback; when provided a destructive *Delete post* entry is appended to the menu. `ShareCardView` wires this for own posts and removes the now-redundant standalone ellipsis button.
- **Fixes the \"can't delete my own posts\"** bug: `ShareCardViewModel.viewerEmail` was a `let` captured at `@State` init time. Because the parent `FeedViewModel.userEmail` resolves asynchronously, that value was usually `\"\"` when the card mounted — so `isOwnPost` was permanently false and the delete affordance never rendered. The view now holds `viewerEmail` as a view-level `let` and re-syncs it into the VM via `.task(id: viewerEmail)` once the parent's async lookup lands.
- Bumps `MARKETING_VERSION` → **1.2.0** (feat).

## Backend-blocked items still open (cannot be fixed from iOS)
- `/shares/comments` returns 500 on detail open
- `/shares/reactions` toggle returns 500
- `/ratings/publish` reportedly not saving
All three look like the same deferred deploy batch (xomify-infrastructure#72 + `deploy-backend.yml`).

## Spotify in-app playback
Yes — `TrackActionsMenu`'s *Play now* hits the Spotify Web API via `QueueActionController.play(uri:)`, which starts playback on the user's currently-active Spotify device. When no device is active it deep-links into the Spotify app so the user can tap Play once and the next call lands on a live device.

## Test plan
- [ ] Build & install: `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build`
- [ ] Open Feed; every card shows the ellipsis (top-right) with Play / Queue / Open / Builder / Share entries.
- [ ] Cards authored by the signed-in viewer also show the destructive *Delete post* entry. Cards by other users do not.
- [ ] Tap *Delete post* → confirmation dialog → Delete; the share is removed from the feed (calls `FeedViewModel.deleteShare`).
- [ ] Re-open the app cold to verify the delete entry still shows up after the email resolves async (the bug this PR fixes).