### PR TITLE
fix: rating 400 (missing albumArt) + surface feed Actions menu (1.5.0)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -558,12 +558,16 @@ actor XomifyService {
     // MARK: - Ratings
 
     /// Publish (create or update) a rating for a track. Rating is 1-5.
+    /// `albumArt` is required by the backend (`/ratings/publish` rejects with
+    /// 400 when missing). Pass `share.albumArtUrl` from the feed; for non-feed
+    /// rate surfaces, hand in `track.imageUrl?.absoluteString`.
     @discardableResult
     func publishRating(
         email: String,
         trackId: String,
         trackName: String,
         artistName: String,
+        albumArt: String?,
         rating: Int,
         review: String? = nil
     ) async throws -> SuccessResponse {
@@ -572,6 +576,7 @@ actor XomifyService {
             "trackId": trackId,
             "trackName": trackName,
             "artistName": artistName,
+            "albumArt": albumArt ?? "",
             "rating": rating
         ]
         if let review = review, !review.isEmpty {

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -70,6 +70,7 @@ protocol XomifyServiceProtocol: Sendable {
         trackId: String,
         trackName: String,
         artistName: String,
+        albumArt: String?,
         rating: Int,
         review: String?
     ) async throws -> SuccessResponse

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -127,6 +127,7 @@ final class ShareCardViewModel {
                 trackId: share.trackId,
                 trackName: share.trackName,
                 artistName: share.artistName,
+                albumArt: share.albumArtUrl,
                 rating: stars,
                 review: nil
             )

--- a/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
@@ -140,6 +140,7 @@ final class ShareDetailViewModel {
                 trackId: share.trackId,
                 trackName: share.trackName,
                 artistName: share.artistName,
+                albumArt: share.albumArtUrl,
                 rating: stars,
                 review: nil
             )

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -55,14 +55,7 @@ struct ShareCardView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 8) {
-                detailTapZone
-                TrackActionsMenu(
-                    track: makeTrackForActions(),
-                    style: .icon,
-                    onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil
-                )
-            }
+            detailTapZone
             actionRow
             socialRow
             if let error = viewModel.queueError {
@@ -325,12 +318,22 @@ struct ShareCardView: View {
 
     // MARK: - Action row
 
+    /// `Queue` stays as a one-tap primary; the labeled `Actions` pill exposes
+    /// the rest of the track menu (play now, open in Spotify, add to playlist
+    /// builder, share to feed, plus delete on own posts) so the affordance is
+    /// as discoverable as on the detail view — the prior icon-only "…" at the
+    /// top of the card was too easy to miss.
     private var actionRow: some View {
         HStack(spacing: 10) {
             queueButton
             rateButton
-            commentButton
+            TrackActionsMenu(
+                track: makeTrackForActions(),
+                style: .pill,
+                onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil
+            )
             Spacer()
+            commentButton
             if viewModel.displayedQueueCount > 0 {
                 queueCountChip
             }

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -112,7 +112,7 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
 
     func publishRating(
         email: String, trackId: String, trackName: String, artistName: String,
-        rating: Int, review: String?
+        albumArt: String?, rating: Int, review: String?
     ) async throws -> SuccessResponse {
         SuccessResponse(success: true)
     }


### PR DESCRIPTION
## Summary

Two iOS fixes from this round of testing:

### 1. Ratings 400 — `Missing required fields: albumArt`
\`/ratings/publish\` returns:
\`\`\`
{"error":{"message":"Missing required fields: albumArt","status":400,"field":"albumArt"}}
\`\`\`
We weren't sending it. Plumbed \`share.albumArtUrl\` through \`publishRating\` (protocol, service, mock, both feed call sites). Empty-string fallback when the share has no art.

### 2. Feed actions discoverability
The small icon-only "…" at the top-right of each feed card was too easy to miss — users only saw the prominent **Queue** button and assumed that was the only action.

Replaced it with a labeled **Actions** pill in the bottom action row, matching the detail view treatment. Same menu items (Play now, Add to queue, Open in Spotify, Add to Playlist Builder, Share to Feed) plus **Delete** for own posts.

Bottom row now reads: \`[Queue] [Rate] [Actions ⋯]    [💬]  [chip]\`

## Still backend-blocked (NOT iOS-fixable, surface for next backend deploy)

- **Comments POST 500** — \`/shares/comments\` returns \`{"message":""}\`. Likely the same deferred terraform/lambda deploy as before.
- **"Play now counts as listened"** — needs a new interaction action type (\`played\` or expanded \`queued\`) on the backend before iOS can record it.

## Test plan

- [ ] Pull, build, install
- [ ] Rate a feed post — should succeed (no 400) and persist on refresh
- [ ] Tap **Actions** on a feed card — full 5-action menu opens
- [ ] On own post, **Actions** menu includes destructive **Delete post**
- [ ] Detail view rating still works (also passes albumArt)