### PR TITLE
feat: route queue/play through SpotifyPlaybackCoordinator (Phase 3)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Services/QueueActionController.swift
+++ b/Xomify-iOS/Services/QueueActionController.swift
@@ -29,7 +29,7 @@ final class QueueActionController {
 
     private let spotifyService: SpotifyQueueing
 
-    init(spotifyService: SpotifyQueueing = SpotifyService.shared) {
+    init(spotifyService: SpotifyQueueing = SpotifyPlaybackCoordinator.shared) {
         self.spotifyService = spotifyService
     }
 
@@ -95,14 +95,14 @@ final class QueueActionController {
         }
     }
 
-    /// When the Web API reports no active device, the user simply hasn't
-    /// opened Spotify yet. Deep-link them into the track page so Spotify
-    /// launches and they can tap Play — the next action will then hit a
-    /// live device.
+    /// Web API fallback reported no active device. This is a rare edge case now
+    /// that the SDK can wake Spotify directly — it typically means both the SDK
+    /// path failed *and* Spotify isn't running. Deep-link into the track page as
+    /// a last resort so the user can open Spotify and resume.
     private func handleNoDevice(uri: String, action: String) {
         if let url = URL(string: uri), UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
-            toast = "Open Spotify to finish the \(action)."
+            toast = "Opening Spotify — try again once it's playing."
         } else {
             toast = SpotifyServiceError.noActiveDevice.errorDescription
         }

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -48,7 +48,7 @@ final class ShareCardViewModel {
         share: Share,
         viewerEmail: String,
         xomifyService: XomifyServiceProtocol = XomifyService.shared,
-        spotifyService: SpotifyQueueing = SpotifyService.shared
+        spotifyService: SpotifyQueueing = SpotifyPlaybackCoordinator.shared
     ) {
         self.share = share
         self.viewerEmail = viewerEmail

--- a/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
+++ b/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
@@ -10,6 +10,16 @@
 - **Decisions**: Project uses `PBXFileSystemSynchronizedRootGroup` — no manual pbxproj file references needed for new Swift files. `SpotifyRemoteError.Sendable` conformance requires wrapping associated `Error` values; used `@unchecked Sendable` pattern is avoided since these errors are only thrown/caught in `@MainActor` context.
 - **Result**: BUILD SUCCEEDED (iphonesimulator)
 
+## [2026-04-26 00:02] — Phase 3: Wire call sites + Web API fallback
+
+- **Action**: Changed `QueueActionController.init` and `ShareCardViewModel.init` default `spotifyService` param from `SpotifyService.shared` to `SpotifyPlaybackCoordinator.shared`. Audited codebase — no other direct `queueTrack`/`playTrack` callers. Updated `handleNoDevice` copy to reflect that `.noActiveDevice` is now a rare last-resort path. Bumped version 1.6.2 → 1.7.0 (feat: first user-visible change).
+- **Files changed**:
+  - `Xomify-iOS/Services/QueueActionController.swift` — default injection + toast copy
+  - `Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift` — default injection
+  - `Xomify-iOS.xcodeproj/project.pbxproj` — version bump
+- **Decisions**: No call-site changes needed beyond the default parameter — protocol shape is identical. Toast copy updated to signal "SDK tried, fell all the way through" rather than the old "open Spotify first" instruction.
+- **Result**: BUILD SUCCEEDED (iphonesimulator)
+
 ## [2026-04-26 00:01] — Phase 2: SpotifyRemoteService + connection lifecycle
 
 - **Action**: Created `SpotifyRemoteService.swift` — `@MainActor @Observable NSObject` wrapping `SPTAppRemote`, conforming to `SpotifyQueueing`. Bridges delegate callbacks (`appRemoteDidEstablishConnection`, `didFailConnectionAttemptWithError`, `didDisconnectWithError`) via `CheckedContinuation`. Created `SpotifyPlaybackCoordinator.swift` — `@MainActor @Observable` class implementing `SpotifyQueueing`, routing SDK-first with Web API fallback. Added `onTokenRefresh` hook and `accessTokenForSDK()` to `AuthService`. Updated `Xomify_iOSApp.swift` to inject coordinator into environment, wire `scenePhase` observer, and forward `onOpenURL` to SDK. Bumped version 1.6.1 → 1.6.2.

--- a/docs/features/spotify-ios-sdk/PLAN.md
+++ b/docs/features/spotify-ios-sdk/PLAN.md
@@ -137,19 +137,18 @@ holding a connection while the app isn't foregrounded.
 - [x] Bump version: `scripts/bump-version.sh fix`. → 1.6.2
 
 ### Phase 3 — Wire call sites + Web-API fallback (PR #3)
-- [ ] Change `QueueActionController.init` default param from
+- [x] Change `QueueActionController.init` default param from
       `SpotifyService.shared` to `SpotifyPlaybackCoordinator.shared`.
       The protocol shape (`SpotifyQueueing`) means zero call-site churn.
-- [ ] Same for `ShareCardViewModel.init`'s `spotifyService` param.
-- [ ] Audit the codebase for any other direct `SpotifyService.shared.queueTrack`
-      / `playTrack` callers and route them through the coordinator. (Quick
-      search of the project — the two known consumers above are the only ones.)
-- [ ] Update `QueueActionController.handleNoDevice` user copy: with the SDK
-      online, `.noActiveDevice` should now be a rare edge case (Web-API
-      fallback hit while Spotify wasn't running). Keep the deep-link rescue
-      path as a last resort.
+- [x] Same for `ShareCardViewModel.init`'s `spotifyService` param.
+- [x] Audit the codebase for any other direct `SpotifyService.shared.queueTrack`
+      / `playTrack` callers and route them through the coordinator. (Confirmed:
+      only the two above.)
+- [x] Update `QueueActionController.handleNoDevice` user copy: with the SDK
+      online, `.noActiveDevice` is now a rare last-resort path. Deep-link
+      rescue kept; toast copy updated.
 - [ ] Manual test on real device — see Test Plan §Phase 3.
-- [ ] Bump version: `scripts/bump-version.sh feat` (first user-visible change).
+- [x] Bump version: `scripts/bump-version.sh feat` (first user-visible change). → 1.7.0
 
 ### Phase 4 — Settings diagnostics + force-fallback toggle (PR #4)
 - [ ] Add `PlaybackDiagnosticsView.swift` under `Xomify-iOS/Views/Settings/`.


### PR DESCRIPTION
## Phase 3 of 4 — Wire Call Sites + Web API Fallback

This is the first user-visible change. Queue and Play actions now go through `SpotifyPlaybackCoordinator`, which tries the SDK first and falls back to the Web API. No more 404s when Spotify isn't actively playing on a device.

## What changed

- `QueueActionController.init` default `spotifyService` param: `SpotifyService.shared` → `SpotifyPlaybackCoordinator.shared`
- `ShareCardViewModel.init` same change
- Audited codebase: these are the only two consumers of `SpotifyQueueing`. No other call sites.
- `QueueActionController.handleNoDevice` toast copy updated: `.noActiveDevice` is now a rare edge case (SDK + Web API both failed), not the normal path.

## User impact

- Feed card queue button now works even when Spotify isn't playing anywhere
- Track actions "Add to queue" / "Play now" now work without a pre-active device
- If Spotify app is missing or SDK fails: automatic fallback to Web API, then deep-link rescue as last resort

## Note on SDK + simulator

Spotify iOS SDK does NOT run in the simulator — `BUILD SUCCEEDED` confirmed. Real-device validation required per test plan.

Closes #83