### PR TITLE
(2c) Wire Last 4 Weeks (Current) page to /user/top-items

### DIFF
--- a/Xomify-iOS/Models/TopItemsResponse.swift
+++ b/Xomify-iOS/Models/TopItemsResponse.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - Top Items Response (`GET /user/top-items`)
+//
+// Live, daily-cached top tracks/artists/genres for the signed-in user. The
+// backend serves snake_case keys (`short_term`, `medium_term`, `long_term`,
+// `failed_ranges`) and `NetworkService.xomifyGet` decodes with
+// `keyDecodingStrategy = .convertFromSnakeCase`, so the Swift property names
+// here are the camelCased equivalents.
+//
+// Each per-term value is optional — the backend isolates per-range failures
+// and emits `null` for any range it could not fetch, populating
+// `meta.failed_ranges` with the union of failing range names. Genres for a
+// failed artists range are also `null` (genres are derived from artists).
+//
+// Cache contract (epic Q7): the response is at most ~24h stale, refreshed
+// once per UTC day on first request. iOS does not need a client-side cache.
+
+/// Envelope returned by `GET /user/top-items`. Fields are mirrors of the
+/// Spotify shapes already in use (`SpotifyTrack`, `SpotifyArtist`) plus a
+/// `genres` map of `{ genre: weighted_score }` per term.
+struct TopItemsResponse: Codable, Sendable {
+    let tracks: TopItemsTracks?
+    let artists: TopItemsArtists?
+    let genres: TopItemsGenres?
+    let meta: TopItemsMeta?
+
+    struct TopItemsTracks: Codable, Sendable {
+        let shortTerm: [SpotifyTrack]?
+        let mediumTerm: [SpotifyTrack]?
+        let longTerm: [SpotifyTrack]?
+    }
+
+    struct TopItemsArtists: Codable, Sendable {
+        let shortTerm: [SpotifyArtist]?
+        let mediumTerm: [SpotifyArtist]?
+        let longTerm: [SpotifyArtist]?
+    }
+
+    /// Backend ships genres as `{ genre_name: weighted_score }` per term.
+    /// Mirrors the existing `MonthlyWrap.TermGenres` shape so callers can
+    /// reuse the same render path.
+    struct TopItemsGenres: Codable, Sendable {
+        let shortTerm: [String: Int]?
+        let mediumTerm: [String: Int]?
+        let longTerm: [String: Int]?
+    }
+
+    /// Present only on partial failure. `failedRanges` is a sorted list of
+    /// `short_term` / `medium_term` / `long_term` strings (raw enum values
+    /// of `TimeRange`) that the backend could not fetch from Spotify.
+    struct TopItemsMeta: Codable, Sendable {
+        let failedRanges: [String]?
+    }
+}
+
+extension TopItemsResponse {
+    /// Convenience: tracks for a given `TimeRange`, or empty array if the
+    /// range is missing / nulled by partial failure.
+    func tracks(for term: TimeRange) -> [SpotifyTrack] {
+        switch term {
+        case .shortTerm:  return tracks?.shortTerm ?? []
+        case .mediumTerm: return tracks?.mediumTerm ?? []
+        case .longTerm:   return tracks?.longTerm ?? []
+        }
+    }
+
+    /// Convenience: artists for a given `TimeRange`, or empty array if the
+    /// range is missing / nulled by partial failure.
+    func artists(for term: TimeRange) -> [SpotifyArtist] {
+        switch term {
+        case .shortTerm:  return artists?.shortTerm ?? []
+        case .mediumTerm: return artists?.mediumTerm ?? []
+        case .longTerm:   return artists?.longTerm ?? []
+        }
+    }
+
+    /// Convenience: genres for a given `TimeRange` as a count-descending
+    /// list of `(name, count)` tuples, mirroring the shape `TopItemsView`
+    /// already renders.
+    func genres(for term: TimeRange) -> [(name: String, count: Int)] {
+        let dict: [String: Int]?
+        switch term {
+        case .shortTerm:  dict = genres?.shortTerm
+        case .mediumTerm: dict = genres?.mediumTerm
+        case .longTerm:   dict = genres?.longTerm
+        }
+        guard let dict else { return [] }
+        return dict
+            .map { (name: $0.key, count: $0.value) }
+            .sorted { $0.count > $1.count }
+    }
+
+    /// `true` when the backend reported a partial Spotify failure for the
+    /// given term — UI can use this to surface a soft retry hint without
+    /// hiding the data we did get.
+    func didFail(term: TimeRange) -> Bool {
+        guard let failed = meta?.failedRanges else { return false }
+        return failed.contains(term.rawValue)
+    }
+}

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -68,6 +68,22 @@ actor XomifyService {
         ])
     }
 
+    // MARK: - Top Items (live, daily-cached)
+
+    /// Live top tracks/artists/genres for the signed-in user, served from a
+    /// per-user, per-UTC-day cache on the backend (epic Q7). Caller identity
+    /// is resolved server-side from the per-user JWT in the `Authorization`
+    /// header — no `email` query param. Replaces the per-range Spotify calls
+    /// the iOS client used to make for the "Last 4 Weeks (Current)" /
+    /// "Music Taste" surface (sub-feature 2c, auth-identity epic).
+    ///
+    /// On per-range partial failure the backend returns the ranges it could
+    /// fetch and lists the failed range names in `meta.failedRanges`; the
+    /// UI can render a soft retry hint without losing the data we did get.
+    func getCurrentTopItems() async throws -> TopItemsResponse {
+        try await network.xomifyGet("/user/top-items")
+    }
+
     // MARK: - Social — Shares
     //
     // The deployed `shares_create` / `shares_feed` contract is fully

--- a/Xomify-iOS/ViewModels/TopItemsViewModel.swift
+++ b/Xomify-iOS/ViewModels/TopItemsViewModel.swift
@@ -1,89 +1,88 @@
 import Foundation
 
-/// ViewModel for Top Items screen
+/// ViewModel for the Top Items / Music Taste screen.
+///
+/// **Sub-feature 2c (auth-identity epic)** — this VM previously fanned out
+/// six direct calls to `/me/top/{tracks,artists}` against Spotify on every
+/// load. It now reads from `XomifyService.getCurrentTopItems()` which
+/// proxies a single backend request to `GET /user/top-items`, served from
+/// a per-user, per-UTC-day cache (epic Q7). One Spotify call per user per
+/// day instead of six per app launch.
+///
+/// Per-range partial failures are surfaced via `failedRanges` so the view
+/// can render a soft retry hint for the affected term without losing the
+/// data we did get.
 @Observable
 @MainActor
 final class TopItemsViewModel {
-    
+
     // MARK: - Properties
-    
+
     var isLoading = false
     var errorMessage: String?
-    
+
     // Tracks by term
     var shortTermTracks: [SpotifyTrack] = []
     var mediumTermTracks: [SpotifyTrack] = []
     var longTermTracks: [SpotifyTrack] = []
-    
+
     // Artists by term
     var shortTermArtists: [SpotifyArtist] = []
     var mediumTermArtists: [SpotifyArtist] = []
     var longTermArtists: [SpotifyArtist] = []
-    
-    // Genres by term (computed from artists)
+
+    // Genres by term — backend ships weighted `{ genre: score }` per term;
+    // we mirror the existing `(name, count)` tuple shape the view consumes.
     var shortTermGenres: [(name: String, count: Int)] = []
     var mediumTermGenres: [(name: String, count: Int)] = []
     var longTermGenres: [(name: String, count: Int)] = []
-    
-    private let spotifyService = SpotifyService.shared
-    
+
+    /// Range names (raw values of `TimeRange`) the backend could not fetch
+    /// from Spotify on the most recent load. Empty on full success.
+    var failedRanges: Set<String> = []
+
+    private let xomifyService = XomifyService.shared
+
     // MARK: - Actions
-    
+
     func loadData() async {
         guard !isLoading else { return }
-        
+
         isLoading = true
         errorMessage = nil
-        
+
         do {
-            // Load all tracks concurrently
-            async let shortTracks = spotifyService.getTopTracks(timeRange: .shortTerm, limit: 50)
-            async let mediumTracks = spotifyService.getTopTracks(timeRange: .mediumTerm, limit: 50)
-            async let longTracks = spotifyService.getTopTracks(timeRange: .longTerm, limit: 50)
-            
-            // Load all artists concurrently
-            async let shortArtists = spotifyService.getTopArtists(timeRange: .shortTerm, limit: 50)
-            async let mediumArtists = spotifyService.getTopArtists(timeRange: .mediumTerm, limit: 50)
-            async let longArtists = spotifyService.getTopArtists(timeRange: .longTerm, limit: 50)
-            
-            // Await all
-            shortTermTracks = try await shortTracks
-            mediumTermTracks = try await mediumTracks
-            longTermTracks = try await longTracks
-            
-            shortTermArtists = try await shortArtists
-            mediumTermArtists = try await mediumArtists
-            longTermArtists = try await longArtists
-            
-            // Compute genres from artists
-            shortTermGenres = computeGenres(from: shortTermArtists)
-            mediumTermGenres = computeGenres(from: mediumTermArtists)
-            longTermGenres = computeGenres(from: longTermArtists)
-            
-            print("✅ TopItems: Loaded \(shortTermTracks.count) short-term tracks, \(mediumTermTracks.count) medium-term, \(longTermTracks.count) long-term")
-            print("✅ TopItems: Loaded \(shortTermArtists.count) short-term artists, \(mediumTermArtists.count) medium-term, \(longTermArtists.count) long-term")
-            
+            let response = try await xomifyService.getCurrentTopItems()
+
+            shortTermTracks  = response.tracks(for: .shortTerm)
+            mediumTermTracks = response.tracks(for: .mediumTerm)
+            longTermTracks   = response.tracks(for: .longTerm)
+
+            shortTermArtists  = response.artists(for: .shortTerm)
+            mediumTermArtists = response.artists(for: .mediumTerm)
+            longTermArtists   = response.artists(for: .longTerm)
+
+            shortTermGenres  = response.genres(for: .shortTerm)
+            mediumTermGenres = response.genres(for: .mediumTerm)
+            longTermGenres   = response.genres(for: .longTerm)
+
+            failedRanges = Set(response.meta?.failedRanges ?? [])
+
+            print("✅ TopItems: Loaded short=\(shortTermTracks.count) medium=\(mediumTermTracks.count) long=\(longTermTracks.count) tracks; failedRanges=\(failedRanges)")
+
         } catch {
             errorMessage = error.localizedDescription
             print("❌ TopItems: Error loading data - \(error)")
         }
-        
+
         isLoading = false
     }
-    
+
     // MARK: - Helpers
-    
-    private func computeGenres(from artists: [SpotifyArtist]) -> [(name: String, count: Int)] {
-        var genreCounts: [String: Int] = [:]
-        
-        for artist in artists {
-            for genre in artist.genres ?? [] {
-                genreCounts[genre, default: 0] += 1
-            }
-        }
-        
-        return genreCounts
-            .map { (name: $0.key, count: $0.value) }
-            .sorted { $0.count > $1.count }
+
+    /// `true` when the backend reported a partial Spotify failure for the
+    /// given term on the most recent load.
+    func didFail(term: TimeRange) -> Bool {
+        failedRanges.contains(term.rawValue)
     }
 }

--- a/Xomify-iOS/Views/TopItemsView.swift
+++ b/Xomify-iOS/Views/TopItemsView.swift
@@ -44,7 +44,16 @@ struct TopItemsContent: View {
                         if viewModel.isLoading {
                             ProgressView()
                                 .padding(.top, 40)
+                        } else if let error = viewModel.errorMessage {
+                            errorState(error)
                         } else {
+                            // Soft retry hint when the backend reported a
+                            // partial Spotify failure for the selected term.
+                            // Data for other terms is still rendered.
+                            if viewModel.didFail(term: selectedTerm) {
+                                partialFailureHint
+                            }
+
                             switch selectedCategory {
                             case 0:
                                 tracksContent
@@ -495,6 +504,87 @@ struct TopItemsContent: View {
         .padding(12)
         .background(Color.white.opacity(0.03))
         .cornerRadius(10)
+    }
+
+    // MARK: - Error / Partial-failure States
+
+    /// Hard error — the whole `/user/top-items` request failed. Shows a
+    /// retry CTA that re-runs `loadData()`.
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 50))
+                .foregroundStyle(.orange.opacity(0.7))
+
+            Text("Couldn't Load Top Items")
+                .font(.headline)
+                .foregroundStyle(.white)
+
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.gray)
+                .multilineTextAlignment(.center)
+
+            Button {
+                Task { await viewModel.loadData() }
+            } label: {
+                Text("Try Again")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 10)
+                    .background(Color.xomifyPurple)
+                    .foregroundStyle(.white)
+                    .cornerRadius(20)
+            }
+        }
+        .padding(.horizontal, 40)
+        .padding(.top, 60)
+    }
+
+    /// Soft retry hint — backend reported a per-range partial failure for
+    /// the current term. Data for other terms is still rendered; tapping
+    /// "Refresh" reissues the request which will re-attempt failing
+    /// ranges (the partial response was not cached server-side).
+    private var partialFailureHint: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.triangle.2.circlepath.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Partial data for \(selectedTerm.displayName)")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                Text("Spotify hiccupped. Pull to refresh or tap retry.")
+                    .font(.caption2)
+                    .foregroundStyle(.gray)
+            }
+
+            Spacer()
+
+            Button {
+                Task { await viewModel.loadData() }
+            } label: {
+                Text("Retry")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.orange.opacity(0.2))
+                    .foregroundStyle(.orange)
+                    .cornerRadius(12)
+            }
+        }
+        .padding(12)
+        .background(Color.orange.opacity(0.08))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+        )
+        .cornerRadius(10)
+        .padding(.bottom, 4)
     }
 
     // MARK: - Playback


### PR DESCRIPTION
Closes #94.

Sub-feature **(2c)** of the [auth-identity-and-live-top-items](https://github.com/Xomware/xomify-backend/blob/master/docs/features/auth-identity-and-live-top-items/PLAN.md) epic.

## Summary
- Point the "Top 25 — Last 4 Weeks (Current)" page (`TopItemsView` + `TopItemsViewModel` — the "Music Taste" drawer destination) at the new live, daily-cached `GET /user/top-items` backend endpoint.
- Replaces six per-launch `/me/top/{tracks,artists}` Spotify calls with a single backend round-trip served from the per-user, per-UTC-day cache (epic Q7).
- Wrapped page (`WrappedView` / `WrappedViewModel`) is unchanged — it stays on `/wrapped/all` for monthly snapshots.

## Files changed
- **added** `Xomify-iOS/Models/TopItemsResponse.swift` — Codable mirror of the `{ tracks, artists, genres, meta }` payload, plus `tracks(for:) / artists(for:) / genres(for:) / didFail(term:)` convenience accessors.
- **modified** `Xomify-iOS/Services/XomifyService.swift` — adds `getCurrentTopItems()` hitting `GET /user/top-items`. Caller identity is resolved server-side from the per-user JWT in the `Authorization` header — no `email` query param.
- **modified** `Xomify-iOS/ViewModels/TopItemsViewModel.swift` — `loadData()` consumes the new endpoint; exposes `failedRanges` + `didFail(term:)`.
- **modified** `Xomify-iOS/Views/TopItemsView.swift` — adds error state + soft retry hint when `meta.failed_ranges` includes the active term.

## Backend contract
```
GET /user/top-items
Authorization: Bearer <per-user JWT>

200:
{
  tracks:  { short_term: [...], medium_term: [...], long_term: [...] },
  artists: { short_term: [...], medium_term: [...], long_term: [...] },
  genres:  { short_term: {...}, medium_term: {...}, long_term: {...} },
  meta:    { failed_ranges: [...] }   // present only on partial failure
}
```
`NetworkService.xomifyGet` already decodes with `keyDecodingStrategy = .convertFromSnakeCase`, so the Swift property names are camelCased equivalents.

## Out of scope (per epic split)
- Anything in `AuthService.swift` related to JWT minting — owned by **(0d) PR #92**.
- Caller-email sweeps in friends / groups / shares / invites / ratings / notifications / release-radar / wrapped VMs — owned by **(1k)**.
- Backend lambda & infra — already deployed.

## Merge order
- **Depends on (0d) PR #92** (per-user JWT replacing static `XOMIFY_API_TOKEN`) being merged so the `Authorization` header `NetworkService` attaches is the per-user JWT the new backend endpoint requires. Until then, the request still goes out with the static token; the new endpoint will 401 because it reads caller identity from authorizer context only.

## Manual TestFlight verification (post-(0d))
- [ ] Open Music Taste from the drawer — confirm "4 Weeks" loads tracks/artists/genres without going to Spotify directly. Watch the network log: one `GET /user/top-items` call, no per-range `/me/top/*` calls from the app.
- [ ] Switch to "6 Months" and "All Time" — same data is rendered without additional network requests (one envelope holds all three terms).
- [ ] Pull-to-refresh — same single endpoint hit; on second-tap inside the same UTC day, backend logs should show `cache=hit`.
- [ ] Force a per-range failure (or wait for natural Spotify rate-limit) — UI shows the orange "Partial data for {term}" hint with a Retry button. Tapping Retry reissues the request.
- [ ] Kill + relaunch — data still loads (no caller-email assumption in the iOS request).
- [ ] Wrapped page (drawer) is untouched — it still loads monthly snapshots from `/wrapped/all`.

## Build status
`xcodebuild -scheme Xomify-iOS -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build` — **clean**, no new warnings introduced.