### PR TITLE
feat: Phase 6 — likesCount on FriendProfile, un-gate Likes chip

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13.0;
+				MARKETING_VERSION = 1.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -606,6 +606,11 @@ struct FriendProfile: Codable, Sendable {
     /// `ios-profile-redesign-contract.md` adds this in a follow-up; until it
     /// ships, header falls back to 3 stats instead of 4.
     let shareCount: Int?
+    /// Cached liked-songs count. Present only when `likes_public == true` or
+    /// caller is the profile owner (backend PR #172). Nil → chip hides.
+    let likesCount: Int?
+    /// ISO8601 timestamp of the last successful likes push. Internal use only.
+    let likesUpdatedAt: String?
     let topSongs: [String: JSONValue]?
     let topArtists: [String: JSONValue]?
     let topGenres: [String: JSONValue]?

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -255,6 +255,7 @@ final class UserProfileViewModel {
         followersCount = profile.followersCount
         followingCount = profile.followingCount
         friendCount = profile.friendsCount
+        likesCount = profile.likesCount
     }
 }
 

--- a/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
+++ b/Xomify-iOS/Views/Profile/ProfileHeaderView.swift
@@ -126,8 +126,12 @@ struct ProfileHeaderView: View {
                     color: .xomifyGreen,
                     destination: .feed
                 )
-                // Likes chip — self-only, hidden on friend profiles.
-                if viewModel.context.isSelf, let likesCount = viewModel.likesCount {
+                // Likes chip — shown for self and friends when likesCount is
+                // present. Backend omits likesCount when likes_public=false
+                // (or when the backend hasn't synced yet), so nil auto-hides.
+                // Phase 7 wires the friend-scoped destination; for now both
+                // contexts route to .likes (self-scoped as a placeholder).
+                if let likesCount = viewModel.likesCount {
                     divider
                     statItem(
                         value: likesCount,

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -46,7 +46,7 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     var getFriendProfileResponse: FriendProfile = FriendProfile(
         email: nil, displayName: nil, userId: nil, avatar: nil,
         followersCount: nil, followingCount: nil, playlistCount: nil,
-        friendsCount: nil, shareCount: nil,
+        friendsCount: nil, shareCount: nil, likesCount: nil, likesUpdatedAt: nil,
         topSongs: nil, topArtists: nil, topGenres: nil, playlists: nil
     )
     var getFriendProfileError: Error?


### PR DESCRIPTION
## Summary

- Adds `likesCount: Int?` and `likesUpdatedAt: String?` to `FriendProfile` in `SocialModels.swift`
- In `UserProfileViewModel.loadOtherHeader`: sets `likesCount = profile.likesCount` after the existing header field assignments
- In `ProfileHeaderView` at the stats row: removes the `viewModel.context.isSelf` gate — chip now renders for both `.me` and `.other` when `likesCount != nil`
- Chip auto-hides when `likesCount` is nil (backend omits the field when `likes_public = false` or no sync has happened yet — backwards compatible)
- Updates `MockXomifyServiceProtocol.getFriendProfileResponse` to include `likesCount: nil, likesUpdatedAt: nil`

## Notes

- Phase 7 wires the chip tap on `.other` to the friend-scoped `LikesView`. For this PR both contexts route to `.likes` as a placeholder.
- Version bumped to 1.14.0

## Test plan

- [ ] Build succeeds on iPhone 17 Simulator
- [ ] Self profile: Likes chip shows with count from Spotify `/me/tracks`
- [ ] Friend profile: Likes chip shows when `FriendProfile.likesCount != nil`; hidden when nil

Part of social-library-likes plan — Phase 6 of 7.