### PR TITLE
feat: Recent tab on Profile — last-25 liked + recently played (1.4.0)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SpotifyModels.swift
+++ b/Xomify-iOS/Models/SpotifyModels.swift
@@ -200,6 +200,34 @@ struct MultipleTracksResponse: Codable, Sendable {
     let tracks: [SpotifyTrack?]
 }
 
+/// `/me/tracks` response item — wraps a `SpotifyTrack` with the date the user
+/// hearted it. `addedAt` decodes from snake-case `added_at` thanks to the
+/// network layer's `convertFromSnakeCase` policy.
+struct SpotifySavedTrack: Codable, Sendable {
+    let addedAt: String?
+    let track: SpotifyTrack
+}
+
+struct SavedTracksResponse: Codable, Sendable {
+    let items: [SpotifySavedTrack]
+    let total: Int?
+    let limit: Int?
+    let offset: Int?
+}
+
+/// `/me/player/recently-played` response item — track + playback context +
+/// when it was played.
+struct SpotifyPlayHistory: Codable, Sendable {
+    let track: SpotifyTrack
+    let playedAt: String?
+}
+
+struct RecentlyPlayedResponse: Codable, Sendable {
+    let items: [SpotifyPlayHistory]
+    let next: String?
+    let limit: Int?
+}
+
 struct SearchResponse: Codable, Sendable {
     let tracks: SearchTracks?
     let artists: SearchArtists?

--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -63,6 +63,7 @@ final class AuthService: NSObject, Sendable {
             "user-follow-modify",
             "user-modify-playback-state",
             "user-read-playback-state",
+            "user-read-recently-played",
             "streaming"
         ].joined(separator: " ")
         

--- a/Xomify-iOS/Services/SpotifyService.swift
+++ b/Xomify-iOS/Services/SpotifyService.swift
@@ -184,8 +184,28 @@ actor SpotifyService {
         return response.items
     }
     
+    // MARK: - Library / Recently Played
+
+    /// User's saved (liked) tracks, newest-first. Requires the
+    /// `user-library-read` scope on the Spotify token.
+    func getSavedTracks(limit: Int = 25) async throws -> [SpotifySavedTrack] {
+        let response: SavedTracksResponse = try await network.spotifyGet(
+            "/me/tracks?limit=\(limit)"
+        )
+        return response.items
+    }
+
+    /// User's recently played tracks, newest-first. Requires the
+    /// `user-read-recently-played` scope.
+    func getRecentlyPlayed(limit: Int = 25) async throws -> [SpotifyPlayHistory] {
+        let response: RecentlyPlayedResponse = try await network.spotifyGet(
+            "/me/player/recently-played?limit=\(limit)"
+        )
+        return response.items
+    }
+
     // MARK: - Tracks
-    
+
     /// Get track details
     func getTrack(id: String) async throws -> SpotifyTrack {
         try await network.spotifyGet("/tracks/\(id)")

--- a/Xomify-iOS/ViewModels/Profile/ProfileRecentViewModel.swift
+++ b/Xomify-iOS/ViewModels/Profile/ProfileRecentViewModel.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Loads the signed-in user's last-25 liked tracks and last-25 recently
+/// played tracks from Spotify so the Recent tab on Profile can offer a
+/// quick "what was I just into?" surface — Dom's ask: easy way to find
+/// songs to add to the feed without leaving the app.
+///
+/// Both endpoints are best-effort; one failing doesn't block the other.
+@Observable
+@MainActor
+final class ProfileRecentViewModel {
+
+    // MARK: - State
+
+    var likedTracks: [SpotifyTrack] = []
+    var recentlyPlayed: [SpotifyTrack] = []
+
+    var isLoading: Bool = false
+    var likedError: String?
+    var recentError: String?
+
+    private var hasLoaded: Bool = false
+
+    // MARK: - Dependencies
+
+    private let spotifyService: SpotifyRecentProviding
+
+    init(spotifyService: SpotifyRecentProviding = SpotifyService.shared) {
+        self.spotifyService = spotifyService
+    }
+
+    // MARK: - Load
+
+    /// Run both fetches in parallel. Re-entrant safe — no-ops while in flight,
+    /// and uses `hasLoaded` so `.task` doesn't re-fetch on every tab switch.
+    func loadIfNeeded() async {
+        guard !hasLoaded, !isLoading else { return }
+        await load()
+    }
+
+    /// Force a fresh fetch (used by pull-to-refresh).
+    func load() async {
+        guard !isLoading else { return }
+        isLoading = true
+        likedError = nil
+        recentError = nil
+        defer { isLoading = false }
+
+        async let likedTask: [SpotifySavedTrack] = fetchLiked()
+        async let recentTask: [SpotifyPlayHistory] = fetchRecent()
+
+        do {
+            likedTracks = try await likedTask.map { $0.track }
+        } catch {
+            likedError = error.localizedDescription
+            likedTracks = []
+        }
+
+        do {
+            recentlyPlayed = try await recentTask.map { $0.track }
+        } catch {
+            recentError = error.localizedDescription
+            recentlyPlayed = []
+        }
+
+        hasLoaded = true
+    }
+
+    private func fetchLiked() async throws -> [SpotifySavedTrack] {
+        try await spotifyService.getSavedTracks(limit: 25)
+    }
+
+    private func fetchRecent() async throws -> [SpotifyPlayHistory] {
+        try await spotifyService.getRecentlyPlayed(limit: 25)
+    }
+}
+
+/// Narrow protocol so the VM can be unit-tested without standing up the full
+/// `SpotifyService` actor. Mirrors the pattern other Profile VMs use.
+protocol SpotifyRecentProviding: Sendable {
+    func getSavedTracks(limit: Int) async throws -> [SpotifySavedTrack]
+    func getRecentlyPlayed(limit: Int) async throws -> [SpotifyPlayHistory]
+}
+
+extension SpotifyService: SpotifyRecentProviding {}

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -6,6 +6,10 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
     case ratings
     case taste
     case playlists
+    /// Last-25 liked + last-25 recently played from Spotify. Self-only
+    /// because the underlying Spotify endpoints are scoped to the
+    /// authenticated user — we have no way to fetch a friend's library.
+    case recent
 
     var title: String {
         switch self {
@@ -13,6 +17,7 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
         case .ratings:   return "Ratings"
         case .taste:     return "Taste"
         case .playlists: return "Playlists"
+        case .recent:    return "Recent"
         }
     }
 
@@ -24,6 +29,7 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
         case .ratings:   return "star.fill"
         case .taste:     return "waveform"
         case .playlists: return "music.note.list"
+        case .recent:    return "clock.arrow.circlepath"
         }
     }
 }
@@ -87,7 +93,7 @@ final class UserProfileViewModel {
     /// playlists for `.other` once the `FriendProfile` payload has loaded.
     var visibleTabs: [ProfileTab] {
         switch context {
-        case .me:    return [.shares, .ratings, .taste, .playlists]
+        case .me:    return [.shares, .ratings, .taste, .playlists, .recent]
         case .other: return [.shares, .ratings, .taste, .playlists]
         }
     }

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRecentTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRecentTab.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// Self-only tab on `ProfileView` that lists the signed-in user's last-25
+/// liked tracks and last-25 recently-played tracks. Powers Dom's ask:
+/// a quick way to find songs to share to the feed without bouncing into
+/// the Spotify app.
+///
+/// Each row uses the shared `TrackActionsMenu` so users can play / queue /
+/// open / add to playlist builder / share to feed inline.
+struct ProfileRecentTab: View {
+
+    @State private var viewModel = ProfileRecentViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            section(
+                title: "Recently played",
+                icon: "clock.arrow.circlepath",
+                tracks: viewModel.recentlyPlayed,
+                error: viewModel.recentError,
+                emptyText: "Nothing played recently."
+            )
+
+            section(
+                title: "Liked songs",
+                icon: "heart.fill",
+                tracks: viewModel.likedTracks,
+                error: viewModel.likedError,
+                emptyText: "You haven't liked any songs yet."
+            )
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .task {
+            await viewModel.loadIfNeeded()
+        }
+        .refreshable {
+            await viewModel.load()
+        }
+    }
+
+    @ViewBuilder
+    private func section(
+        title: String,
+        icon: String,
+        tracks: [SpotifyTrack],
+        error: String?,
+        emptyText: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.xomifyGreen)
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Spacer()
+                if !tracks.isEmpty {
+                    Text("\(tracks.count)")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.gray)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Color.white.opacity(0.06))
+                        .clipShape(Capsule())
+                }
+            }
+
+            if let error {
+                errorRow(error)
+            } else if viewModel.isLoading && tracks.isEmpty {
+                loadingRow
+            } else if tracks.isEmpty {
+                emptyRow(emptyText)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
+                        trackRow(index: index, track: track)
+                    }
+                }
+            }
+        }
+    }
+
+    private func trackRow(index: Int, track: SpotifyTrack) -> some View {
+        HStack(spacing: 12) {
+            indexLabel(index)
+            albumArt(track)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(artistNames(track))
+                    .font(.caption2)
+                    .foregroundStyle(.gray)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            TrackActionsMenu(track: track)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func indexLabel(_ index: Int) -> some View {
+        Text("\(index + 1)")
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.white.opacity(0.5))
+            .frame(width: 18, alignment: .trailing)
+    }
+
+    @ViewBuilder
+    private func albumArt(_ track: SpotifyTrack) -> some View {
+        if let url = track.album?.images?.first?.url, let imageUrl = URL(string: url) {
+            AsyncImage(url: imageUrl) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    placeholder
+                }
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(.rect(cornerRadius: 6))
+        } else {
+            placeholder
+                .frame(width: 44, height: 44)
+                .clipShape(.rect(cornerRadius: 6))
+        }
+    }
+
+    private var placeholder: some View {
+        Color.xomifyPurple.opacity(0.25)
+            .overlay(
+                Image(systemName: "music.note")
+                    .foregroundStyle(Color.xomifyPurple)
+            )
+    }
+
+    private func artistNames(_ track: SpotifyTrack) -> String {
+        track.artists.compactMap { $0.name }.joined(separator: ", ")
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            XomifyLoaderSpin()
+            Spacer()
+        }
+        .frame(minHeight: 80)
+    }
+
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(.gray)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.xomifyCard.opacity(0.5))
+            .clipShape(.rect(cornerRadius: 10))
+    }
+
+    private func errorRow(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Color.xomifyCard.opacity(0.6))
+        .clipShape(.rect(cornerRadius: 10))
+    }
+}

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -95,6 +95,9 @@ struct ProfileView: View {
 
         case .playlists:
             ProfilePlaylistsTab(viewModel: viewModel.playlistsViewModel())
+
+        case .recent:
+            ProfileRecentTab()
         }
     }
 


### PR DESCRIPTION
## Summary
Adds a self-only **Recent** tab to `ProfileView` with two sections: last-25 *Recently played* and last-25 *Liked songs* — pulled straight from the Spotify Web API. Each row carries the shared `TrackActionsMenu` so users can play / queue / open in Spotify / add to Playlist Builder / share to Feed in one tap.

Driven by Dom's ask: *\"can we add a recently played/liked section on user profile or side tab? like last 25 liked songs last 25 played songs would be cool and make it easy to find songs to add to feed and such.\"*

## Changes
- `SpotifyService` gains `getSavedTracks(limit:)` (`/v1/me/tracks`) and `getRecentlyPlayed(limit:)` (`/v1/me/player/recently-played`) plus the matching `SpotifySavedTrack` / `SpotifyPlayHistory` decoders.
- `AuthService` requests the **`user-read-recently-played`** scope (`user-library-read` was already on the list). Existing tokens will need a re-login to grant the new scope — Spotify won't add it on the next refresh.
- New `ProfileRecentViewModel` runs the two fetches in parallel; per-section error state so a single endpoint failure doesn't blank the tab.
- New `ProfileRecentTab` view + `ProfileTab.recent` case (clock glyph). Only listed for `.me` context because the underlying endpoints are scoped to the authenticated viewer.
- Bumps version to **1.4.0** (feat).

## Notes
- The Recent tab is `.me`-only — there is no public Spotify endpoint for another user's library/history, so we'd have nothing to render on a friend's profile.
- Nothing else moved on the existing tabs; switching between Posts / Ratings / Taste / Playlists is unchanged.

## Test plan
- [ ] **Re-auth required** to pick up the new scope: Settings → Sign out → Sign back in.
- [ ] Open your own profile → tab strip now shows a clock glyph after Playlists.
- [ ] Tap Recent → both sections render the latest 25 items.
- [ ] Each row's ellipsis menu offers Play now / Add to queue / Open in Spotify / Add to Playlist Builder / Share to Feed.
- [ ] Pull-to-refresh re-fetches both sections.
- [ ] Open a *friend's* profile → Recent tab is **not** present.
- [ ] If one section errors (e.g. simulated 403) the other still loads; per-section banner appears for the failure.