### PR TITLE
hotfix(ios): mint Xomify JWT on bootstrap with fresh Spotify token

### DIFF
--- a/Xomify-iOS/App/Xomify_iOSApp.swift
+++ b/Xomify-iOS/App/Xomify_iOSApp.swift
@@ -10,39 +10,87 @@ struct Xomify_iOSApp: App {
 
     private let coordinator = SpotifyPlaybackCoordinator.shared
 
+    /// Gate the root view until `AuthService.ensureXomifyJwt()` has resolved.
+    /// On existing TestFlight installs the keychain holds a Spotify refresh
+    /// token but no Xomify JWT (the (0d) per-user JWT only mints inside the
+    /// post-OAuth `saveRefreshTokenToXomify` flow). Without this gate, every
+    /// view's `.task` modifier races the async mint and slams the backend
+    /// with calls that 401 because (1k) removed the legacy email fallback.
+    /// Mirrors the web hotfix `APP_INITIALIZER` pattern from PR #263.
+    @State private var didBootstrap = false
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .preferredColorScheme(.dark) // Force dark mode for Xomify branding
-                .environment(coordinator)
-                .onOpenURL { url in
-                    // Route deep links. Invite URLs (Universal Links and custom
-                    // scheme) are stashed on `InviteCoordinator`; the Friends
-                    // screen picks them up once it loads.
-                    //
-                    // Also forward to the SDK in case the URL carries a Spotify
-                    // auth-handover token (xomify://callback?access_token=...).
-                    coordinator.remote.handleOpenURL(url)
+            Group {
+                if didBootstrap {
+                    ContentView()
+                } else {
+                    BootstrapSplash()
+                }
+            }
+            .preferredColorScheme(.dark) // Force dark mode for Xomify branding
+            .environment(coordinator)
+            .task {
+                // Best-effort: failure is fine (not-logged-in, network blip,
+                // refresh token revoked). The bootstrap completes either way
+                // so the user is never stuck on the splash. NetworkService
+                // still has its single-shot 401-retry as a safety net.
+                _ = await AuthService.shared.ensureXomifyJwt()
+                didBootstrap = true
+            }
+            .onOpenURL { url in
+                // Route deep links. Invite URLs (Universal Links and custom
+                // scheme) are stashed on `InviteCoordinator`; the Friends
+                // screen picks them up once it loads.
+                //
+                // Also forward to the SDK in case the URL carries a Spotify
+                // auth-handover token (xomify://callback?access_token=...).
+                coordinator.remote.handleOpenURL(url)
+                InviteCoordinator.shared.handle(url)
+            }
+            .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                // Universal Link handoff — the user tapped a Safari/Messages
+                // link that resolved to us. Extract the URL and delegate to
+                // the same coordinator path.
+                if let url = activity.webpageURL {
                     InviteCoordinator.shared.handle(url)
                 }
-                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
-                    // Universal Link handoff — the user tapped a Safari/Messages
-                    // link that resolved to us. Extract the URL and delegate to
-                    // the same coordinator path.
-                    if let url = activity.webpageURL {
-                        InviteCoordinator.shared.handle(url)
-                    }
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                switch newPhase {
+                case .active:
+                    Task { await coordinator.connectIfAuthenticated() }
+                case .background:
+                    coordinator.disconnect()
+                default:
+                    break
                 }
-                .onChange(of: scenePhase) { _, newPhase in
-                    switch newPhase {
-                    case .active:
-                        Task { await coordinator.connectIfAuthenticated() }
-                    case .background:
-                        coordinator.disconnect()
-                    default:
-                        break
-                    }
-                }
+            }
+        }
+    }
+}
+
+/// Brief splash shown while the JWT bootstrap is in flight. Typical duration
+/// is 200-500ms; on a cold start of a long-idle install it may stretch to
+/// ~1s while the Spotify refresh + mint round-trips complete. We deliberately
+/// keep this dead simple — no progress bar, no copy — because crashing into
+/// a 401 cascade is the failure mode we are preventing, not slow startup.
+private struct BootstrapSplash: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.xomifyDark, Color(red: 18/255, green: 18/255, blue: 37/255)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            Image("banner-logo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 240)
+                .shadow(color: .xomifyPurple.opacity(0.5), radius: 20)
+                .accessibilityLabel("Xomify")
         }
     }
 }

--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -442,6 +442,56 @@ final class AuthService: NSObject, Sendable {
         }
     }
 
+    /// True when the cached Xomify JWT is present and not within its 60s
+    /// expiry buffer. Used by `ensureXomifyJwt()` to short-circuit the
+    /// bootstrap when we already have a usable token.
+    private var hasFreshXomifyJwt: Bool {
+        guard let jwt = xomifyJwt, !jwt.isEmpty else { return false }
+        // No expiration recorded → trust the token; backend will 401 if
+        // it's actually expired and the NetworkService retry will remint.
+        guard let exp = xomifyJwtExpiration else { return true }
+        return Date() < exp.addingTimeInterval(-60)
+    }
+
+    /// Bootstrap-only mint that mirrors the web hotfix `ensureXomifyJwt`.
+    /// Called once at app launch *before* any view's `.task` fires API
+    /// calls. Cold-start contract:
+    ///
+    /// 1. If the keychain already holds a non-expired Xomify JWT → no-op,
+    ///    return `true` (normal cache hit on every launch).
+    /// 2. If there is no Spotify refresh token in the keychain → user is
+    ///    not logged in; return `false` so the bootstrap can complete and
+    ///    the root view falls through to `LoginView`.
+    /// 3. Otherwise the stored Spotify access token is almost certainly
+    ///    stale (Spotify access tokens TTL=1h, app may have been idle
+    ///    overnight). Refresh it first, then mint the Xomify JWT off the
+    ///    fresh access token. Same root cause the web hotfix #263 fixes.
+    ///
+    /// Failures (refresh `invalid_grant`, mint network error, etc.) are
+    /// swallowed and surfaced via `false`. The caller does **not** block
+    /// startup on a failed mint — the 401-retry path in `NetworkService`
+    /// is still in place and the user sees `LoginView` if they're truly
+    /// signed out.
+    @discardableResult
+    func ensureXomifyJwt() async -> Bool {
+        if hasFreshXomifyJwt {
+            return true
+        }
+        guard let refresh = refreshToken, !refresh.isEmpty else {
+            // Not logged in — bootstrap completes, ContentView shows LoginView.
+            return false
+        }
+
+        do {
+            try await refreshAccessToken()
+        } catch {
+            print("⚠️ Auth: ensureXomifyJwt — Spotify refresh failed: \(error)")
+            return false
+        }
+
+        return await mintXomifyJwt()
+    }
+
     /// Best-effort ISO8601 parse — backend may return fractional seconds.
     private func parseISO8601(_ value: String) -> Date? {
         let withFractional = ISO8601DateFormatter()


### PR DESCRIPTION
Closes #101

## Bug
After PRs #92 (per-user Xomify JWT), #96 (current page wire-up), and #100 (drop caller-email) merged, existing TestFlight installs may start showing 401s on every authorized Xomify API call when the app cold-launches after >1h idle.

Same root cause as the web hotfix [Xomware/xomify-frontend#263](https://github.com/Xomware/xomify-frontend/pull/263).

## Root cause
1. `(0d)` only mints the Xomify JWT inside `saveRefreshTokenToXomify` (post-OAuth). Existing installs already past OAuth never re-trigger this on app launch.
2. `NetworkService.retryAfterReauth(...)` recovers an in-flight 401 by calling `refreshAccessToken` -> `mintXomifyJwt` -> retry, but only once a 401 has actually surfaced.
3. After `(1k)` callers no longer send a query/body `email` fallback, so the backend has no fallback - the first authorized call MUST succeed via JWT or it 401s.
4. SwiftUI views fire API calls in `.task` modifiers that race any async keychain JWT minting on launch.

## Fix
1. **`AuthService.ensureXomifyJwt() async -> Bool`** mirrors the web's `ensureXomifyJwt`:
   - Fresh JWT in keychain -> no-op (normal cache hit on every launch).
   - No Spotify refresh token -> short-circuit `false` (LoginView will render).
   - Otherwise: refresh the Spotify access token first (the stored one is almost certainly stale - Spotify access tokens TTL=1h), then mint the Xomify JWT off the fresh access token.
2. **`Xomify_iOSApp` blocks startup** until the bootstrap mint resolves. A small `@State didBootstrap` flag toggles between `BootstrapSplash` (brief) and `ContentView` so view `.task` modifiers no longer race the mint. Mirrors the web's `APP_INITIALIZER` pattern.
3. **OAuth-callback mint unchanged.** `saveRefreshTokenToXomify` still mints inline post-login.
4. **NetworkService 401-retry safety net unchanged.** Bootstrap is the front line; retry is the backstop.

## Files changed
- `Xomify-iOS/Services/AuthService.swift` - added `ensureXomifyJwt()` + `hasFreshXomifyJwt` helper.
- `Xomify-iOS/App/Xomify_iOSApp.swift` - bootstrap gate + `BootstrapSplash` view.

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build` -> **BUILD SUCCEEDED**, no new warnings.
- [ ] **TestFlight verification (manual):** existing install >1h idle cold-launches -> brief splash -> MainShell with no 401 cascade in logs.
- [ ] Fresh OAuth login still mints JWT inline via `saveRefreshTokenToXomify`.
- [ ] Logged-out install: bootstrap returns immediately, LoginView renders without splash flash beyond ~1 frame.

## Out of scope
- Splash polish (logo lockup, animation) - intentional minimal surface for hotfix.
- Bootstrap deduplication for `.onChange(of: scenePhase)` (foreground re-checks). The current `hasFreshXomifyJwt` cache hit makes that safe in practice.

This is a HOTFIX. Do not merge until manual TestFlight smoke test passes.