### PR TITLE
feat: SpotifyRemoteService + PlaybackCoordinator + scene lifecycle (Phase 2)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/App/Xomify_iOSApp.swift
+++ b/Xomify-iOS/App/Xomify_iOSApp.swift
@@ -6,14 +6,23 @@ struct Xomify_iOSApp: App {
     /// Owned here so the app has a single delegate for the whole lifecycle.
     @UIApplicationDelegateAdaptor(XomifyAppDelegate.self) private var appDelegate
 
+    @Environment(\.scenePhase) private var scenePhase
+
+    private let coordinator = SpotifyPlaybackCoordinator.shared
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .preferredColorScheme(.dark) // Force dark mode for Xomify branding
+                .environment(coordinator)
                 .onOpenURL { url in
                     // Route deep links. Invite URLs (Universal Links and custom
                     // scheme) are stashed on `InviteCoordinator`; the Friends
                     // screen picks them up once it loads.
+                    //
+                    // Also forward to the SDK in case the URL carries a Spotify
+                    // auth-handover token (xomify://callback?access_token=...).
+                    coordinator.remote.handleOpenURL(url)
                     InviteCoordinator.shared.handle(url)
                 }
                 .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
@@ -22,6 +31,16 @@ struct Xomify_iOSApp: App {
                     // the same coordinator path.
                     if let url = activity.webpageURL {
                         InviteCoordinator.shared.handle(url)
+                    }
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    switch newPhase {
+                    case .active:
+                        Task { await coordinator.connectIfAuthenticated() }
+                    case .background:
+                        coordinator.disconnect()
+                    default:
+                        break
                     }
                 }
         }

--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -16,7 +16,13 @@ final class AuthService: NSObject, Sendable {
     private(set) var refreshToken: String?
     private(set) var tokenExpirationDate: Date?
     private(set) var isAuthenticated = false
-    
+
+    /// Called whenever a new access token is persisted (initial login or refresh).
+    /// `SpotifyPlaybackCoordinator` wires itself in here so it can push the
+    /// updated token into the live `SPTAppRemote` instance without polling.
+    @ObservationIgnored
+    var onTokenRefresh: (@Sendable (String) -> Void)?
+
     private var authSession: ASWebAuthenticationSession?
     private var codeVerifier: String?
     
@@ -104,6 +110,25 @@ final class AuthService: NSObject, Sendable {
         }
         
         print("✅ Auth: Tokens saved to Keychain, expires in \(expiresIn)s")
+
+        onTokenRefresh?(accessToken)
+    }
+
+    // MARK: - SDK Token Access
+
+    /// Returns a valid access token for the Spotify iOS SDK, auto-refreshing
+    /// if the current token is expired. Returns `nil` if not authenticated.
+    func accessTokenForSDK() async -> String? {
+        guard isAuthenticated else { return nil }
+        if isTokenExpired {
+            do {
+                try await refreshAccessToken()
+            } catch {
+                print("⚠️ Auth: Could not refresh token for SDK: \(error)")
+                return nil
+            }
+        }
+        return accessToken
     }
     
     var isTokenExpired: Bool {

--- a/Xomify-iOS/Services/SpotifyPlaybackCoordinator.swift
+++ b/Xomify-iOS/Services/SpotifyPlaybackCoordinator.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Routes Play / Queue actions through the Spotify iOS SDK first, falling back
+/// to the Web API when the SDK is unavailable (Spotify not installed, not
+/// connected) or when the user has enabled the force-fallback toggle in
+/// Settings → Playback Diagnostics.
+///
+/// Call sites consume this via the `SpotifyQueueing` protocol — identical to
+/// how they used `SpotifyService` directly. No call-site changes required.
+@MainActor
+@Observable
+final class SpotifyPlaybackCoordinator: SpotifyQueueing {
+
+    // MARK: - Singleton
+
+    static let shared = SpotifyPlaybackCoordinator()
+
+    // MARK: - Sub-services
+
+    let remote = SpotifyRemoteService()
+    private let web: SpotifyService = .shared
+
+    // MARK: - Observable state
+
+    /// When `true`, all play/queue actions bypass the SDK and hit the Web API
+    /// directly. Persisted in `UserDefaults`.
+    var forceWebFallback: Bool {
+        get { UserDefaults.standard.bool(forKey: "xomify.playback.forceWebFallback") }
+        set { UserDefaults.standard.set(newValue, forKey: "xomify.playback.forceWebFallback") }
+    }
+
+    /// Most recent error from a `connectIfAuthenticated()` call.
+    private(set) var lastConnectError: Error?
+
+    // MARK: - Init
+
+    private init() {
+        // Wire up the token-refresh hook so we push updated tokens into the
+        // live SDK connection without needing to poll or reconnect.
+        AuthService.shared.onTokenRefresh = { [weak self] newToken in
+            Task { @MainActor [weak self] in
+                self?.remote.updateAccessToken(newToken)
+            }
+        }
+    }
+
+    // MARK: - Connection lifecycle
+
+    /// Fetches a valid access token and connects the SDK if not already connected.
+    /// Swallows errors into `lastConnectError` — a connection failure must not
+    /// surface to the user; we fall back to Web API silently.
+    func connectIfAuthenticated() async {
+        guard let token = await AuthService.shared.accessTokenForSDK() else { return }
+        do {
+            try await remote.connect(accessToken: token)
+            lastConnectError = nil
+        } catch {
+            lastConnectError = error
+            print("⚠️ SpotifyPlaybackCoordinator: SDK connect failed — \(error.localizedDescription)")
+        }
+    }
+
+    /// Disconnects the SDK. Call on scene `.background`.
+    func disconnect() {
+        remote.disconnect()
+    }
+
+    // MARK: - SpotifyQueueing
+
+    func queueTrack(uri: String) async throws {
+        if forceWebFallback {
+            try await web.queueTrack(uri: uri)
+            return
+        }
+        do {
+            try await remote.queueTrack(uri: uri)
+        } catch SpotifyRemoteError.notConnected,
+                SpotifyRemoteError.notInstalled {
+            // SDK not available — fall through to Web API.
+            try await web.queueTrack(uri: uri)
+        }
+        // `.connectFailed` and `.actionFailed` propagate — the action
+        // controller's generic `catch` will surface them to the user.
+    }
+
+    func playTrack(uri: String) async throws {
+        if forceWebFallback {
+            try await web.playTrack(uri: uri)
+            return
+        }
+        do {
+            try await remote.playTrack(uri: uri)
+        } catch SpotifyRemoteError.notConnected,
+                SpotifyRemoteError.notInstalled {
+            try await web.playTrack(uri: uri)
+        }
+    }
+}

--- a/Xomify-iOS/Services/SpotifyRemoteService.swift
+++ b/Xomify-iOS/Services/SpotifyRemoteService.swift
@@ -1,0 +1,177 @@
+import Foundation
+import UIKit
+import SpotifyiOS
+
+/// Wraps `SPTAppRemote` and bridges its Objective-C delegate callbacks to
+/// Swift async/await. Conforms to `SpotifyQueueing` so it can be swapped in
+/// wherever `SpotifyService` is used today.
+///
+/// All SDK interaction — including delegate callbacks — happens on the main
+/// actor. `SPTAppRemote` is not `Sendable` and must never cross actor
+/// boundaries.
+@MainActor
+@Observable
+final class SpotifyRemoteService: NSObject, SpotifyQueueing {
+
+    // MARK: - Observable state
+
+    /// Whether the SDK is currently connected to the Spotify app.
+    private(set) var isConnected: Bool = false
+
+    /// The most recent SDK-level error (connection or player action).
+    private(set) var lastError: SpotifyRemoteError?
+
+    // MARK: - Private
+
+    private let appRemote: SPTAppRemote
+
+    /// Pending continuation for an in-flight `connect()` call.
+    private var connectContinuation: CheckedContinuation<Void, Error>?
+
+    // MARK: - Init
+
+    override init() {
+        let clientID = Bundle.main.object(forInfoDictionaryKey: "SPOTIFY_CLIENT_ID") as? String ?? ""
+        let redirectURL = URL(string: "xomify://callback")!
+        let config = SPTConfiguration(clientID: clientID, redirectURL: redirectURL)
+
+        appRemote = SPTAppRemote(configuration: config, logLevel: .error)
+        super.init()
+        appRemote.delegate = self
+    }
+
+    // MARK: - Connection
+
+    /// Connects to the Spotify app using a pre-fetched access token.
+    /// Throws `SpotifyRemoteError.notInstalled` if Spotify isn't installed,
+    /// or `.connectFailed` if the handshake is rejected.
+    func connect(accessToken: String) async throws {
+        guard UIApplication.shared.canOpenURL(URL(string: "spotify:")!) else {
+            lastError = .notInstalled
+            throw SpotifyRemoteError.notInstalled
+        }
+
+        if appRemote.isConnected {
+            // Already connected — just refresh the token in case it changed.
+            appRemote.connectionParameters.accessToken = accessToken
+            isConnected = true
+            return
+        }
+
+        appRemote.connectionParameters.accessToken = accessToken
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            connectContinuation = continuation
+            appRemote.connect()
+        }
+    }
+
+    /// Disconnects from the Spotify app. Idempotent.
+    func disconnect() {
+        guard appRemote.isConnected else { return }
+        appRemote.disconnect()
+    }
+
+    /// Pushes a new access token into the live connection (called after token refresh).
+    func updateAccessToken(_ token: String) {
+        appRemote.connectionParameters.accessToken = token
+    }
+
+    // MARK: - SpotifyQueueing
+
+    func queueTrack(uri: String) async throws {
+        guard isConnected, let playerAPI = appRemote.playerAPI else {
+            throw SpotifyRemoteError.notConnected
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            playerAPI.enqueueTrackUri(uri) { _, error in
+                if let error {
+                    continuation.resume(throwing: SpotifyRemoteError.actionFailed(underlying: error))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    func playTrack(uri: String) async throws {
+        guard isConnected, let playerAPI = appRemote.playerAPI else {
+            throw SpotifyRemoteError.notConnected
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            playerAPI.play(uri) { _, error in
+                if let error {
+                    continuation.resume(throwing: SpotifyRemoteError.actionFailed(underlying: error))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    // MARK: - URL handling
+
+    /// Forward the URL received in `onOpenURL` to the SDK's auth-handover parser.
+    /// Call this from the app entry's `.onOpenURL` modifier.
+    func handleOpenURL(_ url: URL) {
+        guard let params = appRemote.authorizationParameters(from: url) else { return }
+
+        if let token = params[SPTAppRemoteAccessTokenKey] {
+            appRemote.connectionParameters.accessToken = token
+            appRemote.connect()
+        } else if let errorDescription = params[SPTAppRemoteErrorDescriptionKey] {
+            print("❌ SpotifyRemoteService: Auth callback error — \(errorDescription)")
+            lastError = .connectFailed(underlying: NSError(
+                domain: "SpotifyRemote",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: errorDescription]
+            ))
+        }
+    }
+}
+
+// MARK: - SPTAppRemoteDelegate
+
+extension SpotifyRemoteService: SPTAppRemoteDelegate {
+
+    nonisolated func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
+        Task { @MainActor in
+            self.isConnected = true
+            self.lastError = nil
+            self.connectContinuation?.resume()
+            self.connectContinuation = nil
+            print("✅ SpotifyRemoteService: Connected")
+        }
+    }
+
+    nonisolated func appRemote(
+        _ appRemote: SPTAppRemote,
+        didFailConnectionAttemptWithError error: Error?
+    ) {
+        Task { @MainActor in
+            self.isConnected = false
+            let remoteError = SpotifyRemoteError.connectFailed(
+                underlying: error ?? NSError(domain: "SpotifyRemote", code: -1)
+            )
+            self.lastError = remoteError
+            self.connectContinuation?.resume(throwing: remoteError)
+            self.connectContinuation = nil
+            print("❌ SpotifyRemoteService: Connection failed — \(error?.localizedDescription ?? "unknown")")
+        }
+    }
+
+    nonisolated func appRemote(
+        _ appRemote: SPTAppRemote,
+        didDisconnectWithError error: Error?
+    ) {
+        Task { @MainActor in
+            self.isConnected = false
+            if let error {
+                self.lastError = .connectFailed(underlying: error)
+                print("⚠️ SpotifyRemoteService: Disconnected with error — \(error.localizedDescription)")
+            } else {
+                print("ℹ️ SpotifyRemoteService: Disconnected cleanly")
+            }
+        }
+    }
+}

--- a/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
+++ b/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
@@ -9,3 +9,15 @@
   - `Xomify-iOS.xcodeproj/project.pbxproj` — version bump
 - **Decisions**: Project uses `PBXFileSystemSynchronizedRootGroup` — no manual pbxproj file references needed for new Swift files. `SpotifyRemoteError.Sendable` conformance requires wrapping associated `Error` values; used `@unchecked Sendable` pattern is avoided since these errors are only thrown/caught in `@MainActor` context.
 - **Result**: BUILD SUCCEEDED (iphonesimulator)
+
+## [2026-04-26 00:01] — Phase 2: SpotifyRemoteService + connection lifecycle
+
+- **Action**: Created `SpotifyRemoteService.swift` — `@MainActor @Observable NSObject` wrapping `SPTAppRemote`, conforming to `SpotifyQueueing`. Bridges delegate callbacks (`appRemoteDidEstablishConnection`, `didFailConnectionAttemptWithError`, `didDisconnectWithError`) via `CheckedContinuation`. Created `SpotifyPlaybackCoordinator.swift` — `@MainActor @Observable` class implementing `SpotifyQueueing`, routing SDK-first with Web API fallback. Added `onTokenRefresh` hook and `accessTokenForSDK()` to `AuthService`. Updated `Xomify_iOSApp.swift` to inject coordinator into environment, wire `scenePhase` observer, and forward `onOpenURL` to SDK. Bumped version 1.6.1 → 1.6.2.
+- **Files changed**:
+  - `Xomify-iOS/Services/SpotifyRemoteService.swift` — new
+  - `Xomify-iOS/Services/SpotifyPlaybackCoordinator.swift` — new
+  - `Xomify-iOS/Services/AuthService.swift` — added `onTokenRefresh`, `accessTokenForSDK()`
+  - `Xomify-iOS/App/Xomify_iOSApp.swift` — scene lifecycle + URL forwarding
+  - `Xomify-iOS.xcodeproj/project.pbxproj` — version bump
+- **Decisions**: Used `@ObservationIgnored` on `onTokenRefresh` in `AuthService` to resolve `@Observable` macro incompatibility with `@Sendable` closure types. Chose closure-based hook over `AsyncStream` for simplicity (plan open question resolved to callback). SPTAppRemoteDelegate conformance uses `nonisolated` + `Task { @MainActor in }` to bridge ObjC callbacks safely under strict concurrency. `SpotifyRemoteError` cases with associated `Error` are not `Equatable` but that's acceptable — coordinator only pattern-matches on case identity.
+- **Result**: BUILD SUCCEEDED (iphonesimulator)

--- a/docs/features/spotify-ios-sdk/PLAN.md
+++ b/docs/features/spotify-ios-sdk/PLAN.md
@@ -100,7 +100,7 @@ holding a connection while the app isn't foregrounded.
 - [x] Bump version: `scripts/bump-version.sh fix` (no user-visible change yet). → 1.6.1
 
 ### Phase 2 — `SpotifyRemoteService` + connection lifecycle (PR #2)
-- [ ] Create `Xomify-iOS/Services/SpotifyRemoteService.swift`:
+- [x] Create `Xomify-iOS/Services/SpotifyRemoteService.swift`:
   - `@MainActor @Observable final class SpotifyRemoteService: NSObject, SpotifyQueueing, SPTAppRemoteDelegate`
   - Properties: `isConnected: Bool`, `lastError: SpotifyRemoteError?`
   - Initialiser builds `SPTConfiguration(clientID:redirectURL:)` from the
@@ -114,9 +114,9 @@ holding a connection while the app isn't foregrounded.
     otherwise. Calls `appRemote.playerAPI?.enqueueTrackUri(uri, callback:)`,
     bridges callback to `async throws`.
   - `playTrack(uri:)`: same pattern, calls `appRemote.playerAPI?.play(uri)`.
-  - `handleOpenURL(_:)`: forwards to `appRemote.authorizeAndPlayURI` /
+  - `handleOpenURL(_:)`: forwards to `appRemote.authorizationParameters(from:)`
     parameter parser as required by the auth-handover flow.
-- [ ] Create `Xomify-iOS/Services/SpotifyPlaybackCoordinator.swift`:
+- [x] Create `Xomify-iOS/Services/SpotifyPlaybackCoordinator.swift`:
   - `@MainActor @Observable final class SpotifyPlaybackCoordinator: SpotifyQueueing`
   - Holds `remote: SpotifyRemoteService` and `web: SpotifyService`.
   - `connectIfAuthenticated()` async — fetches token from `AuthService`, calls
@@ -126,18 +126,15 @@ holding a connection while the app isn't foregrounded.
     1. If `forceWebFallback` toggle is on → use `web` directly.
     2. Else try `remote.queueTrack(uri:)`. On `.notConnected` / `.notInstalled`
        fall through to `web.queueTrack(uri:)`.
-- [ ] Wire scene-phase + URL forwarding into the `App` struct:
-  - Inject the coordinator via `.environment(coordinator)` (or a singleton —
-    prefer environment so it's testable).
+- [x] Wire scene-phase + URL forwarding into the `App` struct:
+  - Inject the coordinator via `.environment(coordinator)`.
   - `.onChange(of: scenePhase)` → `.active` → `Task { await coordinator.connectIfAuthenticated() }`,
     `.background` → `coordinator.disconnect()`.
   - `.onOpenURL { coordinator.remote.handleOpenURL($0) }`.
-- [ ] Push token refreshes through: extend `AuthService` with a tiny callback
-      / async stream so the coordinator updates `appRemote.connectionParameters.accessToken`
-      after `refreshAccessToken()` succeeds. (Otherwise the SDK keeps the stale
-      token and starts failing after the first refresh.)
+- [x] Push token refreshes through: extended `AuthService` with `onTokenRefresh: (@Sendable (String) -> Void)?`
+      callback and `accessTokenForSDK() async -> String?`. Coordinator wires itself in at init.
 - [ ] Manual test on a real device — see Test Plan §Phase 2.
-- [ ] Bump version: `scripts/bump-version.sh fix`.
+- [x] Bump version: `scripts/bump-version.sh fix`. → 1.6.2
 
 ### Phase 3 — Wire call sites + Web-API fallback (PR #3)
 - [ ] Change `QueueActionController.init` default param from


### PR DESCRIPTION
## Phase 2 of 4 — SpotifyRemoteService + Connection Lifecycle

Adds the SDK wrapper (`SpotifyRemoteService`) and routing layer (`SpotifyPlaybackCoordinator`). No call-site changes yet — that's Phase 3.

## What's in this PR

### New: `SpotifyRemoteService`
- `@MainActor @Observable NSObject` wrapping `SPTAppRemote`
- Bridges `SPTAppRemoteDelegate` ObjC callbacks to Swift `async/await` via `CheckedContinuation`
- `connect(accessToken:)` — idempotent, throws `SpotifyRemoteError.notInstalled` if Spotify isn't on device
- `queueTrack(uri:)` / `playTrack(uri:)` — async throws, guard on `isConnected`
- `handleOpenURL(_:)` — forwards SDK auth-handover URLs via `authorizationParameters(from:)`
- Strict concurrency: all SDK interaction on `@MainActor`, delegate methods bridged with `nonisolated` + `Task { @MainActor in }`

### New: `SpotifyPlaybackCoordinator`
- SDK-first routing: tries `SpotifyRemoteService`, falls back to `SpotifyService` (Web API) on `.notConnected` / `.notInstalled`
- `forceWebFallback` toggle persisted in `UserDefaults` (used by Phase 4 diagnostics)
- Wires `AuthService.onTokenRefresh` at init so SDK gets fresh tokens without reconnecting

### `AuthService` additions
- `onTokenRefresh: (@Sendable (String) -> Void)?` — `@ObservationIgnored` hook called after every `saveTokens`
- `accessTokenForSDK() async -> String?` — auto-refreshes if expired, returns nil if not authenticated

### `Xomify_iOSApp.swift` updates
- Injects coordinator into SwiftUI environment
- `scenePhase .active` → `connectIfAuthenticated()`, `.background` → `disconnect()`
- `onOpenURL` forwards to `coordinator.remote.handleOpenURL(_:)` before `InviteCoordinator`

## Note on SDK + simulator

Spotify iOS SDK does NOT run in the simulator — `BUILD SUCCEEDED` confirmed on iphonesimulator. Real-device validation per the test plan is required before relying on playback.

Closes #82