### PR TITLE
feat: Phase 1 — sidebar destinations scaffolded

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7.1;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Navigation/NavigationStore.swift
+++ b/Xomify-iOS/Navigation/NavigationStore.swift
@@ -7,6 +7,8 @@ import SwiftUI
 enum SidebarDestination: Hashable {
     case profile
     case feed
+    case likes
+    case recentlyPlayed
     case musicTaste
     case wrapped
     case releaseRadar

--- a/Xomify-iOS/Views/Library/LikesView.swift
+++ b/Xomify-iOS/Views/Library/LikesView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Top-level destination: user's full Spotify liked-songs library with
+/// search and infinite scroll. Stub — full implementation lands in Phase 2.
+struct LikesView: View {
+    var body: some View {
+        ZStack {
+            Color.xomifyDark.ignoresSafeArea()
+            Text("Likes")
+                .foregroundStyle(.white)
+                .font(.title2)
+        }
+        .navigationTitle("Likes")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Xomify-iOS/Views/Library/RecentlyPlayedView.swift
+++ b/Xomify-iOS/Views/Library/RecentlyPlayedView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Top-level destination: user's recently played tracks with search and
+/// cursor-based pagination. Stub — full implementation lands in Phase 3.
+struct RecentlyPlayedView: View {
+    var body: some View {
+        ZStack {
+            Color.xomifyDark.ignoresSafeArea()
+            Text("Recently Played")
+                .foregroundStyle(.white)
+                .font(.title2)
+        }
+        .navigationTitle("Recently Played")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Xomify-iOS/Views/Shell/DrawerView.swift
+++ b/Xomify-iOS/Views/Shell/DrawerView.swift
@@ -31,6 +31,8 @@ struct DrawerView: View {
     /// duplicated as a row.
     private let primaryEntries: [DrawerEntry] = [
         .init(destination: .feed,             label: "Feed",              systemImage: "sparkles"),
+        .init(destination: .likes,            label: "Likes",             systemImage: "heart.fill"),
+        .init(destination: .recentlyPlayed,   label: "Recently Played",   systemImage: "clock.arrow.circlepath"),
         .init(destination: .musicTaste,       label: "Music Taste",       systemImage: "waveform"),
         .init(destination: .wrapped,          label: "Wrapped",           systemImage: "chart.bar.fill"),
         .init(destination: .releaseRadar,     label: "Release Radar",     systemImage: "antenna.radiowaves.left.and.right"),

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -77,6 +77,10 @@ struct MainShell: View {
             ProfileView()
         case .feed:
             FeedView()
+        case .likes:
+            LikesView()
+        case .recentlyPlayed:
+            RecentlyPlayedView()
         case .musicTaste:
             TopItemsView()
         case .wrapped:


### PR DESCRIPTION
## Summary
- Adds `likes` and `recentlyPlayed` cases to `SidebarDestination`
- Wires stub `LikesView` and `RecentlyPlayedView` into `MainShell.destinationRoot`
- Adds two new drawer entries (heart.fill, clock.arrow.circlepath) adjacent to Feed in `DrawerView`
- Bumps version to 1.8.0

## Plan reference
`docs/features/likes-and-recent-destinations/PLAN.md` — Phase 1

Stub views return `Text` placeholders; real implementations land in Phase 2 (Likes) and Phase 3 (Recently Played).