### PR TITLE
feat: PlaybackDiagnosticsView + Developer section in Settings (Phase 4)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Views/Settings/PlaybackDiagnosticsView.swift
+++ b/Xomify-iOS/Views/Settings/PlaybackDiagnosticsView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import UIKit
+
+/// Developer diagnostics for the Spotify iOS SDK playback path.
+///
+/// Shows current SDK connection state, last error, Spotify-app-install status,
+/// token expiry, and a force-fallback toggle. Useful for confirming the SDK is
+/// running without adding logging instrumentation.
+struct PlaybackDiagnosticsView: View {
+
+    @Environment(SpotifyPlaybackCoordinator.self) private var coordinator
+
+    var body: some View {
+        List {
+            connectionSection
+            tokenSection
+            fallbackSection
+            actionsSection
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(Color.xomifyDark.ignoresSafeArea())
+        .navigationTitle("Playback Diagnostics")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Sections
+
+    private var connectionSection: some View {
+        Section {
+            statusRow(
+                title: "Spotify app installed",
+                value: spotifyInstalled ? "Yes" : "No",
+                valueColor: spotifyInstalled ? .xomifyGreen : .red
+            )
+
+            statusRow(
+                title: "SDK connected",
+                value: coordinator.remote.isConnected ? "Connected" : "Disconnected",
+                valueColor: coordinator.remote.isConnected ? .xomifyGreen : .orange
+            )
+
+            if let error = coordinator.remote.lastError {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Last SDK error")
+                        .foregroundStyle(.white)
+                    Text(error.errorDescription ?? "Unknown error")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(3)
+                }
+                .frame(minHeight: 44)
+                .padding(.vertical, 4)
+            }
+        } header: {
+            Text("SDK Status")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    private var tokenSection: some View {
+        Section {
+            statusRow(
+                title: "Token expires",
+                value: tokenExpiryString,
+                valueColor: tokenExpiringSoon ? .orange : .gray
+            )
+        } header: {
+            Text("Auth Token")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    private var fallbackSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { coordinator.forceWebFallback },
+                set: { coordinator.forceWebFallback = $0 }
+            )) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Force Web API fallback")
+                        .foregroundStyle(.white)
+                    Text("Bypasses the SDK — useful for A/B comparison.")
+                        .font(.caption)
+                        .foregroundStyle(.gray)
+                }
+            }
+            .tint(Color.xomifyGreen)
+            .frame(minHeight: 44)
+        } header: {
+            Text("Fallback")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    private var actionsSection: some View {
+        Section {
+            Button {
+                Task {
+                    coordinator.disconnect()
+                    await coordinator.connectIfAuthenticated()
+                }
+            } label: {
+                Label("Reconnect SDK", systemImage: "arrow.clockwise")
+                    .foregroundStyle(Color.xomifyGreen)
+            }
+            .frame(minHeight: 44)
+            .disabled(!spotifyInstalled)
+            .accessibilityHint("Disconnects then reconnects the Spotify SDK")
+
+            if let spotifyURL = URL(string: "spotify:"), spotifyInstalled {
+                Button {
+                    UIApplication.shared.open(spotifyURL)
+                } label: {
+                    Label("Open Spotify app", systemImage: "arrow.up.right.square")
+                        .foregroundStyle(Color.xomifyGreen)
+                }
+                .frame(minHeight: 44)
+                .accessibilityHint("Opens the Spotify app")
+            }
+        } header: {
+            Text("Actions")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    // MARK: - Helpers
+
+    private var spotifyInstalled: Bool {
+        UIApplication.shared.canOpenURL(URL(string: "spotify:")!)
+    }
+
+    private var tokenExpiryString: String {
+        guard let expiry = AuthService.shared.tokenExpirationDate else { return "—" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: expiry, relativeTo: .now)
+    }
+
+    private var tokenExpiringSoon: Bool {
+        guard let expiry = AuthService.shared.tokenExpirationDate else { return true }
+        return expiry.timeIntervalSinceNow < 300 // less than 5 min
+    }
+
+    private func statusRow(title: String, value: String, valueColor: Color) -> some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(.white)
+            Spacer()
+            Text(value)
+                .foregroundStyle(valueColor)
+                .lineLimit(1)
+        }
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value)")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PlaybackDiagnosticsView()
+            .environment(SpotifyPlaybackCoordinator.shared)
+    }
+}

--- a/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
             aboutSection
             legalSection
             supportSection
+            developerSection
             dangerSection
         }
         .listStyle(.insetGrouped)
@@ -294,6 +295,26 @@ struct SettingsView: View {
             }
         } header: {
             Text("Support")
+                .foregroundStyle(.gray)
+        }
+        .listRowBackground(Color.xomifyCard)
+    }
+
+    // MARK: - Developer
+
+    private var developerSection: some View {
+        Section {
+            NavigationLink {
+                PlaybackDiagnosticsView()
+                    .environment(SpotifyPlaybackCoordinator.shared)
+            } label: {
+                Label("Playback Diagnostics", systemImage: "waveform.path.ecg")
+                    .foregroundStyle(.white)
+            }
+            .frame(minHeight: 44)
+            .accessibilityHint("SDK connection status, token info, and force-fallback toggle")
+        } header: {
+            Text("Developer")
                 .foregroundStyle(.gray)
         }
         .listRowBackground(Color.xomifyCard)

--- a/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
+++ b/docs/features/spotify-ios-sdk/EXECUTION_LOG.md
@@ -10,6 +10,20 @@
 - **Decisions**: Project uses `PBXFileSystemSynchronizedRootGroup` — no manual pbxproj file references needed for new Swift files. `SpotifyRemoteError.Sendable` conformance requires wrapping associated `Error` values; used `@unchecked Sendable` pattern is avoided since these errors are only thrown/caught in `@MainActor` context.
 - **Result**: BUILD SUCCEEDED (iphonesimulator)
 
+## [2026-04-26 00:04] — Final summary
+
+All 4 phases complete. PRs: #81 (infra), #82 (SDK wrapper + lifecycle), #83 (call site wiring), #84 (diagnostics). Version 1.6.0 → 1.7.1. Real-device testing required per the plan's test sections before relying on SDK playback.
+
+## [2026-04-26 00:03] — Phase 4: Settings diagnostics + force-fallback toggle
+
+- **Action**: Created `PlaybackDiagnosticsView.swift` under `Xomify-iOS/Views/Settings/`. Shows SDK connection state, last error, Spotify-app-install status, token expiry, force-fallback toggle, Reconnect + Open Spotify buttons. Added "Developer" section to `SettingsView` with `NavigationLink` to the diagnostics view. Toggle bound to `SpotifyPlaybackCoordinator.forceWebFallback` via `Binding(get:set:)`. Bumped version 1.7.0 → 1.7.1.
+- **Files changed**:
+  - `Xomify-iOS/Views/Settings/PlaybackDiagnosticsView.swift` — new
+  - `Xomify-iOS/Views/Shell/Destinations/SettingsView.swift` — Developer section
+  - `Xomify-iOS.xcodeproj/project.pbxproj` — version bump
+- **Decisions**: No developer-mode gate — SettingsView has no such pattern. Plain section keeps it accessible for Dom without extra ceremony. Used `Binding(get:set:)` for `forceWebFallback` since `@Environment` + `@Bindable` in computed property `@ViewBuilder` has tricky syntax. `tokenExpiringSoon` threshold set at 5 min (< 300s) as an opinionated warning.
+- **Result**: BUILD SUCCEEDED (iphonesimulator)
+
 ## [2026-04-26 00:02] — Phase 3: Wire call sites + Web API fallback
 
 - **Action**: Changed `QueueActionController.init` and `ShareCardViewModel.init` default `spotifyService` param from `SpotifyService.shared` to `SpotifyPlaybackCoordinator.shared`. Audited codebase — no other direct `queueTrack`/`playTrack` callers. Updated `handleNoDevice` copy to reflect that `.noActiveDevice` is now a rare last-resort path. Bumped version 1.6.2 → 1.7.0 (feat: first user-visible change).

--- a/docs/features/spotify-ios-sdk/PLAN.md
+++ b/docs/features/spotify-ios-sdk/PLAN.md
@@ -1,6 +1,6 @@
 # Plan: Spotify iOS SDK Integration (SPTAppRemote)
 
-**Status**: In Progress
+**Status**: Done
 **Created**: 2026-04-26
 **Last updated**: 2026-04-26
 
@@ -151,7 +151,7 @@ holding a connection while the app isn't foregrounded.
 - [x] Bump version: `scripts/bump-version.sh feat` (first user-visible change). → 1.7.0
 
 ### Phase 4 — Settings diagnostics + force-fallback toggle (PR #4)
-- [ ] Add `PlaybackDiagnosticsView.swift` under `Xomify-iOS/Views/Settings/`.
+- [x] Add `PlaybackDiagnosticsView.swift` under `Xomify-iOS/Views/Settings/`.
       Shows:
   - Spotify app installed: `UIApplication.shared.canOpenURL("spotify:")`
   - SDK connection state: `coordinator.remote.isConnected`
@@ -160,11 +160,12 @@ holding a connection while the app isn't foregrounded.
   - Toggle: `Force fallback to Web API` (persisted in `UserDefaults` under
     `xomify.playback.forceWebFallback`).
   - Buttons: `Reconnect SDK`, `Open Spotify app`.
-- [ ] Hook the toggle into `SpotifyPlaybackCoordinator.forceWebFallback`.
-- [ ] Add a Settings entry to launch this view (developer-mode-gated if the
-      Settings screen has that pattern; otherwise plain entry).
+- [x] Hook the toggle into `SpotifyPlaybackCoordinator.forceWebFallback`.
+- [x] Add a Settings entry: "Developer" section in `SettingsView` with
+      `NavigationLink` to `PlaybackDiagnosticsView` (no developer-mode gate —
+      Settings screen had no such pattern).
 - [ ] Manual test on real device — see Test Plan §Phase 4.
-- [ ] Bump version: `scripts/bump-version.sh fix`.
+- [x] Bump version: `scripts/bump-version.sh fix`. → 1.7.1
 
 ## Test Plan
 


### PR DESCRIPTION
## Phase 4 of 4 — Settings Diagnostics + Force-Fallback Toggle

Final phase of the Spotify iOS SDK integration. Adds a developer diagnostics screen so you can verify SDK state on device without re-instrumenting.

## What's in this PR

### New: `PlaybackDiagnosticsView`
Lives at Settings → Developer → Playback Diagnostics.

**SDK Status section**
- Spotify app installed: live `canOpenURL("spotify:")` check
- SDK connected: `coordinator.remote.isConnected`
- Last SDK error: shown in red when present

**Auth Token section**
- Token expiry: shown as relative time (e.g. "in 58 minutes"), orange if expiring within 5 min

**Fallback section**
- "Force Web API fallback" toggle — persisted in `UserDefaults` under `xomify.playback.forceWebFallback`. When ON, all play/queue bypass the SDK entirely (useful for A/B confirming SDK vs Web API behaviour).

**Actions section**
- "Reconnect SDK" — calls `disconnect()` then `connectIfAuthenticated()`
- "Open Spotify app" — deep-links to Spotify (shown only when installed)

### Updated: `SettingsView`
New "Developer" section at the bottom (above Danger Zone) with a `NavigationLink` to `PlaybackDiagnosticsView`.

## Note on SDK + simulator

`BUILD SUCCEEDED` on iphonesimulator confirmed. Real-device validation per test plan required.

Closes #84