### PR TITLE
(1k) Drop caller-email from URLs/bodies — caller now in JWT context

### DIFF
--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -265,9 +265,10 @@ final class AuthService: NSObject, Sendable {
         request.setValue("Bearer \(xomifyApiToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        // Caller identity (email + userId) is now read from the JWT context
+        // server-side per sub-feature (1i). Body carries only the mutable
+        // profile fields the backend persists.
         let body: [String: Any] = [
-            "email": userProfile.email,
-            "userId": userProfile.id,
             "displayName": userProfile.displayName ?? userProfile.email,
             "refreshToken": refresh,
             "avatar": userProfile.images?.first?.url ?? ""

--- a/Xomify-iOS/Services/NotificationsService.swift
+++ b/Xomify-iOS/Services/NotificationsService.swift
@@ -108,6 +108,11 @@ final class NotificationsService: NSObject {
 
     /// Called from `XomifyAppDelegate.didRegisterForRemoteNotificationsWithDeviceToken`.
     /// Hex-encodes the raw token, caches it, and upserts to the backend.
+    ///
+    /// Caller identity is read from the JWT context server-side
+    /// (sub-feature 1f). We still gate on a resolvable Spotify email so we
+    /// don't register a device against an empty session, and we still cache
+    /// it so `unregister()` can run after the session has been torn down.
     func handleDeviceToken(_ data: Data) async {
         let hex = Self.hexString(from: data)
         defaults.set(hex, forKey: Self.cachedTokenKey)
@@ -125,7 +130,6 @@ final class NotificationsService: NSObject {
         for attempt in 1...2 {
             do {
                 _ = try await xomify.registerPushToken(
-                    email: email,
                     deviceToken: hex,
                     queueNotificationsEnabled: queueEnabled,
                     digestEnabled: digestEnabled
@@ -147,26 +151,23 @@ final class NotificationsService: NSObject {
 
     /// Flipped by `SettingsViewModel` when the user toggles either switch.
     /// Re-POSTs to `/notifications/register` as an upsert using the cached token.
+    ///
+    /// Caller identity is taken from the JWT context server-side
+    /// (sub-feature 1f); this method only sends the token + preference flags.
+    /// We still gate on having a session anchor (cached email or current
+    /// Spotify user) to avoid issuing register requests for signed-out users.
     func updatePreferences(queueNotificationsEnabled: Bool, digestEnabled: Bool) async {
         guard let hex = defaults.string(forKey: Self.cachedTokenKey) else {
             // No token yet — next `handleDeviceToken` call will pick up the
             // latest flags from UserDefaults and POST them.
             return
         }
-        // Prefer the cached email (written on first successful register) so
-        // this call path stays independent of the Spotify session.
-        let email: String
-        if let cached = defaults.string(forKey: Self.cachedEmailKey), !cached.isEmpty {
-            email = cached
-        } else if let fetched = await currentUserEmail() {
-            email = fetched
-        } else {
-            return
-        }
+        let hasCachedEmail = defaults.string(forKey: Self.cachedEmailKey)?.isEmpty == false
+        let hasCurrentSpotifyEmail = await currentUserEmail() != nil
+        guard hasCachedEmail || hasCurrentSpotifyEmail else { return }
 
         do {
             _ = try await xomify.registerPushToken(
-                email: email,
                 deviceToken: hex,
                 queueNotificationsEnabled: queueNotificationsEnabled,
                 digestEnabled: digestEnabled
@@ -179,8 +180,11 @@ final class NotificationsService: NSObject {
     /// Called on sign-out. Swallows errors — the user is leaving anyway, and a
     /// stale backend token expires on the next failed send (APNs 410).
     ///
-    /// Uses the cached email (written after the first successful register) so
-    /// this works even after the Spotify access token has been cleared.
+    /// Caller identity is read from the JWT context server-side
+    /// (sub-feature 1f); we only send the device token. The cached email is
+    /// still consulted as a session anchor — when present we still had a
+    /// signed-in user to whom this token belonged. This call must run before
+    /// the JWT is cleared.
     func unregister() async {
         let hex = defaults.string(forKey: Self.cachedTokenKey)
         let cachedEmail = defaults.string(forKey: Self.cachedEmailKey)
@@ -194,7 +198,7 @@ final class NotificationsService: NSObject {
         guard let hex, let cachedEmail, !cachedEmail.isEmpty else { return }
 
         do {
-            _ = try await xomify.unregisterPushToken(email: cachedEmail, deviceToken: hex)
+            _ = try await xomify.unregisterPushToken(deviceToken: hex)
         } catch {
             print("ℹ️ Notifications: unregister failed (swallowed) — \(error.localizedDescription)")
         }

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -1,69 +1,73 @@
 import Foundation
 
 /// Service for Xomify backend API calls
+///
+/// Caller identity is sourced from the per-user JWT in the Authorization
+/// header (sub-feature 0d). Backend handlers extract `email` + `userId` from
+/// the API Gateway authorizer context (sub-features 1a–1i). Methods here
+/// therefore no longer take or transmit the caller's email — only target
+/// identifiers (`friendEmail`, `requestEmail`, `targetEmail`,
+/// `memberEmail`, `groupId`, `shareId`, `inviteCode`, `trackId`, etc.) ride
+/// the wire.
 actor XomifyService {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = XomifyService()
-    
+
     private let network = NetworkService.shared
-    
+
     private init() {}
-    
+
     // MARK: - User / Enrollment
-    
+
     /// Get user enrollment status and wraps
-    func getUserData(email: String) async throws -> WrappedDataResponse {
-        try await network.xomifyGet("/wrapped/all", queryParams: ["email": email])
+    func getUserData() async throws -> WrappedDataResponse {
+        try await network.xomifyGet("/wrapped/all")
     }
 
     /// Get user table data
-    func getUserTableData(email: String) async throws -> XomifyUser {
-        try await network.xomifyGet("/user/data", queryParams: ["email": email])
+    func getUserTableData() async throws -> XomifyUser {
+        try await network.xomifyGet("/user/data")
     }
 
     /// Enroll or update user enrollments
     func updateEnrollments(
-        email: String,
         activeWrapped: Bool,
         activeReleaseRadar: Bool
     ) async throws {
         let _: EmptyResponse = try await network.xomifyPost("/user/update", body: [
-            "email": email,
             "wrappedEnrolled": activeWrapped,
             "releaseRadarEnrolled": activeReleaseRadar
         ])
     }
-    
+
     // MARK: - Release Radar
-    
+
     /// Get release radar history (past weeks)
-    func getReleaseRadarHistory(email: String, limit: Int = 12) async throws -> ReleaseRadarHistoryResponse {
+    func getReleaseRadarHistory(limit: Int = 12) async throws -> ReleaseRadarHistoryResponse {
         try await network.xomifyGet("/release-radar/history", queryParams: [
-            "email": email,
             "limit": String(limit)
         ])
     }
-    
+
     /// Check release radar status
-    func checkReleaseRadar(email: String) async throws -> ReleaseRadarCheckResponse {
-        try await network.xomifyGet("/release-radar/check", queryParams: ["email": email])
+    func checkReleaseRadar() async throws -> ReleaseRadarCheckResponse {
+        try await network.xomifyGet("/release-radar/check")
     }
-    
-    
+
+
     // MARK: - Wrapped
-    
+
     /// Get all wraps
-    func getWraps(email: String) async throws -> [MonthlyWrap] {
-        let response: WrappedDataResponse = try await network.xomifyGet("/wrapped/all", queryParams: ["email": email])
+    func getWraps() async throws -> [MonthlyWrap] {
+        let response: WrappedDataResponse = try await network.xomifyGet("/wrapped/all")
         return response.wraps ?? []
     }
-    
+
     /// Get specific wrap by month
-    func getWrap(email: String, monthKey: String) async throws -> MonthlyWrap {
+    func getWrap(monthKey: String) async throws -> MonthlyWrap {
         try await network.xomifyGet("/wrapped/month", queryParams: [
-            "email": email,
             "monthKey": monthKey
         ])
     }
@@ -81,7 +85,6 @@ actor XomifyService {
     /// Backend rejects `public=false` with empty `groupIds`.
     @discardableResult
     func createShare(
-        email: String,
         trackId: String,
         trackUri: String,
         trackName: String,
@@ -95,7 +98,6 @@ actor XomifyService {
         isPublic: Bool? = nil
     ) async throws -> ShareCreateResponse {
         var body: [String: Any] = [
-            "email": email,
             "trackId": trackId,
             "trackUri": trackUri,
             "trackName": trackName,
@@ -112,16 +114,14 @@ actor XomifyService {
         return try await network.xomifyPost("/shares/create", body: body)
     }
 
-    /// Fetch the social feed for a user. Supports optional group scoping and
+    /// Fetch the social feed for the caller. Supports optional group scoping and
     /// keyset pagination via `before` (the `sharedAt` of the last received share).
     func getFeed(
-        email: String,
         groupId: String? = nil,
         limit: Int = 50,
         before: String? = nil
     ) async throws -> FeedResponse {
         var params: [String: String] = [
-            "email": email,
             "limit": String(limit)
         ]
         if let groupId = groupId { params["groupId"] = groupId }
@@ -129,20 +129,17 @@ actor XomifyService {
         return try await network.xomifyGet("/shares/feed", queryParams: params)
     }
 
-    /// Fetch shares authored by a specific user. Both `email` (the caller) and
-    /// `targetEmail` (the author) are required — backend keeps the caller for
-    /// future friendship gating and enrichment.
+    /// Fetch shares authored by a specific user (`targetEmail`). Caller
+    /// identity is read from the JWT context server-side.
     ///
     /// Response shape is identical to `/shares/feed` — reuse `FeedResponse`.
     /// `nextBefore` is the pagination cursor (ISO8601 `createdAt`).
     func getSharesByUser(
-        email: String,
         targetEmail: String,
         limit: Int = 50,
         before: String? = nil
     ) async throws -> FeedResponse {
         var params: [String: String] = [
-            "email": email,
             "targetEmail": targetEmail,
             "limit": String(limit)
         ]
@@ -157,13 +154,11 @@ actor XomifyService {
     /// Endpoint is query-param only; backend accepts `sharedBy` / `sharedAt`
     /// for forward-compat but ignores them today.
     func getShareDetail(
-        email: String,
         shareId: String,
         sharedBy: String? = nil,
         sharedAt: String? = nil
     ) async throws -> ShareDetailResponse {
         var params: [String: String] = [
-            "email": email,
             "shareId": shareId
         ]
         if let sharedBy = sharedBy { params["sharedBy"] = sharedBy }
@@ -174,12 +169,10 @@ actor XomifyService {
     /// Delete a share (author only). Backend expects composite key via body.
     @discardableResult
     func deleteShare(
-        email: String,
         shareId: String,
         sharedAt: String
     ) async throws -> SuccessResponse {
         try await network.xomifyPost("/shares/delete", body: [
-            "email": email,
             "shareId": shareId,
             "sharedAt": sharedAt
         ])
@@ -192,14 +185,12 @@ actor XomifyService {
     @discardableResult
     func interactWithShare(
         shareId: String,
-        email: String,
         sharedAt: String,
         interaction: String,
         rating: Int? = nil
     ) async throws -> ShareInteractionResponse {
         var body: [String: Any] = [
             "shareId": shareId,
-            "email": email,
             "sharedAt": sharedAt,
             "interaction": interaction
         ]
@@ -213,27 +204,24 @@ actor XomifyService {
     @discardableResult
     func reactToShare(
         shareId: String,
-        email: String,
         sharedAt: String,
         reaction: String
     ) async throws -> ReactionResponse {
         try await network.xomifyPost("/shares/react", body: [
             "shareId": shareId,
-            "email": email,
             "sharedAt": sharedAt,
             "reaction": reaction
         ])
     }
 
     /// Create a friend invite code
-    func createInvite(email: String) async throws -> InviteCreateResponse {
-        try await network.xomifyPost("/invites/create", body: ["email": email])
+    func createInvite() async throws -> InviteCreateResponse {
+        try await network.xomifyPost("/invites/create", body: [:])
     }
 
     /// Accept a friend invite code
-    func acceptInvite(email: String, inviteCode: String) async throws -> InviteAcceptResponse {
+    func acceptInvite(inviteCode: String) async throws -> InviteAcceptResponse {
         try await network.xomifyPost("/invites/accept", body: [
-            "email": email,
             "inviteCode": inviteCode
         ])
     }
@@ -242,89 +230,80 @@ actor XomifyService {
     /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
     /// Until the backend ships, this will raise a server error; the UI renders
     /// an empty state against that failure.
-    func listPendingInvites(email: String) async throws -> PendingInvitesResponse {
-        try await network.xomifyGet("/invites/pending", queryParams: ["email": email])
+    func listPendingInvites() async throws -> PendingInvitesResponse {
+        try await network.xomifyGet("/invites/pending")
     }
 
     /// Decline a deep-link invite.
     /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
     @discardableResult
-    func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse {
+    func declineInvite(inviteCode: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/invites/decline", body: [
-            "email": email,
             "inviteCode": inviteCode
         ])
     }
 
     // MARK: - Friends
 
-    /// Send a friend request.
+    /// Send a friend request to `requestEmail`.
     @discardableResult
-    func requestFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+    func requestFriend(requestEmail: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/friends/request", body: [
-            "email": email,
             "requestEmail": requestEmail
         ])
     }
 
-    /// Accept an incoming friend request.
+    /// Accept an incoming friend request from `requestEmail`.
     @discardableResult
-    func acceptFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+    func acceptFriend(requestEmail: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/friends/accept", body: [
-            "email": email,
             "requestEmail": requestEmail
         ])
     }
 
     /// Reject an incoming friend request (or cancel an outgoing one).
     @discardableResult
-    func rejectFriend(email: String, requestEmail: String) async throws -> SuccessResponse {
+    func rejectFriend(requestEmail: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/friends/reject", body: [
-            "email": email,
             "requestEmail": requestEmail
         ])
     }
 
     /// Remove an accepted friend.
     @discardableResult
-    func removeFriend(email: String, friendEmail: String) async throws -> SuccessResponse {
+    func removeFriend(friendEmail: String) async throws -> SuccessResponse {
         // Backend expects DELETE with body; use POST-style body via helper that
         // targets DELETE via a query-param workaround -- the simplest reliable
         // shape is POST to /friends/remove. If the lambda strictly requires
         // DELETE, swap to an http DELETE helper later.
         try await network.xomifyPost("/friends/remove", body: [
-            "email": email,
             "friendEmail": friendEmail
         ])
     }
 
     /// Bucketed list of friends (accepted / requested / pending / blocked).
-    /// Hits `/friends/list?email=` — the real user-scoped endpoint.
+    /// Hits `/friends/list` — backend resolves the caller from JWT context.
     /// `/friends/all` is a full-table scan helper and must not be used here.
-    func getAllFriends(email: String) async throws -> FriendsAllResponse {
-        try await network.xomifyGet("/friends/list", queryParams: ["email": email])
+    func getAllFriends() async throws -> FriendsAllResponse {
+        try await network.xomifyGet("/friends/list")
     }
 
     /// Discovery list: every other user on the platform. `/user/all` returns a
-    /// bare JSON array; the backend filters self out server-side when `email`
-    /// is passed.
-    func listUsers(email: String) async throws -> UserListResponse {
-        let users: [SearchResult] = try await network.xomifyGet(
-            "/user/all",
-            queryParams: ["email": email]
-        )
+    /// bare JSON array; the backend filters self out server-side using the
+    /// caller email from the JWT context.
+    func listUsers() async throws -> UserListResponse {
+        let users: [SearchResult] = try await network.xomifyGet("/user/all")
         return UserListResponse(users: users, totalCount: users.count)
     }
 
     /// Incoming friend requests only (subset of /friends/all).
-    func getPendingFriends(email: String) async throws -> FriendsAllResponse {
-        try await network.xomifyGet("/friends/pending", queryParams: ["email": email])
+    func getPendingFriends() async throws -> FriendsAllResponse {
+        try await network.xomifyGet("/friends/pending")
     }
 
     /// Public profile of another user. Backend expects `friendEmail` and
-    /// resolves the caller from the auth header — previous shape
-    /// (`email` + `profileEmail`) returns 400.
-    func getFriendProfile(email: String, profileEmail: String) async throws -> FriendProfile {
+    /// resolves the caller from the JWT context.
+    func getFriendProfile(profileEmail: String) async throws -> FriendProfile {
         try await network.xomifyGet("/friends/profile", queryParams: [
             "friendEmail": profileEmail
         ])
@@ -333,8 +312,8 @@ actor XomifyService {
     // MARK: - Groups
 
     /// Create a group. Description is optional.
-    func createGroup(email: String, name: String, description: String? = nil) async throws -> GroupCreateResponse {
-        var body: [String: Any] = ["email": email, "name": name]
+    func createGroup(name: String, description: String? = nil) async throws -> GroupCreateResponse {
+        var body: [String: Any] = ["name": name]
         if let description = description, !description.isEmpty {
             body["description"] = description
         }
@@ -345,8 +324,8 @@ actor XomifyService {
     /// /groups/update` — sending POST here would be rejected by API Gateway
     /// before reaching the lambda.
     @discardableResult
-    func updateGroup(email: String, groupId: String, name: String? = nil, description: String? = nil) async throws -> SuccessResponse {
-        var body: [String: Any] = ["email": email, "groupId": groupId]
+    func updateGroup(groupId: String, name: String? = nil, description: String? = nil) async throws -> SuccessResponse {
+        var body: [String: Any] = ["groupId": groupId]
         if let name = name { body["name"] = name }
         if let description = description { body["description"] = description }
         return try await network.xomifyPut("/groups/update", body: body)
@@ -355,27 +334,24 @@ actor XomifyService {
     /// Delete a group (owner only). Backend route is `DELETE
     /// /groups/remove` and reads identifiers from query params (not body).
     @discardableResult
-    func removeGroup(email: String, groupId: String) async throws -> SuccessResponse {
+    func removeGroup(groupId: String) async throws -> SuccessResponse {
         try await network.xomifyDelete("/groups/remove", queryParams: [
-            "email": email,
             "groupId": groupId
         ])
     }
 
     /// Leave a group.
     @discardableResult
-    func leaveGroup(email: String, groupId: String) async throws -> SuccessResponse {
+    func leaveGroup(groupId: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/groups/leave", body: [
-            "email": email,
             "groupId": groupId
         ])
     }
 
     /// Add a member to a group.
     @discardableResult
-    func addMember(email: String, groupId: String, memberEmail: String) async throws -> SuccessResponse {
+    func addMember(groupId: String, memberEmail: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/groups/add-member", body: [
-            "email": email,
             "groupId": groupId,
             "memberEmail": memberEmail
         ])
@@ -384,30 +360,26 @@ actor XomifyService {
     /// Remove a member from a group. Backend is `DELETE
     /// /groups/remove-member` with query params.
     @discardableResult
-    func removeMember(email: String, groupId: String, memberEmail: String) async throws -> SuccessResponse {
+    func removeMember(groupId: String, memberEmail: String) async throws -> SuccessResponse {
         try await network.xomifyDelete("/groups/remove-member", queryParams: [
-            "email": email,
             "groupId": groupId,
             "memberEmail": memberEmail
         ])
     }
 
-    /// Groups the user belongs to.
-    func listGroups(email: String) async throws -> GroupsListResponse {
-        try await network.xomifyGet("/groups/list", queryParams: ["email": email])
+    /// Groups the caller belongs to.
+    func listGroups() async throws -> GroupsListResponse {
+        try await network.xomifyGet("/groups/list")
     }
 
     /// Group detail — members + tracks.
-    func getGroupInfo(groupId: String, email: String? = nil) async throws -> GroupInfo {
-        var params: [String: String] = ["groupId": groupId]
-        if let email = email { params["email"] = email }
-        return try await network.xomifyGet("/groups/info", queryParams: params)
+    func getGroupInfo(groupId: String) async throws -> GroupInfo {
+        try await network.xomifyGet("/groups/info", queryParams: ["groupId": groupId])
     }
 
     /// Add a track to a group.
     @discardableResult
     func addSong(
-        email: String,
         groupId: String,
         trackId: String,
         trackName: String,
@@ -416,7 +388,6 @@ actor XomifyService {
         imageUrl: String? = nil
     ) async throws -> SuccessResponse {
         var body: [String: Any] = [
-            "email": email,
             "groupId": groupId,
             "trackId": trackId,
             "trackName": trackName,
@@ -429,9 +400,8 @@ actor XomifyService {
 
     /// Add a track to a group by pasting a Spotify URL (backend parses it).
     @discardableResult
-    func addSongByUrl(email: String, groupId: String, trackUrl: String) async throws -> SuccessResponse {
+    func addSongByUrl(groupId: String, trackUrl: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/groups/add-song-url", body: [
-            "email": email,
             "groupId": groupId,
             "trackUrl": trackUrl
         ])
@@ -441,28 +411,25 @@ actor XomifyService {
     /// /groups/remove-song` and reads `songId` (not `trackIdTimestamp`)
     /// from query params.
     @discardableResult
-    func removeSong(email: String, groupId: String, trackIdTimestamp: String) async throws -> SuccessResponse {
+    func removeSong(groupId: String, trackIdTimestamp: String) async throws -> SuccessResponse {
         try await network.xomifyDelete("/groups/remove-song", queryParams: [
-            "email": email,
             "groupId": groupId,
             "songId": trackIdTimestamp
         ])
     }
 
-    /// Check my listen-status for a single group track.
-    func getSongStatus(email: String, groupId: String, trackIdTimestamp: String) async throws -> SongStatusResponse {
+    /// Check the caller's listen-status for a single group track.
+    func getSongStatus(groupId: String, trackIdTimestamp: String) async throws -> SongStatusResponse {
         try await network.xomifyGet("/groups/song-status", queryParams: [
-            "email": email,
             "groupId": groupId,
             "trackIdTimestamp": trackIdTimestamp
         ])
     }
 
-    /// Mark every track in the group as listened by me.
+    /// Mark every track in the group as listened by the caller.
     @discardableResult
-    func markAllListened(email: String, groupId: String) async throws -> SuccessResponse {
+    func markAllListened(groupId: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/groups/mark-all-listened", body: [
-            "email": email,
             "groupId": groupId
         ])
     }
@@ -480,12 +447,10 @@ actor XomifyService {
     /// row so the UI can render it without a follow-up fetch.
     @discardableResult
     func createComment(
-        email: String,
         shareId: String,
         body: String
     ) async throws -> ShareComment {
         try await network.xomifyPost("/shares/comments-create", body: [
-            "email": email,
             "shareId": shareId,
             "body": body
         ])
@@ -495,13 +460,11 @@ actor XomifyService {
     /// is the `createdAt` cursor from the previous page; nil for the first
     /// page. `limit` is capped at 100 server-side.
     func listComments(
-        email: String,
         shareId: String,
         limit: Int = 20,
         before: String? = nil
     ) async throws -> CommentsListResponse {
         var params: [String: String] = [
-            "email": email,
             "shareId": shareId,
             "limit": String(limit)
         ]
@@ -513,12 +476,10 @@ actor XomifyService {
     /// share author to delete; everyone else gets 403.
     @discardableResult
     func deleteComment(
-        email: String,
         shareId: String,
         commentId: String
     ) async throws -> CommentDeleteResponse {
         try await network.xomifyDelete("/shares/comments-delete", body: [
-            "email": email,
             "shareId": shareId,
             "commentId": commentId
         ])
@@ -533,12 +494,10 @@ actor XomifyService {
     /// otherwise added. Multiple slugs per viewer per share is allowed.
     @discardableResult
     func toggleReaction(
-        email: String,
         shareId: String,
         reaction: ShareReaction
     ) async throws -> ReactionToggleResponse {
         try await network.xomifyPost("/shares/reactions-toggle", body: [
-            "email": email,
             "shareId": shareId,
             "reaction": reaction.rawValue
         ])
@@ -546,11 +505,9 @@ actor XomifyService {
 
     /// Read-only fetch of the full reaction summary for a share.
     func listReactions(
-        email: String,
         shareId: String
     ) async throws -> ReactionsListResponse {
         try await network.xomifyGet("/shares/reactions-list", queryParams: [
-            "email": email,
             "shareId": shareId
         ])
     }
@@ -563,7 +520,6 @@ actor XomifyService {
     /// rate surfaces, hand in `track.imageUrl?.absoluteString`.
     @discardableResult
     func publishRating(
-        email: String,
         trackId: String,
         trackName: String,
         artistName: String,
@@ -572,7 +528,6 @@ actor XomifyService {
         review: String? = nil
     ) async throws -> SuccessResponse {
         var body: [String: Any] = [
-            "email": email,
             "trackId": trackId,
             "trackName": trackName,
             "artistName": artistName,
@@ -587,29 +542,27 @@ actor XomifyService {
 
     /// Delete a rating.
     @discardableResult
-    func removeRating(email: String, trackId: String) async throws -> SuccessResponse {
+    func removeRating(trackId: String) async throws -> SuccessResponse {
         try await network.xomifyPost("/ratings/remove", body: [
-            "email": email,
             "trackId": trackId
         ])
     }
 
-    /// All ratings the user has posted.
-    func getAllRatings(email: String) async throws -> RatingsAllResponse {
+    /// All ratings the caller has posted.
+    func getAllRatings() async throws -> RatingsAllResponse {
         // Try dict shape first; fall back to bare array.
         do {
-            return try await network.xomifyGet("/ratings/all", queryParams: ["email": email])
+            return try await network.xomifyGet("/ratings/all")
         } catch {
-            let ratings: [TrackRating] = try await network.xomifyGet("/ratings/all", queryParams: ["email": email])
-            return RatingsAllResponse(email: email, ratings: ratings, totalCount: ratings.count)
+            let ratings: [TrackRating] = try await network.xomifyGet("/ratings/all")
+            return RatingsAllResponse(email: nil, ratings: ratings, totalCount: ratings.count)
         }
     }
 
     /// A single track's rating (or nil).
-    func getTrackRating(email: String, trackId: String) async throws -> TrackRating? {
+    func getTrackRating(trackId: String) async throws -> TrackRating? {
         do {
             let rating: TrackRating = try await network.xomifyGet("/ratings/track", queryParams: [
-                "email": email,
                 "trackId": trackId
             ])
             return rating
@@ -622,33 +575,30 @@ actor XomifyService {
     //
     // Thin wrappers over the deployed `notifications_register` /
     // `notifications_unregister` lambdas. Body shape is camelCase and matches
-    // the Python handlers exactly.
+    // the Python handlers exactly. Caller identity is read from the JWT
+    // context server-side.
 
-    /// Upsert the user's APNs device token + push preferences. Idempotent —
+    /// Upsert the caller's APNs device token + push preferences. Idempotent —
     /// safe to call on every cold launch when the APNs token refreshes.
     @discardableResult
     func registerPushToken(
-        email: String,
         deviceToken: String,
         queueNotificationsEnabled: Bool,
         digestEnabled: Bool
     ) async throws -> SuccessResponse {
         try await network.xomifyPost("/notifications/register", body: [
-            "email": email,
             "deviceToken": deviceToken,
             "queueNotificationsEnabled": queueNotificationsEnabled,
             "digestEnabled": digestEnabled
         ])
     }
 
-    /// Delete the user's APNs device token from the backend. Called on sign-out.
+    /// Delete the caller's APNs device token from the backend. Called on sign-out.
     @discardableResult
     func unregisterPushToken(
-        email: String,
         deviceToken: String
     ) async throws -> SuccessResponse {
         try await network.xomifyPost("/notifications/unregister", body: [
-            "email": email,
             "deviceToken": deviceToken
         ])
     }

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -6,12 +6,14 @@ import Foundation
 ///
 /// `XomifyService` (the concrete actor singleton) conforms via the extension
 /// at the bottom of this file.
+///
+/// Caller identity rides the per-user JWT (sub-feature 0d) and is resolved
+/// server-side (1a–1i). Methods here only carry target identifiers.
 protocol XomifyServiceProtocol: Sendable {
 
     // MARK: - Shares
 
     func createShare(
-        email: String,
         trackId: String,
         trackUri: String,
         trackName: String,
@@ -26,27 +28,23 @@ protocol XomifyServiceProtocol: Sendable {
     ) async throws -> ShareCreateResponse
 
     func getFeed(
-        email: String,
         groupId: String?,
         limit: Int,
         before: String?
     ) async throws -> FeedResponse
 
     func getSharesByUser(
-        email: String,
         targetEmail: String,
         limit: Int,
         before: String?
     ) async throws -> FeedResponse
 
     func deleteShare(
-        email: String,
         shareId: String,
         sharedAt: String
     ) async throws -> SuccessResponse
 
     func getShareDetail(
-        email: String,
         shareId: String,
         sharedBy: String?,
         sharedAt: String?
@@ -55,18 +53,16 @@ protocol XomifyServiceProtocol: Sendable {
     // MARK: - Friend profile (used by UserProfileViewModel)
 
     func getFriendProfile(
-        email: String,
         profileEmail: String
     ) async throws -> FriendProfile
 
     // MARK: - Groups (for filter chips)
 
-    func listGroups(email: String) async throws -> GroupsListResponse
+    func listGroups() async throws -> GroupsListResponse
 
     // MARK: - Ratings (used by ShareCardViewModel)
 
     func publishRating(
-        email: String,
         trackId: String,
         trackName: String,
         artistName: String,
@@ -79,41 +75,36 @@ protocol XomifyServiceProtocol: Sendable {
 
     /// All ratings authored by the caller. Used by the self-profile header to
     /// populate the Ratings stat without a dedicated counts endpoint.
-    func getAllRatings(email: String) async throws -> RatingsAllResponse
+    func getAllRatings() async throws -> RatingsAllResponse
 
     /// Full friends payload for the caller. Used by the self-profile header
     /// (friend count) and the Friends drawer.
-    func getAllFriends(email: String) async throws -> FriendsAllResponse
+    func getAllFriends() async throws -> FriendsAllResponse
 
     // MARK: - Comments + Reactions (xomify-backend#139)
 
     func createComment(
-        email: String,
         shareId: String,
         body: String
     ) async throws -> ShareComment
 
     func listComments(
-        email: String,
         shareId: String,
         limit: Int,
         before: String?
     ) async throws -> CommentsListResponse
 
     func deleteComment(
-        email: String,
         shareId: String,
         commentId: String
     ) async throws -> CommentDeleteResponse
 
     func toggleReaction(
-        email: String,
         shareId: String,
         reaction: ShareReaction
     ) async throws -> ReactionToggleResponse
 
     func listReactions(
-        email: String,
         shareId: String
     ) async throws -> ReactionsListResponse
 }

--- a/Xomify-iOS/Services/XomifyServicing.swift
+++ b/Xomify-iOS/Services/XomifyServicing.swift
@@ -6,47 +6,49 @@ import Foundation
 ///
 /// Only the operations exercised by Friends / Invites flows are included here —
 /// keep this surface tight and expand incrementally as other screens adopt it.
+///
+/// Caller identity rides the per-user JWT (sub-feature 0d) and is resolved
+/// server-side (1a–1i). Methods here only carry target identifiers.
 protocol XomifyServicing: Sendable {
 
     // MARK: - Friends
 
-    func getAllFriends(email: String) async throws -> FriendsAllResponse
-    func listUsers(email: String) async throws -> UserListResponse
+    func getAllFriends() async throws -> FriendsAllResponse
+    func listUsers() async throws -> UserListResponse
 
     @discardableResult
-    func requestFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+    func requestFriend(requestEmail: String) async throws -> SuccessResponse
 
     @discardableResult
-    func acceptFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+    func acceptFriend(requestEmail: String) async throws -> SuccessResponse
 
     @discardableResult
-    func rejectFriend(email: String, requestEmail: String) async throws -> SuccessResponse
+    func rejectFriend(requestEmail: String) async throws -> SuccessResponse
 
     @discardableResult
-    func removeFriend(email: String, friendEmail: String) async throws -> SuccessResponse
+    func removeFriend(friendEmail: String) async throws -> SuccessResponse
 
     // MARK: - Invites
 
-    func createInvite(email: String) async throws -> InviteCreateResponse
+    func createInvite() async throws -> InviteCreateResponse
 
-    func acceptInvite(email: String, inviteCode: String) async throws -> InviteAcceptResponse
+    func acceptInvite(inviteCode: String) async throws -> InviteAcceptResponse
 
     /// List deep-link invites sent to this user and awaiting accept/decline.
     /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
-    func listPendingInvites(email: String) async throws -> PendingInvitesResponse
+    func listPendingInvites() async throws -> PendingInvitesResponse
 
     /// Decline a deep-link invite.
     /// TODO: endpoint lands in backend-interactions-and-friends-handlers PR.
     @discardableResult
-    func declineInvite(email: String, inviteCode: String) async throws -> SuccessResponse
+    func declineInvite(inviteCode: String) async throws -> SuccessResponse
 
     // MARK: - Notifications
 
-    /// Upsert an APNs device token + preference flags for the user.
-    /// Idempotent on `(email, deviceToken)` — safe to call on every cold launch.
+    /// Upsert an APNs device token + preference flags for the caller.
+    /// Idempotent on `(caller, deviceToken)` — safe to call on every cold launch.
     @discardableResult
     func registerPushToken(
-        email: String,
         deviceToken: String,
         queueNotificationsEnabled: Bool,
         digestEnabled: Bool
@@ -55,7 +57,6 @@ protocol XomifyServicing: Sendable {
     /// Delete a device token from the backend. Called on sign-out.
     @discardableResult
     func unregisterPushToken(
-        email: String,
         deviceToken: String
     ) async throws -> SuccessResponse
 }

--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -267,7 +267,6 @@ final class FeedViewModel {
 
         do {
             let response = try await xomifyService.getFeed(
-                email: userEmail,
                 groupId: selectedFilter.groupId,
                 limit: FeedCacheService.maxSharesPerFilter,
                 before: nil
@@ -304,7 +303,6 @@ final class FeedViewModel {
 
         do {
             let response = try await xomifyService.getFeed(
-                email: userEmail,
                 groupId: selectedFilter.groupId,
                 limit: FeedCacheService.maxSharesPerFilter,
                 before: before
@@ -342,7 +340,7 @@ final class FeedViewModel {
         guard !userEmail.isEmpty else { return }
 
         do {
-            let response = try await xomifyService.listGroups(email: userEmail)
+            let response = try await xomifyService.listGroups()
             groups = response.groups ?? []
         } catch {
             // Non-fatal — chips just show `Friends` without group rows.
@@ -367,7 +365,7 @@ final class FeedViewModel {
 
         // Friends — `email` on the row is the CALLER's email, `friendEmail`
         // is the other party. Always key by `targetEmail`.
-        if let response = try? await xomifyService.getAllFriends(email: userEmail) {
+        if let response = try? await xomifyService.getAllFriends() {
             for friend in response.accepted ?? [] {
                 let email = friend.targetEmail
                 guard !email.isEmpty else { continue }
@@ -451,7 +449,6 @@ final class FeedViewModel {
 
         do {
             _ = try await xomifyService.deleteShare(
-                email: userEmail,
                 shareId: share.shareId,
                 sharedAt: share.sharedAt
             )

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -123,7 +123,6 @@ final class ShareCardViewModel {
 
         do {
             _ = try await xomifyService.publishRating(
-                email: viewerEmail,
                 trackId: share.trackId,
                 trackName: share.trackName,
                 artistName: share.artistName,
@@ -170,7 +169,6 @@ final class ShareCardViewModel {
 
         do {
             let resp = try await xomifyService.toggleReaction(
-                email: viewerEmail,
                 shareId: share.shareId,
                 reaction: reaction
             )

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -108,7 +108,7 @@ final class ShareComposerViewModel {
             }
         }
         if !userEmail.isEmpty, availableGroups.isEmpty {
-            if let response = try? await xomifyService.listGroups(email: userEmail) {
+            if let response = try? await xomifyService.listGroups() {
                 availableGroups = response.groups ?? []
             }
         }
@@ -258,7 +258,6 @@ final class ShareComposerViewModel {
 
         do {
             let response = try await xomifyService.createShare(
-                email: userEmail,
                 trackId: track.id,
                 trackUri: track.uri ?? "",
                 trackName: track.name,

--- a/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
@@ -79,7 +79,6 @@ final class ShareDetailViewModel {
 
         do {
             let resp = try await xomifyService.getShareDetail(
-                email: viewerEmail,
                 shareId: share.shareId,
                 sharedBy: share.sharedBy,
                 sharedAt: share.sharedAt
@@ -136,7 +135,6 @@ final class ShareDetailViewModel {
 
         do {
             _ = try await xomifyService.publishRating(
-                email: viewerEmail,
                 trackId: share.trackId,
                 trackName: share.trackName,
                 artistName: share.artistName,
@@ -165,7 +163,6 @@ final class ShareDetailViewModel {
 
         do {
             let resp = try await xomifyService.listComments(
-                email: viewerEmail,
                 shareId: share.shareId,
                 limit: 50,
                 before: nil
@@ -191,7 +188,6 @@ final class ShareDetailViewModel {
 
         do {
             let comment = try await xomifyService.createComment(
-                email: viewerEmail,
                 shareId: share.shareId,
                 body: trimmed
             )
@@ -222,7 +218,6 @@ final class ShareDetailViewModel {
 
         do {
             _ = try await xomifyService.deleteComment(
-                email: viewerEmail,
                 shareId: share.shareId,
                 commentId: comment.commentId
             )
@@ -271,7 +266,6 @@ final class ShareDetailViewModel {
 
         do {
             let resp = try await xomifyService.toggleReaction(
-                email: viewerEmail,
                 shareId: share.shareId,
                 reaction: reaction
             )

--- a/Xomify-iOS/ViewModels/FriendsViewModel.swift
+++ b/Xomify-iOS/ViewModels/FriendsViewModel.swift
@@ -59,9 +59,9 @@ final class FriendsViewModel {
         isLoading = true
         errorMessage = nil
 
-        async let friendsBucket = xomify.getAllFriends(email: email)
-        async let allUsers = xomify.listUsers(email: email)
-        async let pendingInvites = loadPendingInvitesResult(email: email)
+        async let friendsBucket = xomify.getAllFriends()
+        async let allUsers = xomify.listUsers()
+        async let pendingInvites = loadPendingInvitesResult()
 
         do {
             let (friendsResp, usersResp, invitesResp) = try await (friendsBucket, allUsers, pendingInvites)
@@ -81,9 +81,9 @@ final class FriendsViewModel {
     /// Defensive wrapper around `listPendingInvites` — the backend endpoint is
     /// pending, so any error is swallowed here to avoid nuking the whole load.
     /// Returns an empty list on failure.
-    private func loadPendingInvitesResult(email: String) async -> [PendingInvite] {
+    private func loadPendingInvitesResult() async -> [PendingInvite] {
         do {
-            let response = try await xomify.listPendingInvites(email: email)
+            let response = try await xomify.listPendingInvites()
             return response.invites ?? []
         } catch {
             // Endpoint not yet deployed — render an empty list. Not a fatal error.
@@ -108,7 +108,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(targetEmail) }
 
         do {
-            _ = try await xomify.requestFriend(email: userEmail, requestEmail: targetEmail)
+            _ = try await xomify.requestFriend(requestEmail: targetEmail)
             // Optimistic: add to outgoing, flag discovery row.
             let friend = Friend(
                 email: userEmail,
@@ -135,7 +135,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(targetEmail) }
 
         do {
-            _ = try await xomify.acceptFriend(email: userEmail, requestEmail: targetEmail)
+            _ = try await xomify.acceptFriend(requestEmail: targetEmail)
             incoming.removeAll { $0.targetEmail == targetEmail }
             accepted.append(friend)
             updateDiscoverFlags(for: targetEmail, isFriend: true)
@@ -155,7 +155,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(targetEmail) }
 
         do {
-            _ = try await xomify.rejectFriend(email: userEmail, requestEmail: targetEmail)
+            _ = try await xomify.rejectFriend(requestEmail: targetEmail)
             incoming.removeAll { $0.targetEmail == targetEmail }
             updateDiscoverFlags(for: targetEmail, clearAll: true)
         } catch {
@@ -172,7 +172,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(targetEmail) }
 
         do {
-            _ = try await xomify.rejectFriend(email: userEmail, requestEmail: targetEmail)
+            _ = try await xomify.rejectFriend(requestEmail: targetEmail)
             outgoing.removeAll { $0.targetEmail == targetEmail }
             updateDiscoverFlags(for: targetEmail, clearAll: true)
         } catch {
@@ -188,7 +188,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(targetEmail) }
 
         do {
-            _ = try await xomify.removeFriend(email: userEmail, friendEmail: targetEmail)
+            _ = try await xomify.removeFriend(friendEmail: targetEmail)
             accepted.removeAll { $0.targetEmail == targetEmail }
             updateDiscoverFlags(for: targetEmail, clearAll: true)
         } catch {
@@ -213,7 +213,7 @@ final class FriendsViewModel {
         lastMintedInvite = nil
 
         do {
-            let response = try await xomify.createInvite(email: userEmail)
+            let response = try await xomify.createInvite()
             guard let shareUrl = response.shareUrl, let url = URL(string: shareUrl) else {
                 inviteMintError = "Invite minted but URL was missing"
                 isMintingInvite = false
@@ -253,7 +253,7 @@ final class FriendsViewModel {
         defer { inFlight.remove(code) }
 
         do {
-            let response = try await xomify.acceptInvite(email: userEmail, inviteCode: code)
+            let response = try await xomify.acceptInvite(inviteCode: code)
             // Value-moment: accepting a deep-link invite = user just crossed a
             // meaningful threshold. Prompt for push permission if we haven't.
             Task { await NotificationsService.shared.requestPermissionIfNeeded() }
@@ -300,7 +300,7 @@ final class FriendsViewModel {
         incomingInvites.removeAll { $0.inviteCode == code }
 
         do {
-            _ = try await xomify.declineInvite(email: userEmail, inviteCode: code)
+            _ = try await xomify.declineInvite(inviteCode: code)
         } catch {
             // Restore the row and surface the error — but only if the failure
             // wasn't "endpoint missing" (404/5xx). We still clear client-side

--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -78,7 +78,7 @@ final class GroupDetailViewModel {
         errorMessage = nil
 
         do {
-            let info = try await xomify.getGroupInfo(groupId: groupId, email: email)
+            let info = try await xomify.getGroupInfo(groupId: groupId)
             group = info.group
             members = info.members ?? []
             tracks = info.tracks ?? []
@@ -127,7 +127,6 @@ final class GroupDetailViewModel {
 
         do {
             let response = try await xomify.getFeed(
-                email: userEmail,
                 groupId: groupId,
                 limit: 50,
                 before: nil
@@ -196,7 +195,7 @@ final class GroupDetailViewModel {
         defer { isLoadingFriends = false }
 
         do {
-            let response = try await xomify.getAllFriends(email: userEmail)
+            let response = try await xomify.getAllFriends()
             friends = response.accepted ?? []
         } catch {
             friendsError = error.localizedDescription
@@ -213,7 +212,7 @@ final class GroupDetailViewModel {
         defer { isAddingMember = false }
 
         do {
-            _ = try await xomify.addMember(email: userEmail, groupId: groupId, memberEmail: target)
+            _ = try await xomify.addMember(groupId: groupId, memberEmail: target)
             addMemberEmail = ""
             await refresh()
         } catch {
@@ -249,7 +248,6 @@ final class GroupDetailViewModel {
 
             do {
                 _ = try await xomify.addMember(
-                    email: userEmail,
                     groupId: groupId,
                     memberEmail: email
                 )
@@ -278,7 +276,6 @@ final class GroupDetailViewModel {
     func removeMember(_ member: GroupMember) async {
         do {
             _ = try await xomify.removeMember(
-                email: userEmail,
                 groupId: groupId,
                 memberEmail: member.email
             )
@@ -308,7 +305,6 @@ final class GroupDetailViewModel {
 
         do {
             _ = try await xomify.updateGroup(
-                email: userEmail,
                 groupId: groupId,
                 name: trimmedName,
                 description: trimmedDesc
@@ -343,7 +339,7 @@ final class GroupDetailViewModel {
     func leave() async -> Bool {
         guard !userEmail.isEmpty, !groupId.isEmpty else { return false }
         do {
-            _ = try await xomify.leaveGroup(email: userEmail, groupId: groupId)
+            _ = try await xomify.leaveGroup(groupId: groupId)
             return true
         } catch {
             errorMessage = "Failed to leave group: \(error.localizedDescription)"
@@ -358,7 +354,7 @@ final class GroupDetailViewModel {
     func delete() async -> Bool {
         guard !userEmail.isEmpty, !groupId.isEmpty else { return false }
         do {
-            _ = try await xomify.removeGroup(email: userEmail, groupId: groupId)
+            _ = try await xomify.removeGroup(groupId: groupId)
             return true
         } catch {
             errorMessage = "Failed to delete group: \(error.localizedDescription)"
@@ -417,7 +413,6 @@ final class GroupDetailViewModel {
 
         do {
             _ = try await xomify.addSong(
-                email: userEmail,
                 groupId: groupId,
                 trackId: track.id,
                 trackName: track.name,
@@ -440,7 +435,6 @@ final class GroupDetailViewModel {
 
         do {
             _ = try await xomify.addSongByUrl(
-                email: userEmail,
                 groupId: groupId,
                 trackUrl: url
             )
@@ -455,7 +449,6 @@ final class GroupDetailViewModel {
     func removeSong(_ track: GroupTrack) async {
         do {
             _ = try await xomify.removeSong(
-                email: userEmail,
                 groupId: groupId,
                 trackIdTimestamp: track.trackIdTimestamp
             )
@@ -468,7 +461,7 @@ final class GroupDetailViewModel {
 
     func markAllListened() async {
         do {
-            _ = try await xomify.markAllListened(email: userEmail, groupId: groupId)
+            _ = try await xomify.markAllListened(groupId: groupId)
             await refresh()
         } catch {
             errorMessage = "Failed to mark listened: \(error.localizedDescription)"

--- a/Xomify-iOS/ViewModels/GroupsViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupsViewModel.swift
@@ -39,7 +39,7 @@ final class GroupsViewModel {
         errorMessage = nil
 
         do {
-            let response = try await xomify.listGroups(email: email)
+            let response = try await xomify.listGroups()
             groups = response.groups ?? []
         } catch {
             errorMessage = error.localizedDescription
@@ -65,7 +65,7 @@ final class GroupsViewModel {
         defer { isLoadingFriends = false }
 
         do {
-            let response = try await xomify.getAllFriends(email: userEmail)
+            let response = try await xomify.getAllFriends()
             friends = response.accepted ?? []
         } catch {
             friendsError = error.localizedDescription
@@ -92,7 +92,6 @@ final class GroupsViewModel {
 
         do {
             let response = try await xomify.createGroup(
-                email: userEmail,
                 name: name,
                 description: description
             )
@@ -114,7 +113,6 @@ final class GroupsViewModel {
                 for email in memberEmails {
                     do {
                         _ = try await xomify.addMember(
-                            email: userEmail,
                             groupId: group.groupId,
                             memberEmail: email
                         )
@@ -142,7 +140,7 @@ final class GroupsViewModel {
 
     func leave(_ group: XomifyGroup) async {
         do {
-            _ = try await xomify.leaveGroup(email: userEmail, groupId: group.groupId)
+            _ = try await xomify.leaveGroup(groupId: group.groupId)
             groups.removeAll { $0.groupId == group.groupId }
         } catch {
             errorMessage = "Failed to leave group: \(error.localizedDescription)"
@@ -155,7 +153,7 @@ final class GroupsViewModel {
     @discardableResult
     func delete(_ group: XomifyGroup) async -> Bool {
         do {
-            _ = try await xomify.removeGroup(email: userEmail, groupId: group.groupId)
+            _ = try await xomify.removeGroup(groupId: group.groupId)
             groups.removeAll { $0.groupId == group.groupId }
             return true
         } catch {

--- a/Xomify-iOS/ViewModels/InvitesViewModel.swift
+++ b/Xomify-iOS/ViewModels/InvitesViewModel.swift
@@ -35,7 +35,7 @@ final class InvitesViewModel {
         errorMessage = nil
 
         do {
-            let response = try await xomify.createInvite(email: email)
+            let response = try await xomify.createInvite()
             inviteCode = response.inviteCode
             shareUrl = response.shareUrl
             expiresAt = response.expiresAt
@@ -62,7 +62,7 @@ final class InvitesViewModel {
         acceptSuccessMessage = nil
 
         do {
-            let response = try await xomify.acceptInvite(email: email, inviteCode: code)
+            let response = try await xomify.acceptInvite(inviteCode: code)
             if let friend = response.friendEmail {
                 acceptSuccessMessage = "You're now friends with \(friend)"
             } else {

--- a/Xomify-iOS/ViewModels/RatingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/RatingsViewModel.swift
@@ -45,7 +45,7 @@ final class RatingsViewModel {
         errorMessage = nil
 
         do {
-            let response = try await xomify.getAllRatings(email: email)
+            let response = try await xomify.getAllRatings()
             ratings = response.ratings ?? []
             await resolveArtwork()
         } catch {
@@ -83,7 +83,7 @@ final class RatingsViewModel {
 
     func delete(_ rating: TrackRating) async {
         do {
-            _ = try await xomify.removeRating(email: userEmail, trackId: rating.trackId)
+            _ = try await xomify.removeRating(trackId: rating.trackId)
             ratings.removeAll { $0.trackId == rating.trackId }
         } catch {
             errorMessage = "Failed to delete rating: \(error.localizedDescription)"

--- a/Xomify-iOS/ViewModels/ReleaseRadarViewModel.swift
+++ b/Xomify-iOS/ViewModels/ReleaseRadarViewModel.swift
@@ -83,7 +83,7 @@ final class ReleaseRadarViewModel {
         print("📡 ReleaseRadar: Loading history for \(email)...")
         
         do {
-            let response = try await xomifyService.getReleaseRadarHistory(email: email)
+            let response = try await xomifyService.getReleaseRadarHistory()
             
             print("✅ ReleaseRadar: Got response")
             print("   - weeks count: \(response.weeks?.count ?? 0)")
@@ -144,7 +144,7 @@ final class ReleaseRadarViewModel {
         print("🔄 ReleaseRadar: Refreshing for \(email)...")
         
         do {
-            let response = try await xomifyService.getReleaseRadarHistory(email: email)
+            let response = try await xomifyService.getReleaseRadarHistory()
             historyWeeks = response.weeks ?? []
             currentWeekKey = response.currentWeek
             

--- a/Xomify-iOS/ViewModels/SettingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/SettingsViewModel.swift
@@ -164,12 +164,11 @@ final class SettingsViewModel {
     // MARK: - Enrollment
 
     func toggleWrappedEnrollment() async {
-        guard !isUpdatingEnrollment, let email = user?.email else { return }
+        guard !isUpdatingEnrollment, user?.email != nil else { return }
         isUpdatingEnrollment = true
         let newValue = !isWrappedEnrolled
         do {
             try await xomifyService.updateEnrollments(
-                email: email,
                 activeWrapped: newValue,
                 activeReleaseRadar: isReleaseRadarEnrolled
             )
@@ -182,12 +181,11 @@ final class SettingsViewModel {
     }
 
     func toggleReleaseRadarEnrollment() async {
-        guard !isUpdatingEnrollment, let email = user?.email else { return }
+        guard !isUpdatingEnrollment, user?.email != nil else { return }
         isUpdatingEnrollment = true
         let newValue = !isReleaseRadarEnrolled
         do {
             try await xomifyService.updateEnrollments(
-                email: email,
                 activeWrapped: isWrappedEnrolled,
                 activeReleaseRadar: newValue
             )
@@ -209,7 +207,8 @@ final class SettingsViewModel {
 
     private func loadXomifyStatus(email: String) async {
         do {
-            let userData = try await xomifyService.getUserData(email: email)
+            _ = email
+            let userData = try await xomifyService.getUserData()
             isWrappedEnrolled = userData.activeWrapped
             isReleaseRadarEnrolled = userData.activeReleaseRadar
             print("✅ Settings: enrollment loaded — Wrapped: \(isWrappedEnrolled), RR: \(isReleaseRadarEnrolled)")

--- a/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
+++ b/Xomify-iOS/ViewModels/SharesByUserViewModel.swift
@@ -61,7 +61,6 @@ final class SharesByUserViewModel {
 
         do {
             let response = try await xomifyService.getSharesByUser(
-                email: callerEmail,
                 targetEmail: targetEmail,
                 limit: 50,
                 before: nil
@@ -88,7 +87,6 @@ final class SharesByUserViewModel {
 
         do {
             _ = try await xomifyService.deleteShare(
-                email: callerEmail,
                 shareId: share.shareId,
                 sharedAt: share.sharedAt
             )
@@ -111,7 +109,6 @@ final class SharesByUserViewModel {
 
         do {
             let response = try await xomifyService.getSharesByUser(
-                email: callerEmail,
                 targetEmail: targetEmail,
                 limit: 50,
                 before: before

--- a/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
+++ b/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
@@ -37,7 +37,8 @@ final class RatingsHistoryViewModel {
                 return
             }
 
-            let response = try await xomifyService.getAllRatings(email: email)
+            _ = email
+            let response = try await xomifyService.getAllRatings()
             let loaded = response.ratings ?? []
             ratings = loaded.sorted(by: Self.isMoreRecent)
             print("✅ RatingsHistory: loaded \(ratings.count) ratings")
@@ -82,7 +83,8 @@ final class RatingsHistoryViewModel {
                 errorMessage = "Could not delete rating — missing email."
                 return
             }
-            _ = try await xomifyService.removeRating(email: email, trackId: rating.trackId)
+            _ = email
+            _ = try await xomifyService.removeRating(trackId: rating.trackId)
             print("🗑️ RatingsHistory: removed rating for \(rating.trackId)")
         } catch {
             ratings.insert(removed, at: index)

--- a/Xomify-iOS/ViewModels/UserProfileViewModel.swift
+++ b/Xomify-iOS/ViewModels/UserProfileViewModel.swift
@@ -226,10 +226,10 @@ final class UserProfileViewModel {
         // Populate the three header stats (Friends / Ratings / Posts) with
         // parallel fetches. Missing counts fall through to nil so the header
         // skeleton keeps working if any single call fails.
-        async let ratings: RatingsAllResponse? = try? xomifyService.getAllRatings(email: callerEmail)
-        async let friends: FriendsAllResponse? = try? xomifyService.getAllFriends(email: callerEmail)
+        async let ratings: RatingsAllResponse? = try? xomifyService.getAllRatings()
+        async let friends: FriendsAllResponse? = try? xomifyService.getAllFriends()
         async let shares: FeedResponse?       = try? xomifyService.getSharesByUser(
-            email: callerEmail, targetEmail: callerEmail, limit: 1, before: nil
+            targetEmail: callerEmail, limit: 1, before: nil
         )
         async let likedPage: SavedTracksResponse? = try? SpotifyService.shared.getSavedTracks(limit: 1, offset: 0)
 
@@ -242,7 +242,6 @@ final class UserProfileViewModel {
 
     private func loadOtherHeader(email: String) async throws {
         let profile = try await xomifyService.getFriendProfile(
-            email: callerEmail,
             profileEmail: email
         )
         friendProfile = profile

--- a/Xomify-iOS/ViewModels/WrappedViewModel.swift
+++ b/Xomify-iOS/ViewModels/WrappedViewModel.swift
@@ -49,18 +49,20 @@ final class WrappedViewModel {
     // MARK: - Actions
     
     func loadWraps() async {
-        guard let email = userEmail else {
+        // Caller email rides the per-user JWT; we still gate on having a
+        // resolved Spotify session locally so we don't fire when signed-out.
+        guard userEmail?.isEmpty == false else {
             errorMessage = "Please log in first"
             return
         }
-        
+
         guard !isLoading else { return }
         
         isLoading = true
         errorMessage = nil
         
         do {
-            wraps = try await xomifyService.getWraps(email: email)
+            wraps = try await xomifyService.getWraps()
             
             // Auto-select most recent wrap
             if let mostRecent = wraps.first {

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -523,7 +523,8 @@ struct WrappedContent: View {
                 return
             }
 
-            wraps = try await xomifyService.getWraps(email: email)
+            _ = email
+            wraps = try await xomifyService.getWraps()
 
             if selectedMonth == nil {
                 selectedMonth = wraps.first


### PR DESCRIPTION
## Summary
Sweeps caller \`email\` (and \`userId\` where applicable) out of every Xomify API call site. Caller identity now arrives via the per-user JWT in the \`Authorization\` header (added by (0d) PR #92). Backend reads it from \`event.requestContext.authorizer\` (deployed via Track 1 batches).

Target identifiers stay in URLs/bodies: \`friendEmail\`, \`requestEmail\`, \`memberEmail\`, \`profileEmail\`, \`targetEmail\`, \`groupId\`, \`shareId\`, \`commentId\`, \`inviteCode\`, \`trackId\`, \`deviceToken\`.

## Files changed (20)
- 3 service files: `XomifyService.swift`, `XomifyServiceProtocol.swift`, `XomifyServicing.swift` — drop `email:` from method signatures (and `userId:` on user/update body)
- `NotificationsService.swift` — drop `email` from register/unregister body; fix `||` autoclosure preventing `await`
- 16 ViewModels + 1 View — sweep all `email:` arguments at call sites

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` — **BUILD SUCCEEDED**
- [ ] TestFlight: log in fresh, verify network requests carry per-user JWT and no caller-email query/body field
- [ ] Watch CloudWatch authorizer logs flip from `auth_path=fallback` to `auth_path=context` for iOS user-agent

## Known caller-vs-target judgment calls
- `friend-profile.component`-equivalent flow on iOS: any view that reads a friend's friends-list count via \`getAllFriends()\` will now return the **caller's** friends, not the friend's. Same root issue surfaced on web in xomify-backend#173. Fix is backend-side (extend \`/friends/profile\` with \`friendsCount\` field) — out of scope for this PR.

## MERGE ORDER
- Depends on **(0d) PR #92** being merged first (per-user JWT mint + 401-retry).
- After this lands, every iOS install older than this version still sends `?email=` query params; backend dual-mode helper accepts those during the migration window. Cleanup PR (1l) closes the fallback after a 7-day burn-in.

Closes #95