### PR TITLE
hotfix(shares): use DELETE method for /shares/delete (was POST -> 403)

### DIFF
--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -183,12 +183,14 @@ actor XomifyService {
     }
 
     /// Delete a share (author only). Backend expects composite key via body.
+    /// Route is wired as DELETE in api-gateway-service; using POST here
+    /// triggers a 403 ForbiddenException from API GW (unmatched method).
     @discardableResult
     func deleteShare(
         shareId: String,
         sharedAt: String
     ) async throws -> SuccessResponse {
-        try await network.xomifyPost("/shares/delete", body: [
+        try await network.xomifyDelete("/shares/delete", body: [
             "shareId": shareId,
             "sharedAt": sharedAt
         ])


### PR DESCRIPTION
## Bug
User reports \"feed cannot delete post from ios\". Backend logs show no \`/shares/delete\` lambda invocation when iOS triggers a delete.

## Root cause
\`XomifyService.deleteShare\` called \`network.xomifyPost(\"/shares/delete\", body: ...)\` but the backend route is wired as \`DELETE\` in \`xomify-infrastructure/terraform/lambdas_shares.tf:25\`. API Gateway returns 403 ForbiddenException for unmatched HTTP methods, before the lambda runs.

The sibling \`deleteComment\` correctly uses \`xomifyDelete\` — the helper exists in NetworkService, the convention is established, \`deleteShare\` just never followed it.

This bug pre-dates the auth-identity epic — git blame shows the function has used POST since the original add. The user only noticed it now after retesting feed delete during the post-(1k) smoke.

## Fix
One-line: \`xomifyPost\` -> \`xomifyDelete\`. Body shape unchanged.

## Test plan
- [x] \`xcodebuild build\` clean
- [ ] TestFlight: long-press own post -> Delete -> verify post removed and backend log shows \`shares_delete\` invocation