### PR TITLE
fix: icon-only feed actions + rating sync + suppress empty-thread comment error (1.5.1)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -350,6 +350,29 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         )
     }
 
+    /// Optimistically patch the viewer's own rating onto the share so the
+    /// downstream detail view (which builds its own VM from this Share) sees
+    /// the rating the user just set on the feed card. `bumpRatedCount` adds 1
+    /// to `ratedCount` when the viewer hadn't already rated this share —
+    /// keeps the friends-rated stat in sync without a refetch.
+    func withViewerRating(_ rating: Int?) -> Share {
+        let bumpRatedCount = (viewerRating == nil && rating != nil) ? 1
+            : (viewerRating != nil && rating == nil) ? -1 : 0
+        return Share(
+            shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt,
+            trackId: trackId, trackUri: trackUri, trackName: trackName,
+            artistName: artistName, albumName: albumName, albumArtUrl: albumArtUrl,
+            caption: caption, moodTag: moodTag, genreTags: genreTags,
+            queuedCount: queuedCount, ratedCount: max(0, ratedCount + bumpRatedCount),
+            viewerHasQueued: viewerHasQueued, viewerRating: rating,
+            sharerRating: sharerRating,
+            groupIds: groupIds, isPublic: isPublic,
+            commentCount: commentCount,
+            reactionCounts: reactionCounts,
+            viewerReactions: viewerReactions
+        )
+    }
+
     /// Same idea for comment count adjustments.
     func withCommentCount(_ newCount: Int) -> Share {
         Share(

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -131,6 +131,11 @@ final class ShareCardViewModel {
                 rating: stars,
                 review: nil
             )
+            // Patch the share so when the user navigates to the detail view,
+            // the freshly-pushed Share carries `viewerRating = stars`.
+            // Without this, ShareDetailViewModel.init reads the stale
+            // server-side `nil` and the detail screen shows no rating.
+            share = share.withViewerRating(stars)
         } catch {
             myRating = previous
             rateError = error.localizedDescription

--- a/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
@@ -144,6 +144,9 @@ final class ShareDetailViewModel {
                 rating: stars,
                 review: nil
             )
+            // Patch local share so a subsequent `load()` won't override the
+            // viewer rating with a stale server value.
+            share = share.withViewerRating(stars)
         } catch {
             myRating = previous
             rateError = error.localizedDescription

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -57,7 +57,6 @@ struct ShareCardView: View {
         VStack(alignment: .leading, spacing: 12) {
             detailTapZone
             actionRow
-            socialRow
             if let error = viewModel.queueError {
                 errorBanner(error)
             }
@@ -318,22 +317,29 @@ struct ShareCardView: View {
 
     // MARK: - Action row
 
-    /// `Queue` stays as a one-tap primary; the labeled `Actions` pill exposes
-    /// the rest of the track menu (play now, open in Spotify, add to playlist
-    /// builder, share to feed, plus delete on own posts) so the affordance is
-    /// as discoverable as on the detail view — the prior icon-only "…" at the
-    /// top of the card was too easy to miss.
+    /// Single icon-first row holding every front-of-card action so labels
+    /// never wrap. The `Queue` shortcut moved into the Actions menu and the
+    /// reaction bar (smiley + active pills) sits inline next to comment so
+    /// users don't have to scan a separate row to react.
+    /// Order: Actions ⋯ → Rate ☆ → 💬 N → 😊 reactions → friend-queued chip.
     private var actionRow: some View {
-        HStack(spacing: 10) {
-            queueButton
-            rateButton
+        HStack(spacing: 8) {
             TrackActionsMenu(
                 track: makeTrackForActions(),
-                style: .pill,
+                style: .icon,
                 onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil
             )
-            Spacer()
+            rateButton
             commentButton
+            ReactionsBar(
+                counts: viewModel.share.reactionCounts,
+                viewerReactions: viewModel.share.viewerReactions,
+                inFlightSlugs: viewModel.reactingSlugs,
+                onToggle: { reaction in
+                    Task { await viewModel.toggleReaction(reaction) }
+                }
+            )
+            Spacer(minLength: 0)
             if viewModel.displayedQueueCount > 0 {
                 queueCountChip
             }
@@ -346,16 +352,19 @@ struct ShareCardView: View {
         Button {
             onOpenDetail?()
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Image(systemName: "bubble.left")
-                Text("\(viewModel.share.commentCount)")
                     .font(.subheadline)
-                    .fontWeight(.medium)
+                if viewModel.share.commentCount > 0 {
+                    Text("\(viewModel.share.commentCount)")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
             }
             .foregroundStyle(.white)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, 10)
             .padding(.vertical, 8)
-            .frame(minHeight: 44)
+            .frame(minWidth: 44, minHeight: 44)
             .background(Color.white.opacity(0.08))
             .clipShape(Capsule())
         }
@@ -363,79 +372,23 @@ struct ShareCardView: View {
         .accessibilityLabel("\(viewModel.share.commentCount) comments. Tap to open.")
     }
 
-    /// Reactions row — only renders pills for reactions with count ≥ 1, plus
-    /// the smiley menu to add a new one.
-    @ViewBuilder
-    private var socialRow: some View {
-        let counts = viewModel.share.reactionCounts
-        let viewer = viewModel.share.viewerReactions
-        if !counts.isEmpty || !viewer.isEmpty {
-            ReactionsBar(
-                counts: counts,
-                viewerReactions: viewer,
-                inFlightSlugs: viewModel.reactingSlugs,
-                onToggle: { reaction in
-                    Task { await viewModel.toggleReaction(reaction) }
-                }
-            )
-        } else {
-            // Empty state: just show the add button so a viewer can react first.
-            HStack {
-                ReactionsBar(
-                    counts: [:],
-                    viewerReactions: [],
-                    inFlightSlugs: viewModel.reactingSlugs,
-                    onToggle: { reaction in
-                        Task { await viewModel.toggleReaction(reaction) }
-                    }
-                )
-                Spacer()
-            }
-        }
-    }
-
-    private var queueButton: some View {
-        Button {
-            Task { await viewModel.queue() }
-        } label: {
-            HStack(spacing: 6) {
-                if viewModel.isQueuing {
-                    ProgressView()
-                        .controlSize(.small)
-                        .tint(.white)
-                } else {
-                    Image(systemName: viewModel.queuedLocally ? "checkmark.circle.fill" : "text.badge.plus")
-                }
-                Text(viewModel.queuedLocally ? "Queued" : "Queue")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-            }
-            .foregroundStyle(.white)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(minHeight: 44)
-            .background(viewModel.queuedLocally ? Color.xomifyGreen.opacity(0.25) : Color.xomifyPurple)
-            .clipShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .disabled(viewModel.isQueuing)
-        .accessibilityLabel(viewModel.queuedLocally ? "Queued on Spotify" : "Queue on Spotify")
-    }
-
     private var rateButton: some View {
         Button {
             showRateSheet = true
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Image(systemName: viewModel.myRating != nil ? "star.fill" : "star")
-                Text(viewModel.myRating.map { "\($0)/5" } ?? "Rate")
                     .font(.subheadline)
-                    .fontWeight(.medium)
+                if let rating = viewModel.myRating {
+                    Text("\(rating)/5")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
             }
             .foregroundStyle(viewModel.myRating != nil ? Color.xomifyGreen : .white)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, 10)
             .padding(.vertical, 8)
-            .frame(minHeight: 44)
+            .frame(minWidth: 44, minHeight: 44)
             .background(Color.white.opacity(0.08))
             .clipShape(Capsule())
         }

--- a/Xomify-iOS/Views/Feed/ShareDetailView.swift
+++ b/Xomify-iOS/Views/Feed/ShareDetailView.swift
@@ -410,7 +410,12 @@ struct ShareDetailView: View {
                 }
             }
 
-            if let error = viewModel.commentsError {
+            // Suppress the load error banner when the thread is empty — the
+            // backend returns 500 on threads that have never had a comment,
+            // and surfacing it on every empty post is just noise. A real
+            // failure on a populated thread (e.g., refresh after the first
+            // load) still falls through to the banner.
+            if let error = viewModel.commentsError, !viewModel.comments.isEmpty {
                 inlineErrorBanner(error)
             }
         }


### PR DESCRIPTION
## Summary

Three iOS fixes from the latest test pass:

### 1. Feed card actions — icon-only single row
Labels were wrapping to multiple lines on narrow widths. Collapsed everything onto one row, icon-first:

\`[Actions ⋯] [Rate ☆ N/5] [💬 N] [😊 reactions] ... [👥 chip]\`

- Standalone **Queue** pill removed — queue lives inside the Actions menu.
- ReactionsBar moves inline next to Comment so react + comment are both on the front of the card without a second row.
- Rate / Comment shed text labels; the count tag only renders when > 0.

### 2. Rating sync feed → detail
After \`publishRating\` succeeds, the card now patches \`share.viewerRating\` via the new \`Share.withViewerRating\` helper (also bumps \`ratedCount\` going nil→set). When the user navigates to the detail view, \`ShareDetailViewModel.init\` reads the pushed Share and sees the rating instead of the stale server-side nil. Same patch on the detail rate path so a subsequent \`load()\` doesn't overwrite the local value.

### 3. Suppress empty-thread comments error banner
Backend returns 500 on threads that have never had a comment. Until that's fixed, the detail view only shows the load-error banner when there are actual comments — empty threads just show \"No comments yet. Be the first.\"

## Backend-blocked (cannot fix from iOS)

- **\`/shares/comments\` POST returns 500** with \`{\"message\":\"\"}\` — Dom can't post a comment.
- **\`/shares/comments\` GET returns 500** on empty threads (this PR hides the banner; the underlying issue is still backend's).
- **\`/shares/reactions\` toggle returns 500** — reactions don't actually persist.
- **Spotify in-app playback without an active device** — the Web API requires a device to be active. The \`Play now\` / \`Add to queue\` actions in TrackActionsMenu fall back to deep-linking the Spotify app today. Real fix: integrate the **Spotify iOS SDK** so we can drive playback in-process. That's a multi-PR effort (SDK install, auth integration, playback controller) and warrants its own plan.

## Test plan

- [ ] Pull, build, install
- [ ] Feed card shows the new compact row (no wrapping labels)
- [ ] React via the smiley — picker opens, emoji toggles
- [ ] Rate from the feed card → open detail → \"your rating\" stat shows the value
- [ ] Open a post with no comments → no red banner