### PR TITLE
feat: searchable author picker replaces inline pill grid (1.3.0)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Views/Feed/AuthorPickerSheet.swift
+++ b/Xomify-iOS/Views/Feed/AuthorPickerSheet.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+/// Searchable picker for the "From" filter on the feed. Replaces the
+/// pill-per-friend grid that used to live inline in `FeedRefinementSheet` —
+/// that grid was fine for ~10 friends but breaks down past ~30 (vertical wall
+/// of pills, no way to find a name without scanning every chip). The picker
+/// scales to hundreds of friends because it's just a `List` + searchable.
+struct AuthorPickerSheet: View {
+
+    @Bindable var viewModel: FeedViewModel
+    let onDismiss: () -> Void
+
+    @State private var query: String = ""
+
+    private var filteredAuthors: [String] {
+        let all = viewModel.availableAuthors
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return all }
+        return all.filter { email in
+            let name = viewModel.identity(for: email).displayName
+            return name.localizedCaseInsensitiveContains(trimmed)
+                || email.localizedCaseInsensitiveContains(trimmed)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.xomifyDark.ignoresSafeArea()
+                content
+            }
+            .navigationTitle("From")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if !viewModel.refinement.authors.isEmpty {
+                        Button("Clear") {
+                            viewModel.refinement.authors = []
+                        }
+                        .foregroundStyle(.white)
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { onDismiss() }
+                        .foregroundStyle(.white)
+                        .fontWeight(.semibold)
+                }
+            }
+            .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search friends")
+        }
+        .tint(Color.xomifyGreen)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let authors = filteredAuthors
+        if viewModel.availableAuthors.isEmpty {
+            emptyState("No authors in the current feed yet.")
+        } else if authors.isEmpty {
+            emptyState("No friends match \"\(query)\".")
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(authors, id: \.self) { email in
+                        row(for: email)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+        }
+    }
+
+    private func row(for email: String) -> some View {
+        let identity = viewModel.identity(for: email)
+        let selected = viewModel.refinement.authors.contains(email)
+
+        return Button {
+            if selected {
+                viewModel.refinement.authors.remove(email)
+            } else {
+                viewModel.refinement.authors.insert(email)
+            }
+        } label: {
+            HStack(spacing: 12) {
+                avatar(for: identity)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(identity.displayName)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    if identity.displayName != email {
+                        Text(email)
+                            .font(.caption2)
+                            .foregroundStyle(.gray)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(selected ? Color.xomifyGreen : Color.white.opacity(0.4))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(minHeight: 44)
+            .background(Color.xomifyCard)
+            .clipShape(.rect(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(identity.displayName)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private func avatar(for identity: SharerIdentity) -> some View {
+        if let url = identity.avatarURL {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    avatarFallback(initial: identity.displayName.prefix(1))
+                }
+            }
+            .frame(width: 36, height: 36)
+            .clipShape(Circle())
+        } else {
+            avatarFallback(initial: identity.displayName.prefix(1))
+        }
+    }
+
+    private func avatarFallback(initial: Substring) -> some View {
+        ZStack {
+            Circle()
+                .fill(LinearGradient.xomifyGradient)
+                .frame(width: 36, height: 36)
+            Text(String(initial).uppercased())
+                .font(.subheadline)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
+        }
+    }
+
+    private func emptyState(_ message: String) -> some View {
+        VStack {
+            Spacer()
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
+++ b/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
@@ -8,6 +8,11 @@ struct FeedRefinementSheet: View {
     @Bindable var viewModel: FeedViewModel
     let onDismiss: () -> Void
 
+    /// Drives the searchable author picker. Surfaced as a separate sheet so
+    /// the refinement sheet stays compact regardless of friend count — the
+    /// previous pill-per-friend grid didn't scale past ~30 friends.
+    @State private var showAuthorPicker: Bool = false
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -42,6 +47,12 @@ struct FeedRefinementSheet: View {
             }
         }
         .tint(Color.xomifyGreen)
+        .sheet(isPresented: $showAuthorPicker) {
+            AuthorPickerSheet(viewModel: viewModel) {
+                showAuthorPicker = false
+            }
+            .presentationDetents([.large])
+        }
     }
 
     // MARK: - Date
@@ -68,12 +79,13 @@ struct FeedRefinementSheet: View {
     @ViewBuilder
     private var authorsSection: some View {
         let authors = viewModel.availableAuthors
+        let selectedCount = viewModel.refinement.authors.count
 
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 sectionHeader("From", icon: "person.2")
                 Spacer()
-                if !viewModel.refinement.authors.isEmpty {
+                if selectedCount > 0 {
                     Button("Clear") {
                         viewModel.refinement.authors = []
                     }
@@ -87,21 +99,62 @@ struct FeedRefinementSheet: View {
                     .font(.caption)
                     .foregroundStyle(.gray)
             } else {
-                WrappingChipGrid {
-                    ForEach(authors, id: \.self) { email in
-                        let name = viewModel.identity(for: email).displayName
-                        let selected = viewModel.refinement.authors.contains(email)
-                        pillChip(label: name, selected: selected) {
-                            if selected {
-                                viewModel.refinement.authors.remove(email)
-                            } else {
-                                viewModel.refinement.authors.insert(email)
-                            }
-                        }
-                    }
-                }
+                authorPickerButton(totalAuthors: authors.count, selectedCount: selectedCount)
             }
         }
+    }
+
+    /// Single-tap surface that opens the searchable picker. Replaces the
+    /// pill-per-friend grid that used to live here; the grid's visual weight
+    /// scaled linearly with friend count and was unusable past ~30 names.
+    private func authorPickerButton(totalAuthors: Int, selectedCount: Int) -> some View {
+        Button {
+            showAuthorPicker = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "person.crop.circle.badge.checkmark")
+                    .font(.body)
+                    .foregroundStyle(Color.xomifyGreen)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(authorButtonTitle(selectedCount: selectedCount, total: totalAuthors))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(.white)
+                    Text(authorButtonSubtitle(selectedCount: selectedCount, total: totalAuthors))
+                        .font(.caption2)
+                        .foregroundStyle(.gray)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            .padding(12)
+            .frame(minHeight: 44)
+            .background(Color.xomifyCard)
+            .clipShape(.rect(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("From \(authorButtonTitle(selectedCount: selectedCount, total: totalAuthors))")
+        .accessibilityHint("Opens the friend picker")
+    }
+
+    private func authorButtonTitle(selectedCount: Int, total: Int) -> String {
+        switch selectedCount {
+        case 0:    return "All friends"
+        case 1:    return "1 friend selected"
+        default:   return "\(selectedCount) friends selected"
+        }
+    }
+
+    private func authorButtonSubtitle(selectedCount: Int, total: Int) -> String {
+        if selectedCount == 0 {
+            return "Showing posts from everyone in this feed"
+        }
+        return "Tap to add or remove friends · \(total) available"
     }
 
     // MARK: - Unlistened


### PR DESCRIPTION
## Summary
The feed refinement sheet's *From* filter used to render one selectable pill per friend in a wrapping grid. That works at ~10 friends but turns into a vertical wall past 30 and is unusable at 100+.

This PR:
- Adds `AuthorPickerSheet` — searchable, scrollable list (avatar + name + checkmark per row).
- Replaces the inline pill grid with a single summary button (\"All friends\" / \"N friends selected\") that opens the picker on tap.
- Bumps version to **1.3.0** (feat).

## Test plan
- [ ] Build & launch.
- [ ] Open Feed → tap *Filters* → in the sheet, the *From* section now shows a single button instead of pills.
- [ ] Tap the button → picker sheet opens with the author list.
- [ ] Type in the search bar — the list filters by display name + email.
- [ ] Tap rows to select / deselect; checkmarks update.
- [ ] *Clear* in the toolbar resets the selection.
- [ ] *Done* dismisses the picker; the button summary updates ("3 friends selected").
- [ ] Re-open the picker — selections persist.