### PR TITLE
feat: Phase 3 — RecentlyPlayedView top-level destination

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SpotifyModels.swift
+++ b/Xomify-iOS/Models/SpotifyModels.swift
@@ -226,6 +226,14 @@ struct RecentlyPlayedResponse: Codable, Sendable {
     let items: [SpotifyPlayHistory]
     let next: String?
     let limit: Int?
+    /// Cursor for backwards pagination. `before` is a string-encoded epoch
+    /// timestamp (ms) — pass it as `before=` to get history older than that point.
+    let cursors: RecentlyPlayedCursors?
+
+    struct RecentlyPlayedCursors: Codable, Sendable {
+        let before: String?
+        let after: String?
+    }
 }
 
 struct SearchResponse: Codable, Sendable {

--- a/Xomify-iOS/Services/SpotifyService.swift
+++ b/Xomify-iOS/Services/SpotifyService.swift
@@ -198,11 +198,19 @@ actor SpotifyService {
 
     /// User's recently played tracks, newest-first. Requires the
     /// `user-read-recently-played` scope.
-    func getRecentlyPlayed(limit: Int = 25) async throws -> [SpotifyPlayHistory] {
-        let response: RecentlyPlayedResponse = try await network.spotifyGet(
-            "/me/player/recently-played?limit=\(limit)"
-        )
-        return response.items
+    ///
+    /// - Parameters:
+    ///   - limit: Number of items to return (max 50).
+    ///   - before: Optional cursor (string-encoded epoch ms). When provided,
+    ///     returns history older than that timestamp, enabling cursor-based
+    ///     backwards pagination.
+    /// - Returns: Full `RecentlyPlayedResponse` so callers can read `cursors.before`.
+    func getRecentlyPlayed(limit: Int = 25, before: String? = nil) async throws -> RecentlyPlayedResponse {
+        var path = "/me/player/recently-played?limit=\(limit)"
+        if let before {
+            path += "&before=\(before)"
+        }
+        return try await network.spotifyGet(path)
     }
 
     // MARK: - Tracks

--- a/Xomify-iOS/ViewModels/Library/RecentlyPlayedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Library/RecentlyPlayedViewModel.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+// MARK: - Protocol
+
+/// Narrow protocol for unit-testing the top-level Recently Played VM
+/// without standing up the full `SpotifyService` actor.
+protocol SpotifyRecentlyPlayedProviding: Sendable {
+    func getRecentlyPlayed(limit: Int, before: String?) async throws -> RecentlyPlayedResponse
+}
+
+extension SpotifyService: SpotifyRecentlyPlayedProviding {}
+
+// MARK: - ViewModel
+
+/// Powers the top-level Recently Played destination. Loads 50 tracks per page
+/// using Spotify's cursor-based `before=` pagination (history is fetched
+/// newest-first; `before` points older into the timeline).
+///
+/// Self-only: `/me/player/recently-played` is scoped to the authenticated user.
+/// No total count is returned by Spotify, so `hasMore` is derived purely from
+/// cursor presence.
+@Observable
+@MainActor
+final class RecentlyPlayedViewModel {
+
+    // MARK: - State
+
+    private(set) var tracks: [SpotifyPlayHistory] = []
+    private(set) var cursorBefore: String?
+    private(set) var isLoading: Bool = false
+    private(set) var isLoadingMore: Bool = false
+    private(set) var hasMore: Bool = false
+    var errorMessage: String?
+    var searchQuery: String = ""
+
+    /// Tracks filtered by `searchQuery` (case-insensitive, name + artist names).
+    /// When the query is empty the full list is returned without copying.
+    var filteredTracks: [SpotifyPlayHistory] {
+        guard !searchQuery.isEmpty else { return tracks }
+        let q = searchQuery.lowercased()
+        return tracks.filter { history in
+            let track = history.track
+            return track.name.lowercased().contains(q)
+                || track.artists.compactMap { $0.name }.joined(separator: " ").lowercased().contains(q)
+        }
+    }
+
+    private var hasLoaded: Bool = false
+    private static let pageSize = 50
+
+    // MARK: - Dependencies
+
+    private let spotifyService: SpotifyRecentlyPlayedProviding
+
+    init(spotifyService: SpotifyRecentlyPlayedProviding = SpotifyService.shared) {
+        self.spotifyService = spotifyService
+    }
+
+    // MARK: - Load
+
+    /// Initial load — no-ops while in flight or already loaded.
+    func loadIfNeeded() async {
+        guard !hasLoaded, !isLoading else { return }
+        await fetchPage(reset: true)
+    }
+
+    /// Force a fresh fetch. Used by pull-to-refresh.
+    func refresh() async {
+        guard !isLoading else { return }
+        await fetchPage(reset: true)
+    }
+
+    /// Append the next page using the current `cursorBefore`. No-ops if
+    /// already loading or no more pages are available.
+    func loadMore() async {
+        guard !isLoadingMore, !isLoading, hasMore else { return }
+        await fetchPage(reset: false)
+    }
+
+    // MARK: - Private
+
+    private func fetchPage(reset: Bool) async {
+        if reset {
+            isLoading = true
+            errorMessage = nil
+            tracks = []
+            cursorBefore = nil
+            hasMore = false
+        } else {
+            isLoadingMore = true
+        }
+
+        defer {
+            isLoading = false
+            isLoadingMore = false
+        }
+
+        do {
+            let response = try await spotifyService.getRecentlyPlayed(
+                limit: Self.pageSize,
+                before: reset ? nil : cursorBefore
+            )
+            tracks.append(contentsOf: response.items)
+            cursorBefore = response.cursors?.before
+            hasMore = cursorBefore != nil
+            hasLoaded = true
+        } catch {
+            errorMessage = error.localizedDescription
+            if reset { tracks = [] }
+        }
+    }
+}

--- a/Xomify-iOS/ViewModels/Profile/ProfileRecentViewModel.swift
+++ b/Xomify-iOS/ViewModels/Profile/ProfileRecentViewModel.swift
@@ -44,7 +44,8 @@ final class ProfileRecentViewModel {
         defer { isLoading = false }
 
         do {
-            recentlyPlayed = try await spotifyService.getRecentlyPlayed(limit: 25).map { $0.track }
+            let response = try await spotifyService.getRecentlyPlayed(limit: 25, before: nil)
+            recentlyPlayed = response.items.map { $0.track }
         } catch {
             recentError = error.localizedDescription
             recentlyPlayed = []
@@ -57,7 +58,7 @@ final class ProfileRecentViewModel {
 /// Narrow protocol so the VM can be unit-tested without standing up the full
 /// `SpotifyService` actor. Mirrors the pattern other Profile VMs use.
 protocol SpotifyRecentProviding: Sendable {
-    func getRecentlyPlayed(limit: Int) async throws -> [SpotifyPlayHistory]
+    func getRecentlyPlayed(limit: Int, before: String?) async throws -> RecentlyPlayedResponse
 }
 
 extension SpotifyService: SpotifyRecentProviding {}

--- a/Xomify-iOS/Views/Library/RecentlyPlayedView.swift
+++ b/Xomify-iOS/Views/Library/RecentlyPlayedView.swift
@@ -1,16 +1,227 @@
 import SwiftUI
 
-/// Top-level destination: user's recently played tracks with search and
-/// cursor-based pagination. Stub — full implementation lands in Phase 3.
+/// Top-level destination: user's recently played Spotify tracks.
+/// Loads 50 per page with cursor-based pagination (newest-first, `before=`
+/// cursor for older history). Supports client-side search over loaded pages
+/// with a hint footer when more history is available.
+///
+/// Self-only: `/me/player/recently-played` is scoped to the authenticated user.
 struct RecentlyPlayedView: View {
+
+    @State private var viewModel = RecentlyPlayedViewModel()
+
     var body: some View {
         ZStack {
             Color.xomifyDark.ignoresSafeArea()
-            Text("Recently Played")
-                .foregroundStyle(.white)
-                .font(.title2)
+
+            VStack(alignment: .leading, spacing: 0) {
+                headerRow
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 12)
+
+                if viewModel.isLoading && viewModel.tracks.isEmpty {
+                    loadingState
+                } else if let error = viewModel.errorMessage, viewModel.tracks.isEmpty {
+                    errorState(error)
+                        .padding(.horizontal, 16)
+                } else if viewModel.tracks.isEmpty {
+                    emptyState
+                        .padding(.horizontal, 16)
+                } else {
+                    trackList
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .navigationTitle("Recently Played")
         .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $viewModel.searchQuery, prompt: "Search recently played")
+        .task {
+            await viewModel.loadIfNeeded()
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.xomifyGreen)
+                .accessibilityHidden(true)
+            Text("Recently played")
+                .font(.headline)
+                .foregroundStyle(.white)
+            Spacer()
+        }
+    }
+
+    // MARK: - Track list
+
+    private var trackList: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                let displayed = viewModel.filteredTracks
+                ForEach(Array(displayed.enumerated()), id: \.offset) { index, history in
+                    trackRow(index: index, track: history.track)
+                        .padding(.horizontal, 16)
+                        .onAppear {
+                            if index >= viewModel.tracks.count - 5 {
+                                Task { await viewModel.loadMore() }
+                            }
+                        }
+                }
+
+                // Search hint — show when filtering and more history exists.
+                if !viewModel.searchQuery.isEmpty && viewModel.hasMore {
+                    searchHintFooter
+                        .padding(.horizontal, 16)
+                }
+
+                if viewModel.isLoadingMore {
+                    HStack {
+                        Spacer()
+                        XomifyLoaderSpin()
+                        Spacer()
+                    }
+                    .frame(minHeight: 60)
+                    .accessibilityLabel("Loading more tracks")
+                } else if !viewModel.hasMore && !viewModel.tracks.isEmpty && viewModel.searchQuery.isEmpty {
+                    Text("\(viewModel.tracks.count) tracks loaded")
+                        .font(.caption2)
+                        .foregroundStyle(.gray.opacity(0.6))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                }
+            }
+            .padding(.bottom, 8)
+        }
+    }
+
+    private var searchHintFooter: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .accessibilityHidden(true)
+            Text("Showing \(viewModel.tracks.count) tracks — load more to search older history")
+                .font(.caption2)
+                .foregroundStyle(.gray)
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color.xomifyCard.opacity(0.5))
+        .clipShape(.rect(cornerRadius: 8))
+    }
+
+    // MARK: - Row
+
+    private func trackRow(index: Int, track: SpotifyTrack) -> some View {
+        HStack(spacing: 12) {
+            indexLabel(index)
+            albumArt(track)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(artistNames(track))
+                    .font(.caption2)
+                    .foregroundStyle(.gray)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            TrackActionsMenu(track: track)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(Color.xomifyCard)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(index + 1). \(track.name) by \(artistNames(track))")
+    }
+
+    private func indexLabel(_ index: Int) -> some View {
+        Text("\(index + 1)")
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.white.opacity(0.5))
+            .frame(width: 18, alignment: .trailing)
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func albumArt(_ track: SpotifyTrack) -> some View {
+        if let url = track.album?.images?.first?.url, let imageUrl = URL(string: url) {
+            AsyncImage(url: imageUrl) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    albumArtPlaceholder
+                }
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(.rect(cornerRadius: 6))
+        } else {
+            albumArtPlaceholder
+                .frame(width: 44, height: 44)
+                .clipShape(.rect(cornerRadius: 6))
+        }
+    }
+
+    private var albumArtPlaceholder: some View {
+        Color.xomifyPurple.opacity(0.25)
+            .overlay(
+                Image(systemName: "music.note")
+                    .foregroundStyle(Color.xomifyPurple)
+            )
+    }
+
+    private func artistNames(_ track: SpotifyTrack) -> String {
+        track.artists.compactMap { $0.name }.joined(separator: ", ")
+    }
+
+    // MARK: - States
+
+    private var loadingState: some View {
+        HStack {
+            Spacer()
+            XomifyLoaderSpin()
+            Spacer()
+        }
+        .frame(minHeight: 120)
+        .accessibilityLabel("Loading recently played tracks")
+    }
+
+    private var emptyState: some View {
+        Text("Nothing played recently.")
+            .font(.caption)
+            .foregroundStyle(.gray)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(Color.xomifyCard.opacity(0.5))
+            .clipShape(.rect(cornerRadius: 10))
+    }
+
+    private func errorState(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Color.xomifyCard.opacity(0.6))
+        .clipShape(.rect(cornerRadius: 10))
     }
 }


### PR DESCRIPTION
## Summary
- Extends `SpotifyService.getRecentlyPlayed` to accept `before: String?` cursor and return `RecentlyPlayedResponse` (previously returned `[SpotifyPlayHistory]`)
- Adds `cursors.before` field to `RecentlyPlayedResponse` model
- Updates `SpotifyRecentProviding` protocol and `ProfileRecentViewModel` call site for new signature
- Creates `RecentlyPlayedViewModel` (`ViewModels/Library/`) with `SpotifyRecentlyPlayedProviding` protocol, 50-per-page cursor pagination, `searchQuery`/`filteredTracks`
- Replaces `RecentlyPlayedView` stub with full implementation mirroring `LikesView` structure
- Bumps version to 1.10.0

## Plan reference
`docs/features/likes-and-recent-destinations/PLAN.md` — Phase 3