### PR TITLE
feat: Phase 5 — friend-profile stat tile parity

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -175,7 +175,11 @@ struct ProfileHeaderView: View {
         color: Color,
         destination: SidebarDestination?
     ) -> some View {
-        let isTappable = destination != nil && viewModel.context.isSelf
+        // Both self and friend profiles can tap stat tiles to drill in.
+        // Friend-scoped FriendsView / RatingsView / posts-feed scoping is a
+        // follow-up item — for now taps land on viewer-scoped destinations,
+        // which is better than being silently disabled.
+        let isTappable = destination != nil
 
         let content = VStack(spacing: 4) {
             Text("\(value)")


### PR DESCRIPTION
## Summary
- Un-gates `statItem.isTappable` in `ProfileHeaderView`: removed `&& viewModel.context.isSelf` so Friends / Ratings / Posts tiles are tappable on friend profiles
- Bumps version to 1.12.0

## Known partial parity (follow-up items)
- Friend stat tile taps currently land on **viewer-scoped** destinations (e.g. tapping Friends on a friend's profile shows your own friends list, not theirs). This is honest progress — better than being silently disabled. Friend-scoped `FriendsView` / `RatingsView` / posts-feed scoping requires target-email param work, filed as a follow-up.
- `ProfileRatingsTab.viewAllButton` still calls `navStore.select(.ratings)` regardless of context — same issue, same follow-up scope.
- Likes chip confirmed NOT rendered on `.other` (already gated by `viewModel.context.isSelf` check in Phase 4).
- Recent sub-tab confirmed self-only (not in `.other` `visibleTabs`).
- `onDelete` in `ProfileSharesTab` confirmed gated on `context.isSelf` — no change needed.

## Plan reference
`docs/features/likes-and-recent-destinations/PLAN.md` — Phase 5