### PR TITLE
hotfix(ios): tolerate unwrapped /auth/login response (no envelope)

### DIFF
--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -415,9 +415,18 @@ final class AuthService: NSObject, Sendable {
                 return false
             }
 
-            let envelope = try JSONDecoder().decode(AuthLoginEnvelope.self, from: data)
-            guard let payload = envelope.data else {
-                print("❌ Auth: /auth/login missing data envelope")
+            // Backend's success_response returns the body raw (no envelope).
+            // Try unwrapped first, fall back to a wrapped { data: ... } shape
+            // in case the envelope ever gets adopted.
+            let payload: AuthLoginPayload
+            if let raw = try? JSONDecoder().decode(AuthLoginPayload.self, from: data) {
+                payload = raw
+            } else if let env = try? JSONDecoder().decode(AuthLoginEnvelope.self, from: data),
+                      let inner = env.data {
+                payload = inner
+            } else {
+                let bodyPreview = String(data: data, encoding: .utf8) ?? "<non-utf8>"
+                print("❌ Auth: /auth/login response did not match payload or envelope shape: \(bodyPreview.prefix(300))")
                 return false
             }
 


### PR DESCRIPTION
## Bug
Same root cause as web hotfix [#268](https://github.com/Xomware/xomify-frontend/pull/268). Music Taste, Friends, and every other authorized iOS view 401s with \"Missing caller identity: 'email' not present in authorizer context, query string, or body\".

## Root cause
Backend \`success_response\` (\`utility_helpers.py\`) returns the body **raw**, not wrapped in \`{ data, error, meta }\`. iOS \`AuthLoginEnvelope\` Codable expects the wrapped shape. Decode fails → \`mintXomifyJwt\` returns false → keychain never gets the per-user JWT → every subsequent request falls back to the static \`XOMIFY_API_TOKEN\` → backend authorizer accepts via legacy path (no \`email\`/\`userId\` claims) → handler raises \`MissingCallerIdentityError\` → 401.

Confirmed via CloudWatch: \`xomify-auth-login\` minting succeeds repeatedly. \`xomify-authorizer\` shows \`auth_path=fallback tokenType=legacy\` for every subsequent call. Smoking gun.

## Fix
Try \`AuthLoginPayload\` (unwrapped) first, fall back to \`AuthLoginEnvelope\` (wrapped) — defensive against a future envelope migration.

## Test plan
- [x] xcodebuild iphonesimulator — BUILD SUCCEEDED
- [ ] TestFlight: clear app data (or force re-login), verify Music Taste page loads top tracks; verify Friends list loads; verify CloudWatch authorizer logs flip to \`auth_path=context tokenType=user\` for the device's user-agent.