### PR TITLE
feat: Phase 5 — likes service methods, push coordinator, cold-open hook

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -938,3 +938,52 @@ struct CommentDeleteResponse: Codable, Sendable {
     let deleted: Bool
     let commentId: String
 }
+
+// MARK: - Likes Push / By-User
+
+/// A single track payload sent to POST `/likes/push`.
+struct LikesPushTrack: Codable, Sendable {
+    let trackId: String
+    let addedAt: String?
+    let name: String
+    let artist: String
+    let albumArt: String?
+}
+
+/// Request body for POST `/likes/push`.
+struct LikesPushRequest: Codable, Sendable {
+    let email: String
+    let total: Int
+    let tracks: [LikesPushTrack]
+}
+
+/// Response from POST `/likes/push`.
+struct LikesPushResponse: Codable, Sendable {
+    let success: Bool?
+    let deduped: Bool?
+    let count: Int?
+}
+
+/// A single track row returned by GET `/likes/by-user`.
+struct LikesByUserTrack: Codable, Sendable, Identifiable, Hashable {
+    let trackId: String
+    let trackName: String?
+    let artistName: String?
+    let albumArt: String?
+    let addedAt: String?
+
+    var id: String { trackId }
+
+    var albumArtURL: URL? {
+        guard let s = albumArt, !s.isEmpty else { return nil }
+        return URL(string: s)
+    }
+}
+
+/// Response from GET `/likes/by-user`.
+struct LikesByUserResponse: Codable, Sendable {
+    let tracks: [LikesByUserTrack]
+    let total: Int?
+    let hasMore: Bool?
+    let likesPublic: Bool?
+}

--- a/Xomify-iOS/Services/LikesPushCoordinator.swift
+++ b/Xomify-iOS/Services/LikesPushCoordinator.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Pushes the signed-in user's top-200 Spotify saved tracks to the backend
+/// on cold app open. Fire-and-forget — never blocks the UI.
+///
+/// Dedupe: the backend short-circuits if `total` and first-track `addedAt`
+/// are unchanged since the last push, so calling this on every launch is safe.
+///
+/// The push fires once per app process lifetime (tracked via `hasFiredThisSession`).
+/// A concurrent launch won't double-fire because the flag is checked and set
+/// synchronously inside the `Task` before any network I/O begins.
+actor LikesPushCoordinator {
+
+    // MARK: - Singleton
+
+    static let shared = LikesPushCoordinator()
+
+    private init() {}
+
+    // MARK: - State
+
+    private var hasFiredThisSession: Bool = false
+
+    // MARK: - Constants
+
+    private static let maxTracks = 200
+    private static let pageSize  = 50    // Spotify page cap
+
+    // MARK: - Public API
+
+    /// Call from `MainShell.task` (or equivalent cold-open hook) after auth
+    /// resolves. Returns immediately — all I/O runs in a detached task.
+    nonisolated func triggerIfNeeded(
+        spotifyService: SpotifyLikesProviding = SpotifyService.shared,
+        xomifyService: XomifyService = XomifyService.shared
+    ) {
+        Task.detached(priority: .utility) {
+            await self.fire(spotifyService: spotifyService, xomifyService: xomifyService)
+        }
+    }
+
+    // MARK: - Private
+
+    private func fire(
+        spotifyService: SpotifyLikesProviding,
+        xomifyService: XomifyService
+    ) async {
+        // One push per process lifetime.
+        guard !hasFiredThisSession else { return }
+        hasFiredThisSession = true
+
+        do {
+            // Resolve the caller's email via Spotify.
+            let user = try await SpotifyService.shared.getCurrentUser()
+            guard let email = user.email, !email.isEmpty else { return }
+
+            // Fetch the total count first (limit=1 is cheapest).
+            let firstPage = try await spotifyService.getSavedTracks(limit: 1, offset: 0)
+            guard let total = firstPage.total, total > 0 else { return }
+
+            // Paginate up to maxTracks (200), 50 per page → max 4 calls.
+            let pagesToFetch = Int(ceil(Double(min(total, Self.maxTracks)) / Double(Self.pageSize)))
+            var allTracks: [LikesPushTrack] = []
+
+            for page in 0..<pagesToFetch {
+                let offset = page * Self.pageSize
+                let remaining = min(Self.maxTracks, total) - offset
+                guard remaining > 0 else { break }
+                let limit = min(Self.pageSize, remaining)
+
+                let response = try await spotifyService.getSavedTracks(limit: limit, offset: offset)
+                let pushTracks: [LikesPushTrack] = response.items.compactMap { saved -> LikesPushTrack? in
+                    let track = saved.track
+                    guard !track.id.isEmpty else { return nil }
+                    let albumArt = track.album?.images?.first?.url
+                    let artist = track.artists.compactMap { $0.name }.first ?? ""
+                    return LikesPushTrack(
+                        trackId: track.id,
+                        addedAt: saved.addedAt,
+                        name: track.name,
+                        artist: artist,
+                        albumArt: albumArt
+                    )
+                }
+                allTracks.append(contentsOf: pushTracks)
+            }
+
+            guard !allTracks.isEmpty else { return }
+
+            _ = try await xomifyService.pushUserLikes(
+                email: email,
+                total: total,
+                tracks: allTracks
+            )
+
+            print("✅ LikesPushCoordinator: pushed \(allTracks.count) tracks (total: \(total))")
+        } catch {
+            // Non-critical — backend may not yet have the route (infra in progress).
+            print("⚠️ LikesPushCoordinator: push failed — \(error)")
+        }
+    }
+}

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -652,4 +652,53 @@ actor XomifyService {
             "deviceToken": deviceToken
         ])
     }
+
+    // MARK: - Likes
+
+    /// Push the caller's top-200 saved tracks to the backend.
+    /// Verb-disambiguated path: `/likes/push` (POST).
+    @discardableResult
+    func pushUserLikes(email: String, total: Int, tracks: [LikesPushTrack]) async throws -> LikesPushResponse {
+        let trackDicts: [[String: Any]] = tracks.map { t -> [String: Any] in
+            var row: [String: Any] = [
+                "trackId": t.trackId,
+                "name": t.name,
+                "artist": t.artist
+            ]
+            if let addedAt = t.addedAt { row["addedAt"] = addedAt }
+            if let albumArt = t.albumArt { row["albumArt"] = albumArt }
+            return row
+        }
+        let body: [String: Any] = [
+            "email": email,
+            "total": total,
+            "tracks": trackDicts
+        ]
+        return try await network.xomifyPost("/likes/push", body: body)
+    }
+
+    /// Fetch a friend's (or self) liked tracks from the backend.
+    /// Verb-disambiguated path: `/likes/by-user` (GET).
+    func getLikesByUser(
+        email: String,
+        targetEmail: String,
+        limit: Int = 50,
+        offset: Int = 0
+    ) async throws -> LikesByUserResponse {
+        try await network.xomifyGet("/likes/by-user", queryParams: [
+            "email": email,
+            "targetEmail": targetEmail,
+            "limit": String(limit),
+            "offset": String(offset)
+        ])
+    }
+
+    /// Set the caller's `likes_public` flag.
+    @discardableResult
+    func setLikesPublic(email: String, value: Bool) async throws -> SuccessResponse {
+        try await network.xomifyPost("/users/likes-public", body: [
+            "email": email,
+            "value": value
+        ])
+    }
 }

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -116,6 +116,21 @@ protocol XomifyServiceProtocol: Sendable {
         email: String,
         shareId: String
     ) async throws -> ReactionsListResponse
+
+    // MARK: - Likes
+
+    @discardableResult
+    func pushUserLikes(email: String, total: Int, tracks: [LikesPushTrack]) async throws -> LikesPushResponse
+
+    func getLikesByUser(
+        email: String,
+        targetEmail: String,
+        limit: Int,
+        offset: Int
+    ) async throws -> LikesByUserResponse
+
+    @discardableResult
+    func setLikesPublic(email: String, value: Bool) async throws -> SuccessResponse
 }
 
 extension XomifyService: XomifyServiceProtocol {}

--- a/Xomify-iOS/Views/Shell/MainShell.swift
+++ b/Xomify-iOS/Views/Shell/MainShell.swift
@@ -57,6 +57,9 @@ struct MainShell: View {
             // can call `select(.feed)`.
             NotificationsService.shared.navigationStore = navStore
             await fetchAvatar()
+            // Fire-and-forget: push user's saved tracks to the backend once
+            // per cold open so friends can see a Likes count on the profile.
+            LikesPushCoordinator.shared.triggerIfNeeded()
         }
         .onChange(of: navStore.pendingDeepLink) { _, newValue in
             // Feed empty-state CTAs set `pendingDeepLink`; consume on the next

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -209,6 +209,59 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
         if let listReactionsError { throw listReactionsError }
         return listReactionsResponse
     }
+
+    // MARK: - Likes
+
+    struct PushUserLikesCall: Equatable {
+        let email: String
+        let total: Int
+        let trackCount: Int
+    }
+
+    private(set) var pushUserLikesCalls: [PushUserLikesCall] = []
+    var pushUserLikesError: Error?
+
+    func pushUserLikes(email: String, total: Int, tracks: [LikesPushTrack]) async throws -> LikesPushResponse {
+        pushUserLikesCalls.append(PushUserLikesCall(email: email, total: total, trackCount: tracks.count))
+        if let pushUserLikesError { throw pushUserLikesError }
+        return LikesPushResponse(success: true, deduped: false, count: tracks.count)
+    }
+
+    struct GetLikesByUserCall: Equatable {
+        let email: String
+        let targetEmail: String
+        let limit: Int
+        let offset: Int
+    }
+
+    private(set) var getLikesByUserCalls: [GetLikesByUserCall] = []
+    var getLikesByUserResponse: LikesByUserResponse = LikesByUserResponse(tracks: [], total: 0, hasMore: false, likesPublic: true)
+    var getLikesByUserError: Error?
+
+    func getLikesByUser(
+        email: String,
+        targetEmail: String,
+        limit: Int,
+        offset: Int
+    ) async throws -> LikesByUserResponse {
+        getLikesByUserCalls.append(GetLikesByUserCall(email: email, targetEmail: targetEmail, limit: limit, offset: offset))
+        if let getLikesByUserError { throw getLikesByUserError }
+        return getLikesByUserResponse
+    }
+
+    struct SetLikesPublicCall: Equatable {
+        let email: String
+        let value: Bool
+    }
+
+    private(set) var setLikesPublicCalls: [SetLikesPublicCall] = []
+    var setLikesPublicError: Error?
+
+    func setLikesPublic(email: String, value: Bool) async throws -> SuccessResponse {
+        setLikesPublicCalls.append(SetLikesPublicCall(email: email, value: value))
+        if let setLikesPublicError { throw setLikesPublicError }
+        return SuccessResponse(success: true)
+    }
 }
 
 // MARK: - SpotifyCurrentUserProviding mock


### PR DESCRIPTION
## Summary

- Adds `LikesPushResponse`, `LikesByUserResponse`, `LikesPushTrack`, `LikesPushRequest`, `LikesByUserTrack` Codables to `SocialModels.swift`
- Adds `pushUserLikes`, `getLikesByUser`, `setLikesPublic` to `XomifyService` (verb-disambiguated paths: `/likes/push`, `/likes/by-user`, `/users/likes-public`)
- Extends `XomifyServiceProtocol` with the three new methods; updates `MockXomifyServiceProtocol` with recording stubs
- Adds `LikesPushCoordinator` (actor) — paginates `/me/tracks` up to 200 tracks and calls `pushUserLikes` once per process lifetime, fire-and-forget
- Hooks the coordinator into `MainShell.task` after `fetchAvatar()` resolves — non-blocking, never stalls UI

## Notes

- New endpoints will 404 until `xomify-infrastructure` ships API GW routes (provisioning in parallel — errors are caught and printed, not thrown to UI)
- Version bumped to 1.13.0

## Test plan

- [ ] Build succeeds on iPhone 17 Simulator
- [ ] Cold-open log shows `LikesPushCoordinator: pushed N tracks` after auth resolves
- [ ] `MockXomifyServiceProtocol.pushUserLikesCalls` records correctly in unit tests

Part of social-library-likes plan — Phase 5 of 7.