### PR TITLE
feat: Phase 4 — profile updates

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -6,11 +6,10 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
     case ratings
     case taste
     case playlists
-    /// Last-25 recently played tracks from Spotify. Self-only because the
+    /// Last-10 recently played tracks from Spotify. Self-only because the
     /// underlying endpoint is scoped to the authenticated user.
+    /// A "See all" CTA deep-links to the top-level Recently Played destination.
     case recent
-    /// Full saved-tracks (liked) library with pagination. Self-only.
-    case likes
 
     var title: String {
         switch self {
@@ -19,7 +18,6 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
         case .taste:     return "Taste"
         case .playlists: return "Playlists"
         case .recent:    return "Recent"
-        case .likes:     return "Likes"
         }
     }
 
@@ -32,7 +30,6 @@ enum ProfileTab: String, CaseIterable, Hashable, Sendable {
         case .taste:     return "waveform"
         case .playlists: return "music.note.list"
         case .recent:    return "clock.arrow.circlepath"
-        case .likes:     return "heart.fill"
         }
     }
 }
@@ -68,6 +65,8 @@ final class UserProfileViewModel {
     var friendCount: Int?
     var followersCount: Int?
     var followingCount: Int?
+    /// Total liked songs count — self-only. Nil until loaded; chip hides when nil.
+    var likesCount: Int?
 
     /// Raw `FriendProfile` payload for `.other` — retained so the Taste tab
     /// can read `topArtists` / `topSongs` / `topGenres` without a second fetch.
@@ -90,16 +89,15 @@ final class UserProfileViewModel {
     private var _sharesVM: SharesByUserViewModel?
     private var _ratingsVM: RatingsViewModel?
     private var _playlistsVM: ProfilePlaylistsViewModel?
-    private var _likesVM: LikesViewModel?
 
     /// Tabs visible for this profile's context. `.playlists` surfaces the
     /// signed-in user's Spotify playlists for `.me`, and the friend's public
     /// playlists for `.other` once the `FriendProfile` payload has loaded.
-    /// `.recent` and `.likes` are self-only because the underlying Spotify
-    /// endpoints are scoped to the authenticated user.
+    /// `.recent` is self-only because the underlying Spotify endpoint is
+    /// scoped to the authenticated user. Likes has moved to the sidebar.
     var visibleTabs: [ProfileTab] {
         switch context {
-        case .me:    return [.shares, .ratings, .taste, .playlists, .recent, .likes]
+        case .me:    return [.shares, .ratings, .taste, .playlists, .recent]
         case .other: return [.shares, .ratings, .taste, .playlists]
         }
     }
@@ -122,14 +120,6 @@ final class UserProfileViewModel {
         if let existing = _ratingsVM { return existing }
         let vm = RatingsViewModel()
         _ratingsVM = vm
-        return vm
-    }
-
-    /// Lazy accessor for the Likes tab view model.
-    func likesViewModel() -> LikesViewModel {
-        if let existing = _likesVM { return existing }
-        let vm = LikesViewModel()
-        _likesVM = vm
         return vm
     }
 
@@ -241,11 +231,13 @@ final class UserProfileViewModel {
         async let shares: FeedResponse?       = try? xomifyService.getSharesByUser(
             email: callerEmail, targetEmail: callerEmail, limit: 1, before: nil
         )
+        async let likedPage: SavedTracksResponse? = try? SpotifyService.shared.getSavedTracks(limit: 1, offset: 0)
 
-        let (r, f, s) = await (ratings, friends, shares)
+        let (r, f, s, l) = await (ratings, friends, shares, likedPage)
         ratingCount = r?.totalCount ?? r?.ratings?.count
         friendCount = f?.acceptedCount ?? f?.accepted?.count
         shareCount  = s?.totalCount ?? s?.shares.count
+        likesCount  = l?.total
     }
 
     private func loadOtherHeader(email: String) async throws {

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -126,6 +126,16 @@ struct ProfileHeaderView: View {
                     color: .xomifyGreen,
                     destination: .feed
                 )
+                // Likes chip — self-only, hidden on friend profiles.
+                if viewModel.context.isSelf, let likesCount = viewModel.likesCount {
+                    divider
+                    statItem(
+                        value: likesCount,
+                        label: "Likes",
+                        color: .xomifyGreen,
+                        destination: .likes
+                    )
+                }
             }
         }
         .padding(.vertical, 12)

--- a/Xomify-iOS/Views/Profile/Tabs/ProfileRecentTab.swift
+++ b/Xomify-iOS/Views/Profile/Tabs/ProfileRecentTab.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-/// Self-only tab on `ProfileView` that lists the signed-in user's last-25
-/// recently-played tracks. Powers the "what was I just listening to?" quick
-/// lookup so tracks can be shared to the feed without bouncing to Spotify.
+/// Self-only tab on `ProfileView` that shows the signed-in user's last 10
+/// recently-played tracks — a quick "what was I just listening to?" lookup.
+/// Tapping "See all" deep-links to the full Recently Played destination.
 ///
-/// Liked songs have moved to the dedicated Likes tab.
 /// Each row uses the shared `TrackActionsMenu` for play / queue / share actions.
 struct ProfileRecentTab: View {
 
+    @Environment(NavigationStore.self) private var navStore
     @State private var viewModel = ProfileRecentViewModel()
 
     var body: some View {
@@ -15,10 +15,14 @@ struct ProfileRecentTab: View {
             section(
                 title: "Recently played",
                 icon: "clock.arrow.circlepath",
-                tracks: viewModel.recentlyPlayed,
+                tracks: Array(viewModel.recentlyPlayed.prefix(10)),
                 error: viewModel.recentError,
                 emptyText: "Nothing played recently."
             )
+
+            if viewModel.recentlyPlayed.count >= 10 {
+                seeAllButton
+            }
         }
         .padding(.horizontal, 16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -28,6 +32,36 @@ struct ProfileRecentTab: View {
         .refreshable {
             await viewModel.load()
         }
+    }
+
+    private var seeAllButton: some View {
+        Button {
+            navStore.select(.recentlyPlayed)
+        } label: {
+            HStack {
+                Text("See all recently played")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+            }
+            .foregroundStyle(.white)
+            .padding(14)
+            .background(
+                LinearGradient(
+                    colors: [Color.xomifyPurple.opacity(0.45), Color.xomifyGreen.opacity(0.35)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color.white.opacity(0.10), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens full recently played history")
     }
 
     @ViewBuilder

--- a/Xomify-iOS/Views/ProfileView.swift
+++ b/Xomify-iOS/Views/ProfileView.swift
@@ -98,9 +98,6 @@ struct ProfileView: View {
 
         case .recent:
             ProfileRecentTab()
-
-        case .likes:
-            LikesView()
         }
     }
 


### PR DESCRIPTION
## Summary
- Removes `case likes` from `ProfileTab` enum and all related switch arms
- Removes `_likesVM` and `likesViewModel()` from `UserProfileViewModel`
- Removes `.likes` from `visibleTabs` (was `.me`-only anyway)
- Caps `ProfileRecentTab` to `prefix(10)` rows; adds "See all" footer button (`navStore.select(.recentlyPlayed)`) when count >= 10
- Injects `@Environment(NavigationStore.self)` into `ProfileRecentTab`
- Adds `likesCount: Int?` to `UserProfileViewModel`; populated via parallel `getSavedTracks(limit: 1, offset: 0)` in `loadSelfHeader`
- Adds self-only Likes count chip as a fourth `statItem` in `ProfileHeaderView.statsRow`; tap navigates to `.likes` destination
- Bumps version to 1.11.0

## Plan reference
`docs/features/likes-and-recent-destinations/PLAN.md` — Phase 4