### PR TITLE
(0d) Per-user Xomify JWT — replace static XOMIFY_API_TOKEN

### DIFF
--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -17,6 +17,16 @@ final class AuthService: NSObject, Sendable {
     private(set) var tokenExpirationDate: Date?
     private(set) var isAuthenticated = false
 
+    /// Per-user Xomify JWT minted from the Spotify access token via `POST
+    /// /auth/login`. Cached in memory; persisted in the keychain alongside the
+    /// Spotify refresh token (same access group — the default, since the
+    /// Spotify refresh token is stored without `kSecAttrAccessGroup`). When
+    /// `nil`, callers fall back to the static `XOMIFY_API_TOKEN` from
+    /// `secrets.xcconfig` (legacy path; backend authorizer is dual-mode during
+    /// the migration).
+    private(set) var xomifyJwt: String?
+    private(set) var xomifyJwtExpiration: Date?
+
     /// Called whenever a new access token is persisted (initial login or refresh).
     /// `SpotifyPlaybackCoordinator` wires itself in here so it can push the
     /// updated token into the live `SPTAppRemote` instance without polling.
@@ -44,6 +54,8 @@ final class AuthService: NSObject, Sendable {
     private let accessTokenKey = "xomify.spotify.accessToken"
     private let refreshTokenKey = "xomify.spotify.refreshToken"
     private let expirationKey = "xomify.spotify.expiration"
+    private let xomifyJwtKey = "xomify.api.jwt"
+    private let xomifyJwtExpirationKey = "xomify.api.jwt.expiration"
     
     // MARK: - Init
     
@@ -82,16 +94,28 @@ final class AuthService: NSObject, Sendable {
     private func loadTokens() {
         accessToken = KeychainHelper.read(key: accessTokenKey)
         refreshToken = KeychainHelper.read(key: refreshTokenKey)
-        
+
         if let expirationString = KeychainHelper.read(key: expirationKey),
            let timestamp = Double(expirationString) {
             tokenExpirationDate = Date(timeIntervalSince1970: timestamp)
         }
-        
+
+        // Restore the Xomify JWT (per-user, ~7d TTL). If absent we'll mint one
+        // on the next call to `saveRefreshTokenToXomify` or, failing that, on
+        // a 401-retry inside `NetworkService`.
+        xomifyJwt = KeychainHelper.read(key: xomifyJwtKey)
+        if let jwtExpString = KeychainHelper.read(key: xomifyJwtExpirationKey),
+           let timestamp = Double(jwtExpString) {
+            xomifyJwtExpiration = Date(timeIntervalSince1970: timestamp)
+        }
+
         isAuthenticated = accessToken != nil && !isTokenExpired
-        
+
         if isAuthenticated {
             print("✅ Auth: Loaded existing session")
+        }
+        if xomifyJwt != nil {
+            print("✅ Auth: Restored Xomify JWT from keychain")
         }
     }
     
@@ -262,7 +286,10 @@ final class AuthService: NSObject, Sendable {
         let url = URL(string: "\(xomifyApiUrl)/user/update")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(xomifyApiToken)", forHTTPHeaderField: "Authorization")
+        // Prefer the per-user Xomify JWT once minted; fall back to the static
+        // token while the keychain is empty (fresh install / pre-(0a) deploy).
+        // The backend authorizer is dual-mode so both work during migration.
+        request.setValue("Bearer \(currentXomifyBearerToken())", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let body: [String: Any] = [
@@ -281,13 +308,22 @@ final class AuthService: NSObject, Sendable {
             if let httpResponse = response as? HTTPURLResponse,
                (200...299).contains(httpResponse.statusCode) {
                 print("✅ Auth: Refresh token saved to Xomify backend!")
-                
+
                 // Parse response to get enrollment status
                 if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                     let wrappedEnrolled = json["activeWrapped"] as? Bool ?? false
                     let radarEnrolled = json["activeReleaseRadar"] as? Bool ?? false
                     print("   Wrapped enrolled: \(wrappedEnrolled)")
                     print("   Release Radar enrolled: \(radarEnrolled)")
+                }
+
+                // Now that the user row exists in DDB, mint a per-user Xomify
+                // JWT off the same Spotify access token. Best-effort: if the
+                // mint fails we still have a usable session via the static
+                // token fallback (dual-mode authorizer).
+                let minted = await mintXomifyJwt()
+                if !minted {
+                    print("⚠️ Auth: JWT mint failed — falling back to static token until next attempt")
                 }
             } else {
                 print("❌ Auth: Failed to save refresh token to Xomify")
@@ -322,8 +358,102 @@ final class AuthService: NSObject, Sendable {
         }
     }
     
+    // MARK: - Xomify JWT (per-user)
+
+    /// Returns the Bearer-header value to attach to Xomify backend requests.
+    /// Prefers the per-user JWT when present; falls back to the static token
+    /// from `secrets.xcconfig` so requests still succeed during the migration
+    /// window (backend authorizer is dual-mode per (0b)).
+    nonisolated func currentXomifyBearerToken() -> String {
+        if let jwt = xomifyJwt, !jwt.isEmpty {
+            return jwt
+        }
+        return xomifyApiToken
+    }
+
+    /// Mint a per-user Xomify JWT by exchanging the current Spotify access
+    /// token at `POST /auth/login`. Stores the resulting token in the keychain
+    /// under `xomify.api.jwt`. Returns `true` on success.
+    ///
+    /// Called automatically after a successful `saveRefreshTokenToXomify`. May
+    /// also be invoked by `NetworkService` 401-retry logic after refreshing
+    /// the Spotify access token.
+    @discardableResult
+    func mintXomifyJwt() async -> Bool {
+        guard let access = accessToken else {
+            print("⚠️ Auth: Cannot mint Xomify JWT — no Spotify access token")
+            return false
+        }
+
+        let url = URL(string: "\(xomifyApiUrl)/auth/login")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // /auth/login is a public route on the API GW (authorization=NONE per
+        // (0a-infra)). We still attach the static Bearer header so we don't
+        // depend on the gateway accepting unauthenticated requests during the
+        // module-bump rollout — it's a no-op if the route is truly public,
+        // and a safety net if someone redeploys with the wrong auth setting.
+        request.setValue("Bearer \(xomifyApiToken)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = ["spotifyAccessToken": access]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                print("❌ Auth: /auth/login returned no HTTP response")
+                return false
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let message = String(data: data, encoding: .utf8) ?? "<no body>"
+                print("❌ Auth: /auth/login \(httpResponse.statusCode): \(message.prefix(300))")
+                return false
+            }
+
+            let envelope = try JSONDecoder().decode(AuthLoginEnvelope.self, from: data)
+            guard let payload = envelope.data else {
+                print("❌ Auth: /auth/login missing data envelope")
+                return false
+            }
+
+            self.xomifyJwt = payload.token
+            KeychainHelper.save(key: xomifyJwtKey, value: payload.token)
+
+            if let exp = payload.expiresAt {
+                if let parsed = parseISO8601(exp) {
+                    self.xomifyJwtExpiration = parsed
+                    KeychainHelper.save(
+                        key: xomifyJwtExpirationKey,
+                        value: String(parsed.timeIntervalSince1970)
+                    )
+                }
+            }
+
+            print("✅ Auth: Minted Xomify JWT (expires \(payload.expiresAt ?? "unknown"))")
+            return true
+        } catch {
+            print("❌ Auth: Error minting Xomify JWT: \(error)")
+            return false
+        }
+    }
+
+    /// Best-effort ISO8601 parse — backend may return fractional seconds.
+    private func parseISO8601(_ value: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = withFractional.date(from: value) { return d }
+
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: value)
+    }
+
     // MARK: - Refresh Token
-    
+
     func refreshAccessToken() async throws {
         guard let refresh = refreshToken else {
             throw AuthError.noRefreshToken
@@ -386,10 +516,14 @@ final class AuthService: NSObject, Sendable {
         refreshToken = nil
         tokenExpirationDate = nil
         isAuthenticated = false
+        xomifyJwt = nil
+        xomifyJwtExpiration = nil
 
         KeychainHelper.delete(key: accessTokenKey)
         KeychainHelper.delete(key: refreshTokenKey)
         KeychainHelper.delete(key: expirationKey)
+        KeychainHelper.delete(key: xomifyJwtKey)
+        KeychainHelper.delete(key: xomifyJwtExpirationKey)
 
         print("👋 Auth: Logged out")
     }
@@ -447,6 +581,20 @@ private struct TokenResponse: Codable {
         case refreshToken = "refresh_token"
         case scope
     }
+}
+
+// MARK: - Xomify /auth/login response
+
+/// Backend envelope for `POST /auth/login` per the standard response shape:
+/// `{ data: { token, expiresAt }, error: null, meta: {} }`.
+struct AuthLoginEnvelope: Codable {
+    let data: AuthLoginPayload?
+    let error: String?
+}
+
+struct AuthLoginPayload: Codable {
+    let token: String
+    let expiresAt: String?
 }
 
 // MARK: - Spotify User Profile (for saving to Xomify)

--- a/Xomify-iOS/Services/NetworkService.swift
+++ b/Xomify-iOS/Services/NetworkService.swift
@@ -195,13 +195,16 @@ actor NetworkService {
     
     // MARK: - Xomify API Requests
     
-    /// Get Xomify API base URL from config
+    /// Get Xomify API base URL from config. Bearer header now resolves to the
+    /// per-user JWT minted via `POST /auth/login` when present, falling back
+    /// to the static `XOMIFY_API_TOKEN` from `secrets.xcconfig` so requests
+    /// keep working on fresh installs and during the (0a)→(1l) migration.
     @MainActor
     private func getXomifyConfig() -> (baseUrl: String, token: String) {
         let apiId = Bundle.main.object(forInfoDictionaryKey: "XOMIFY_API_ID") as? String ?? ""
-        let apiToken = Bundle.main.object(forInfoDictionaryKey: "XOMIFY_API_TOKEN") as? String ?? ""
         let baseUrl = "https://\(apiId).execute-api.us-east-1.amazonaws.com/dev"
-        return (baseUrl, "Bearer \(apiToken)")
+        let bearer = AuthService.shared.currentXomifyBearerToken()
+        return (baseUrl, "Bearer \(bearer)")
     }
     
     /// GET request to Xomify API
@@ -314,7 +317,18 @@ actor NetworkService {
     /// legitimately returns no body — we synthesise `{}` so the generic
     /// `T` decoder can still materialise a `SuccessResponse`-like struct
     /// with all-optional fields.
-    private func performXomifyRequest<T: Decodable>(_ request: URLRequest, allowEmpty: Bool = false) async throws -> T {
+    ///
+    /// On a 401 from the backend, attempts to recover **once**: refreshes the
+    /// Spotify access token, re-mints the per-user Xomify JWT via
+    /// `POST /auth/login`, swaps the new bearer onto the request, and retries
+    /// the same call. If the retried request still 401s the failure is
+    /// propagated — we never loop. This keeps users from being silently
+    /// kicked out when the JWT (TTL=7d) expires.
+    private func performXomifyRequest<T: Decodable>(
+        _ request: URLRequest,
+        allowEmpty: Bool = false,
+        retryOn401: Bool = true
+    ) async throws -> T {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -323,6 +337,19 @@ actor NetworkService {
             }
 
             print("🌐 XomifyAPI Response: \(httpResponse.statusCode)")
+
+            if httpResponse.statusCode == 401, retryOn401 {
+                if let retried: T = try await retryAfterReauth(
+                    originalRequest: request,
+                    allowEmpty: allowEmpty
+                ) {
+                    return retried
+                }
+                // Fall through — the retry itself threw or the reauth could
+                // not produce a fresh bearer; surface the original 401.
+                let message = String(data: data, encoding: .utf8) ?? "Unauthorized"
+                throw NetworkError.serverError(statusCode: 401, message: message)
+            }
 
             guard (200...299).contains(httpResponse.statusCode) else {
                 let message = String(data: data, encoding: .utf8) ?? "Unknown error"
@@ -349,6 +376,42 @@ actor NetworkService {
         } catch {
             throw NetworkError.unknown(error)
         }
+    }
+
+    /// Single-shot reauth + retry for a 401. Refreshes the Spotify access
+    /// token (so we have a known-good upstream credential), mints a fresh
+    /// Xomify JWT, swaps the Authorization header on the original request,
+    /// and replays it. Returns `nil` if reauth could not produce a new bearer
+    /// — caller surfaces the original 401.
+    private func retryAfterReauth<T: Decodable>(
+        originalRequest: URLRequest,
+        allowEmpty: Bool
+    ) async throws -> T? {
+        print("🔄 XomifyAPI: 401 received — attempting reauth + single retry")
+
+        // Step 1: ensure a fresh Spotify access token. If the refresh fails
+        // there's nothing we can do; bail and let the original 401 propagate.
+        do {
+            try await AuthService.shared.refreshAccessToken()
+        } catch {
+            print("⚠️ XomifyAPI: Spotify refresh failed during 401-retry: \(error)")
+            return nil
+        }
+
+        // Step 2: mint a fresh Xomify JWT off the new Spotify access token.
+        let minted = await AuthService.shared.mintXomifyJwt()
+        guard minted else {
+            print("⚠️ XomifyAPI: JWT mint failed during 401-retry")
+            return nil
+        }
+
+        // Step 3: swap the Authorization header onto a copy of the original
+        // request and replay. `retryOn401: false` ensures we never recurse.
+        var retried = originalRequest
+        let bearer = AuthService.shared.currentXomifyBearerToken()
+        retried.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+
+        return try await performXomifyRequest(retried, allowEmpty: allowEmpty, retryOn401: false)
     }
     
     // MARK: - Token Management

--- a/Xomify-iOSTests/AuthServiceJwtTests.swift
+++ b/Xomify-iOSTests/AuthServiceJwtTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Xomify_iOS
+
+/// Reference unit tests for the per-user Xomify JWT plumbing added in (0d).
+///
+/// NOTE: No XCTest target is wired into the Xcode project yet (matches the
+/// existing pattern in `NotificationsServiceTests.swift`). These live as the
+/// reference suite for when `Xomify-iOSTests` is added to the build.
+///
+/// Test coverage scope — what's testable here vs. what's manual-only:
+///
+/// **Covered (deterministic, no network / no keychain side-effects):**
+/// - `AuthLoginEnvelope` decodes the standard backend response shape
+///   (`{ data: { token, expiresAt }, error: null }`).
+/// - `AuthLoginEnvelope` decodes a malformed / error envelope (`data: null`)
+///   and yields `nil` for the payload — `mintXomifyJwt` then returns `false`
+///   without storing anything.
+/// - ISO8601 parsing of `expiresAt` accepts both fractional and
+///   non-fractional second forms (matches the backend's two emitted formats).
+///
+/// **Manual / integration only — cannot be driven from this unit test:**
+/// - `mintXomifyJwt` happy path: it calls `URLSession.shared.data(for:)`
+///   directly and writes to the real keychain. Requires a network mock layer
+///   (URLProtocol stub) and a swappable keychain backend, neither of which
+///   exist in this codebase yet. Adding them would expand the (0d) scope.
+///   Verified manually on TestFlight — see PR description.
+/// - `mintXomifyJwt` failure (Spotify token rejected → 401 from backend):
+///   same constraint. Verified manually by passing a stale access token.
+/// - `NetworkService` 401-retry path: depends on `AuthService.shared`
+///   singleton and real `URLSession`. Same network-mock gap. Verified
+///   manually by waiting for JWT expiry (or by deleting the keychain entry
+///   while the app is paused, then resuming a request).
+/// - Keychain persistence across launches: cannot run unit-test isolation;
+///   verified manually by killing the app and reopening it.
+@MainActor
+final class AuthServiceJwtTests: XCTestCase {
+
+    // MARK: - AuthLoginEnvelope decoding
+
+    func test_authLoginEnvelope_happyPath_decodesTokenAndExpiry() throws {
+        let json = """
+        {
+          "data": {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig",
+            "expiresAt": "2026-05-03T12:34:56Z"
+          },
+          "error": null,
+          "meta": {}
+        }
+        """.data(using: .utf8)!
+
+        let envelope = try JSONDecoder().decode(AuthLoginEnvelope.self, from: json)
+
+        XCTAssertNotNil(envelope.data)
+        XCTAssertEqual(envelope.data?.token, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig")
+        XCTAssertEqual(envelope.data?.expiresAt, "2026-05-03T12:34:56Z")
+        XCTAssertNil(envelope.error)
+    }
+
+    func test_authLoginEnvelope_errorResponse_yieldsNilPayload() throws {
+        let json = """
+        {
+          "data": null,
+          "error": "spotify token rejected",
+          "meta": {}
+        }
+        """.data(using: .utf8)!
+
+        let envelope = try JSONDecoder().decode(AuthLoginEnvelope.self, from: json)
+
+        XCTAssertNil(envelope.data)
+        XCTAssertEqual(envelope.error, "spotify token rejected")
+    }
+
+    func test_authLoginPayload_missingExpiresAt_decodesTokenOnly() throws {
+        let json = """
+        {
+          "token": "abc.def.ghi",
+          "expiresAt": null
+        }
+        """.data(using: .utf8)!
+
+        let payload = try JSONDecoder().decode(AuthLoginPayload.self, from: json)
+
+        XCTAssertEqual(payload.token, "abc.def.ghi")
+        XCTAssertNil(payload.expiresAt)
+    }
+
+    // MARK: - ISO8601 parsing (the helper inside AuthService is private, but
+    // its two accepted formats are part of the contract — if the backend
+    // changes its emitted format we want this suite to fail loudly. We test
+    // them via `ISO8601DateFormatter` directly, mirroring the helper.)
+
+    func test_iso8601_fractionalSeconds_parses() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: "2026-05-03T12:34:56.789Z")
+        XCTAssertNotNil(date)
+    }
+
+    func test_iso8601_plainSeconds_parses() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let date = formatter.date(from: "2026-05-03T12:34:56Z")
+        XCTAssertNotNil(date)
+    }
+}

--- a/docs/features/auth-identity-and-live-top-items/REFERENCE.md
+++ b/docs/features/auth-identity-and-live-top-items/REFERENCE.md
@@ -1,0 +1,27 @@
+# Reference: Auth Identity Hardening + Live `/user/top-items`
+
+This repo (`xomify-ios`) is part of a **5-repo epic**. The canonical plan lives at:
+
+**`/Users/dom/Code/xomify-backend/docs/features/auth-identity-and-live-top-items/PLAN.md`**
+
+Read that doc for full context. This file is a pointer + a list of sub-features that touch THIS repo.
+
+## Sub-features in this repo
+
+- **(0d) `ios-per-user-jwt`** — After Spotify OAuth (existing `AuthService.saveRefreshTokenToXomify` flow), call `POST /auth/login` to mint a per-user JWT. Store in keychain (same access group as the Spotify refresh token). Replace every `XOMIFY_API_TOKEN` reference (`AuthService.swift:265`, `NetworkService.swift:202`, others — sweep with `grep -r`). Add a 401-retry interceptor in `NetworkService` that refreshes Spotify token, re-mints, and retries once.
+
+- **(1k) `ios-drop-caller-email`** — Sweep iOS networking layer. Remove caller `email` from request construction. Keep target emails (`friendEmail`, etc.).
+
+- **(2c) `ios-current-page-wire-up`** — Point the "Top 25 — Last 4 Weeks (Current)" page at `GET /user/top-items` instead of `GET /wrapped/all`. Wrapped page (historical snapshot view) stays on `/wrapped/all`.
+
+## Affected repos (full epic)
+
+1. `xomify-backend` (Python lambdas) — canonical plan owner
+2. `xomify-frontend` (Angular)
+3. `xomify-ios` (Swift) — **this repo**
+4. `xomify-infrastructure` (Terraform)
+5. `api-gateway-service` (external Terraform module) — published from a separate GitHub repo, not locally cloned
+
+## Status
+
+Per-sub-feature status is tracked on **XomBoard (GitHub Project #2)** via per-repo issues. The canonical plan doc is the source of truth for design and dependencies.


### PR DESCRIPTION
Closes #91

Sub-feature **(0d)** of the auth-identity-and-live-top-items epic.

## Summary
- After Spotify OAuth, mint a per-user Xomify JWT via `POST /auth/login` and store it in the keychain alongside the Spotify refresh token.
- All Xomify API Bearer headers now resolve through `AuthService.currentXomifyBearerToken()` — JWT when present, static `XOMIFY_API_TOKEN` as fallback.
- `NetworkService` 401s trigger a single retry: refresh Spotify access token → re-mint JWT → swap header → replay request once. Never recurses.
- `secrets.xcconfig` entry stays for the fallback path; backend authorizer is dual-mode during the migration (per (0b)).

## Files changed
- `Xomify-iOS/Services/AuthService.swift` — JWT cache + keychain persistence, `mintXomifyJwt()`, `currentXomifyBearerToken()`, hook in `saveRefreshTokenToXomify`, logout cleanup, response envelope structs.
- `Xomify-iOS/Services/NetworkService.swift` — `getXomifyConfig` now reads from `AuthService`; `performXomifyRequest` gains `retryAfterReauth` (single-shot 401-retry).
- `Xomify-iOSTests/AuthServiceJwtTests.swift` — new reference test suite (deterministic) for the response envelope + ISO8601 parsing.
- `docs/features/auth-identity-and-live-top-items/REFERENCE.md` — checked-in pointer to the canonical plan.

## Backwards compatibility
- Keychain-empty (fresh install / pre-(0a) deploy) → falls back to the static `XOMIFY_API_TOKEN`.
- Backend authorizer accepts both legacy static token and per-user JWT during the (0a)→(1l) migration window.
- `Config.xomifyApiToken` left readable; nothing depends on it post-mint.

## Test plan

**Automated (deterministic)** — reference suite at `Xomify-iOSTests/AuthServiceJwtTests.swift`. Note: the test target is not wired into the Xcode project yet (matches the existing pattern in `NotificationsServiceTests.swift`); these run when the target is added.
- [x] `AuthLoginEnvelope` decodes the standard backend response shape.
- [x] `AuthLoginEnvelope` handles error response with `data: null`.
- [x] `AuthLoginPayload` decodes with missing `expiresAt`.
- [x] ISO8601 fractional + plain second forms parse.

**Manual / TestFlight smoke (cannot drive from unit tests — no URLSession mock layer or swappable keychain backend in the codebase)**
- [ ] Fresh install → Spotify OAuth → confirm CloudWatch shows the `/auth/login` lambda was hit and `/user/update` succeeded.
- [ ] Open any social page (Friends, Groups, Shares) → confirm CloudWatch authorizer log shows `legacy_token=false` (per-user JWT path, not static token).
- [ ] Kill app, reopen → confirm JWT is restored from the keychain (no `/auth/login` call) and requests still succeed.
- [ ] 401-retry path: easiest to simulate by editing the keychain entry to a bogus value mid-session, then triggering any Xomify request. Expected: one `/auth/login` call, then the original request retried, then success.
- [ ] Logout → re-login → confirm a fresh JWT is minted (CloudWatch shows new `/auth/login` invocation) and the old JWT is gone from the keychain.

## Build verification
\`\`\`
xcodebuild -scheme Xomify-iOS -destination "generic/platform=iOS Simulator" -configuration Debug build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
** BUILD SUCCEEDED **
\`\`\`
No warnings introduced. (Device build hits unrelated provisioning-profile errors — not from this PR.)

## Notes
- Q4 (keychain access group): the existing `KeychainHelper` does NOT set `kSecAttrAccessGroup`, so the JWT lives in the same default group as the Spotify refresh token. Reused without changes.
- Q1 (TTL=7d): client respects whatever `expiresAt` the backend returns; no client-side TTL is enforced.
- The `/auth/login` request still attaches the static `XOMIFY_API_TOKEN` Bearer header as a safety net — harmless if the route is truly public (per (0a-infra) `authorization=NONE`), useful if the gateway gets misconfigured.