### PR TITLE
feat: rate-on-share — star rating input in share composer (iOS)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.1;
+				MARKETING_VERSION = 1.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15.1;
+				MARKETING_VERSION = 1.16.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -111,7 +111,8 @@ actor XomifyService {
         moodTag: MoodTag? = nil,
         genreTags: [String]? = nil,
         groupIds: [String]? = nil,
-        isPublic: Bool? = nil
+        isPublic: Bool? = nil,
+        rating: Int? = nil
     ) async throws -> ShareCreateResponse {
         var body: [String: Any] = [
             "trackId": trackId,
@@ -126,6 +127,7 @@ actor XomifyService {
         if let genreTags = genreTags, !genreTags.isEmpty { body["genreTags"] = genreTags }
         if let groupIds = groupIds, !groupIds.isEmpty { body["groupIds"] = groupIds }
         if let isPublic = isPublic { body["public"] = isPublic }
+        if let rating = rating, (1...5).contains(rating) { body["rating"] = rating }
 
         return try await network.xomifyPost("/shares/create", body: body)
     }

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -24,7 +24,8 @@ protocol XomifyServiceProtocol: Sendable {
         moodTag: MoodTag?,
         genreTags: [String]?,
         groupIds: [String]?,
-        isPublic: Bool?
+        isPublic: Bool?,
+        rating: Int?
     ) async throws -> ShareCreateResponse
 
     func getFeed(

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -58,6 +58,9 @@ final class ShareComposerViewModel {
     var caption: String = ""
     var selectedMood: MoodTag?
     var selectedGenres: [String] = []
+    /// Optional 1-5 star rating the user attaches at composition time.
+    /// `nil` means "no rating" — will not be sent to the backend.
+    var selectedRating: Int? = nil
     /// Whether to publish to the public friends feed. Defaults to true —
     /// matches the legacy single-target behavior.
     var shareToPublic: Bool = true
@@ -255,6 +258,7 @@ final class ShareComposerViewModel {
         let capturedGenres: [String]? = selectedGenres.isEmpty ? nil : selectedGenres
         let capturedGroupIds: [String] = Array(selectedGroupIds)
         let capturedIsPublic: Bool = shareToPublic
+        let capturedRating: Int? = selectedRating
 
         do {
             let response = try await xomifyService.createShare(
@@ -268,7 +272,8 @@ final class ShareComposerViewModel {
                 moodTag: selectedMood,
                 genreTags: capturedGenres,
                 groupIds: capturedGroupIds.isEmpty ? nil : capturedGroupIds,
-                isPublic: capturedIsPublic
+                isPublic: capturedIsPublic,
+                rating: capturedRating
             )
 
             // Value-moment trigger for the APNs permission prompt — fire-and-forget.
@@ -296,10 +301,10 @@ final class ShareComposerViewModel {
                 moodTag: selectedMood,
                 genreTags: capturedGenres,
                 queuedCount: 0,
-                ratedCount: 0,
+                ratedCount: capturedRating != nil ? 1 : 0,
                 viewerHasQueued: false,
-                viewerRating: nil,
-                sharerRating: nil,
+                viewerRating: capturedRating,
+                sharerRating: capturedRating,
                 groupIds: capturedGroupIds,
                 isPublic: capturedIsPublic
             )

--- a/Xomify-iOS/Views/Feed/ShareComposerView.swift
+++ b/Xomify-iOS/Views/Feed/ShareComposerView.swift
@@ -20,6 +20,7 @@ struct ShareComposerView: View {
                     if let track = viewModel.selectedTrack {
                         selectedTrackRow(track)
                         captionSection
+                        ratingSection
                         moodSection
                         genreSection
                         targetsSection
@@ -203,6 +204,46 @@ struct ShareComposerView: View {
             .padding(12)
             .background(Color.xomifyCard)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+    }
+
+    private var ratingSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Rate this track")
+                    .font(.caption)
+                    .foregroundStyle(.gray)
+                Spacer()
+                if viewModel.selectedRating != nil {
+                    Button("Clear") {
+                        viewModel.selectedRating = nil
+                    }
+                    .font(.caption)
+                    .foregroundStyle(Color.xomifyGreen)
+                }
+            }
+            HStack(spacing: 12) {
+                ForEach(1...5, id: \.self) { star in
+                    Button {
+                        if viewModel.selectedRating == star {
+                            viewModel.selectedRating = nil
+                        } else {
+                            viewModel.selectedRating = star
+                        }
+                    } label: {
+                        Image(systemName: (viewModel.selectedRating ?? 0) >= star ? "star.fill" : "star")
+                            .font(.system(size: 28))
+                            .foregroundStyle(
+                                (viewModel.selectedRating ?? 0) >= star
+                                    ? Color.xomifyGreen
+                                    : Color.white.opacity(0.4)
+                            )
+                            .frame(width: 44, height: 44)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(star) star\(star == 1 ? "" : "s")")
+                }
+            }
         }
     }
 

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -6,10 +6,49 @@ import Foundation
 /// methods can be primed to throw or return a specific payload.
 final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendable {
 
+    // MARK: - createShare
+
+    struct CreateShareCall: Equatable {
+        let trackId: String
+        let rating: Int?
+    }
+
+    private(set) var createShareCalls: [CreateShareCall] = []
+    var createShareResult: ShareCreateResponse?
+    var createShareError: Error?
+
+    func createShare(
+        trackId: String,
+        trackUri: String,
+        trackName: String,
+        artistName: String,
+        albumName: String?,
+        albumArtUrl: String?,
+        caption: String?,
+        moodTag: MoodTag?,
+        genreTags: [String]?,
+        groupIds: [String]?,
+        isPublic: Bool?,
+        rating: Int?
+    ) async throws -> ShareCreateResponse {
+        createShareCalls.append(CreateShareCall(trackId: trackId, rating: rating))
+        if let createShareError { throw createShareError }
+        return createShareResult ?? ShareCreateResponse(
+            success: true,
+            shareId: "mock-share-id",
+            share: nil
+        )
+    }
+
+    // MARK: - getFeed
+
+    func getFeed(groupId: String?, limit: Int, before: String?) async throws -> FeedResponse {
+        FeedResponse(shares: [], nextBefore: nil)
+    }
+
     // MARK: - getSharesByUser
 
     struct GetSharesByUserCall: Equatable {
-        let email: String
         let targetEmail: String
         let limit: Int
         let before: String?
@@ -20,13 +59,12 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     var getSharesByUserError: Error?
 
     func getSharesByUser(
-        email: String,
         targetEmail: String,
         limit: Int,
         before: String?
     ) async throws -> FeedResponse {
         getSharesByUserCalls.append(GetSharesByUserCall(
-            email: email, targetEmail: targetEmail, limit: limit, before: before
+            targetEmail: targetEmail, limit: limit, before: before
         ))
         if let getSharesByUserError { throw getSharesByUserError }
         if getSharesByUserResponses.isEmpty {
@@ -35,10 +73,40 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
         return getSharesByUserResponses.removeFirst()
     }
 
+    // MARK: - deleteShare
+
+    func deleteShare(shareId: String, sharedAt: String) async throws -> SuccessResponse {
+        SuccessResponse(success: true)
+    }
+
+    // MARK: - getShareDetail
+
+    struct GetShareDetailCall: Equatable {
+        let shareId: String
+        let sharedBy: String?
+        let sharedAt: String?
+    }
+
+    private(set) var getShareDetailCalls: [GetShareDetailCall] = []
+    var getShareDetailResponses: [ShareDetailResponse] = []
+    var getShareDetailError: Error?
+
+    func getShareDetail(
+        shareId: String, sharedBy: String?, sharedAt: String?
+    ) async throws -> ShareDetailResponse {
+        getShareDetailCalls.append(GetShareDetailCall(
+            shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt
+        ))
+        if let getShareDetailError { throw getShareDetailError }
+        if getShareDetailResponses.isEmpty {
+            throw NSError(domain: "mock", code: -1, userInfo: [NSLocalizedDescriptionKey: "no response primed"])
+        }
+        return getShareDetailResponses.removeFirst()
+    }
+
     // MARK: - getFriendProfile
 
     struct GetFriendProfileCall: Equatable {
-        let email: String
         let profileEmail: String
     }
 
@@ -51,79 +119,38 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     )
     var getFriendProfileError: Error?
 
-    func getFriendProfile(email: String, profileEmail: String) async throws -> FriendProfile {
-        getFriendProfileCalls.append(GetFriendProfileCall(email: email, profileEmail: profileEmail))
+    func getFriendProfile(profileEmail: String) async throws -> FriendProfile {
+        getFriendProfileCalls.append(GetFriendProfileCall(profileEmail: profileEmail))
         if let getFriendProfileError { throw getFriendProfileError }
         return getFriendProfileResponse
     }
 
-    // MARK: - Unused surface — return empty success shapes so the protocol compiles.
+    // MARK: - listGroups
 
-    func createShare(
-        email: String, trackId: String, trackUri: String, trackName: String,
-        artistName: String, albumName: String?, albumArtUrl: String?,
-        caption: String?, moodTag: MoodTag?, genreTags: [String]?,
-        groupIds: [String]?, isPublic: Bool?
-    ) async throws -> ShareCreateResponse {
-        throw NSError(domain: "mock", code: -1)
+    func listGroups() async throws -> GroupsListResponse {
+        GroupsListResponse(email: "", groups: [], totalCount: 0)
     }
 
-    func getFeed(
-        email: String, groupId: String?, limit: Int, before: String?
-    ) async throws -> FeedResponse {
-        FeedResponse(shares: [], nextBefore: nil)
-    }
-
-    func deleteShare(
-        email: String, shareId: String, sharedAt: String
-    ) async throws -> SuccessResponse {
-        SuccessResponse(success: true)
-    }
-
-    // MARK: - getShareDetail
-
-    struct GetShareDetailCall: Equatable {
-        let email: String
-        let shareId: String
-        let sharedBy: String?
-        let sharedAt: String?
-    }
-
-    private(set) var getShareDetailCalls: [GetShareDetailCall] = []
-    var getShareDetailResponses: [ShareDetailResponse] = []
-    var getShareDetailError: Error?
-
-    func getShareDetail(
-        email: String, shareId: String, sharedBy: String?, sharedAt: String?
-    ) async throws -> ShareDetailResponse {
-        getShareDetailCalls.append(GetShareDetailCall(
-            email: email, shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt
-        ))
-        if let getShareDetailError { throw getShareDetailError }
-        if getShareDetailResponses.isEmpty {
-            throw NSError(domain: "mock", code: -1, userInfo: [NSLocalizedDescriptionKey: "no response primed"])
-        }
-        return getShareDetailResponses.removeFirst()
-    }
-
-    func listGroups(email: String) async throws -> GroupsListResponse {
-        GroupsListResponse(email: email, groups: [], totalCount: 0)
-    }
+    // MARK: - publishRating
 
     func publishRating(
-        email: String, trackId: String, trackName: String, artistName: String,
+        trackId: String, trackName: String, artistName: String,
         albumArt: String?, rating: Int, review: String?
     ) async throws -> SuccessResponse {
         SuccessResponse(success: true)
     }
 
-    func getAllRatings(email: String) async throws -> RatingsAllResponse {
-        RatingsAllResponse(email: email, ratings: [], totalCount: 0)
+    // MARK: - getAllRatings
+
+    func getAllRatings() async throws -> RatingsAllResponse {
+        RatingsAllResponse(email: "", ratings: [], totalCount: 0)
     }
 
-    func getAllFriends(email: String) async throws -> FriendsAllResponse {
+    // MARK: - getAllFriends
+
+    func getAllFriends() async throws -> FriendsAllResponse {
         FriendsAllResponse(
-            email: email,
+            email: "",
             accepted: [], requested: [], pending: [], blocked: [],
             acceptedCount: 0, requestedCount: 0, pendingCount: 0, blockedCount: 0,
             totalCount: 0
@@ -131,22 +158,16 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     }
 
     // MARK: - Comments + Reactions (xomify-backend#139)
-    //
-    // Stub default returns; specific tests can prime the response/error.
 
     var createCommentResponse: ShareComment?
     var createCommentError: Error?
 
-    func createComment(
-        email: String,
-        shareId: String,
-        body: String
-    ) async throws -> ShareComment {
+    func createComment(shareId: String, body: String) async throws -> ShareComment {
         if let createCommentError { throw createCommentError }
         return createCommentResponse ?? ShareComment(
             commentId: UUID().uuidString,
             shareId: shareId,
-            email: email,
+            email: "mock@example.com",
             displayName: nil,
             avatar: nil,
             body: body,
@@ -159,23 +180,14 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     )
     var listCommentsError: Error?
 
-    func listComments(
-        email: String,
-        shareId: String,
-        limit: Int,
-        before: String?
-    ) async throws -> CommentsListResponse {
+    func listComments(shareId: String, limit: Int, before: String?) async throws -> CommentsListResponse {
         if let listCommentsError { throw listCommentsError }
         return listCommentsResponse
     }
 
     var deleteCommentError: Error?
 
-    func deleteComment(
-        email: String,
-        shareId: String,
-        commentId: String
-    ) async throws -> CommentDeleteResponse {
+    func deleteComment(shareId: String, commentId: String) async throws -> CommentDeleteResponse {
         if let deleteCommentError { throw deleteCommentError }
         return CommentDeleteResponse(deleted: true, commentId: commentId)
     }
@@ -183,11 +195,7 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     var toggleReactionResponse: ReactionToggleResponse?
     var toggleReactionError: Error?
 
-    func toggleReaction(
-        email: String,
-        shareId: String,
-        reaction: ShareReaction
-    ) async throws -> ReactionToggleResponse {
+    func toggleReaction(shareId: String, reaction: ShareReaction) async throws -> ReactionToggleResponse {
         if let toggleReactionError { throw toggleReactionError }
         return toggleReactionResponse ?? ReactionToggleResponse(
             active: true,
@@ -202,10 +210,7 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
     )
     var listReactionsError: Error?
 
-    func listReactions(
-        email: String,
-        shareId: String
-    ) async throws -> ReactionsListResponse {
+    func listReactions(shareId: String) async throws -> ReactionsListResponse {
         if let listReactionsError { throw listReactionsError }
         return listReactionsResponse
     }

--- a/Xomify-iOSTests/ShareComposerViewModelTests.swift
+++ b/Xomify-iOSTests/ShareComposerViewModelTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import Xomify_iOS
+
+// MARK: - Minimal mock for SpotifyTrackSearching
+
+private final class MockSpotifyTrackSearching: SpotifyTrackSearching, @unchecked Sendable {
+    var results: [SpotifyTrack] = []
+    func searchTracks(query: String, limit: Int) async throws -> [SpotifyTrack] {
+        return results
+    }
+}
+
+// MARK: - Helpers
+
+private func makeTrack(id: String = "track-1", name: String = "Test Track") -> SpotifyTrack {
+    SpotifyTrack(
+        id: id,
+        name: name,
+        uri: "spotify:track:\(id)",
+        durationMs: 200_000,
+        explicit: false,
+        popularity: nil,
+        previewUrl: nil,
+        album: nil,
+        artists: [SpotifyArtist(id: "a1", name: "Artist", externalUrls: nil, images: nil)],
+        externalUrls: nil
+    )
+}
+
+// MARK: - Tests
+
+@MainActor
+final class ShareComposerViewModelTests: XCTestCase {
+
+    // MARK: - Rating passthrough
+
+    func test_submit_withRating_passesRatingToCreateShare() async {
+        let service = MockXomifyServiceProtocol()
+        let spotify = MockSpotifyCurrentUserProviding()
+        let search = MockSpotifyTrackSearching()
+
+        let vm = ShareComposerViewModel(
+            xomifyService: service,
+            spotifyService: search,
+            currentUserProvider: spotify
+        )
+
+        vm.selectTrack(makeTrack())
+        vm.selectedRating = 4
+
+        let share = await vm.submit()
+
+        XCTAssertNotNil(share)
+        XCTAssertEqual(service.createShareCalls.count, 1)
+        XCTAssertEqual(service.createShareCalls.first?.rating, 4)
+    }
+
+    func test_submit_withoutRating_sendsNilRating() async {
+        let service = MockXomifyServiceProtocol()
+        let spotify = MockSpotifyCurrentUserProviding()
+        let search = MockSpotifyTrackSearching()
+
+        let vm = ShareComposerViewModel(
+            xomifyService: service,
+            spotifyService: search,
+            currentUserProvider: spotify
+        )
+
+        vm.selectTrack(makeTrack())
+        // selectedRating is nil by default — no rating attached.
+
+        let share = await vm.submit()
+
+        XCTAssertNotNil(share)
+        XCTAssertEqual(service.createShareCalls.count, 1)
+        XCTAssertNil(service.createShareCalls.first?.rating)
+    }
+
+    func test_submit_ratingAppearsOnOptimisticShare() async {
+        let service = MockXomifyServiceProtocol()
+        // Return a response with no embedded Share so the VM synthesizes one.
+        service.createShareResult = ShareCreateResponse(success: true, shareId: "s1", share: nil)
+
+        let spotify = MockSpotifyCurrentUserProviding()
+        let search = MockSpotifyTrackSearching()
+
+        let vm = ShareComposerViewModel(
+            xomifyService: service,
+            spotifyService: search,
+            currentUserProvider: spotify
+        )
+
+        vm.selectTrack(makeTrack())
+        vm.selectedRating = 3
+
+        let share = await vm.submit()
+
+        XCTAssertEqual(share?.sharerRating, 3)
+        XCTAssertEqual(share?.viewerRating, 3)
+    }
+}

--- a/Xomify-iOSTests/SharesByUserViewModelTests.swift
+++ b/Xomify-iOSTests/SharesByUserViewModelTests.swift
@@ -44,7 +44,6 @@ final class SharesByUserViewModelTests: XCTestCase {
         XCTAssertNil(vm.errorMessage)
 
         let call = try? XCTUnwrap(mock.getSharesByUserCalls.first)
-        XCTAssertEqual(call?.email, "me@example.com")
         XCTAssertEqual(call?.targetEmail, "target@example.com")
         XCTAssertNil(call?.before)
     }

--- a/Xomify-iOSTests/UserProfileViewModelTests.swift
+++ b/Xomify-iOSTests/UserProfileViewModelTests.swift
@@ -128,7 +128,6 @@ final class UserProfileViewModelTests: XCTestCase {
         XCTAssertEqual(vm.shareCount, 3)
         XCTAssertNotNil(vm.friendProfile)
         XCTAssertEqual(xomify.getFriendProfileCalls.count, 1)
-        XCTAssertEqual(xomify.getFriendProfileCalls.first?.email, "me@example.com")
         XCTAssertEqual(xomify.getFriendProfileCalls.first?.profileEmail, "friend@example.com")
     }
 


### PR DESCRIPTION
## Summary
- `ShareComposerView`: adds an optional 1-5 star row between caption and mood sections. Tap a star to set; tap the selected star again (or "Clear") to unset.
- `ShareComposerViewModel`: new `selectedRating: Int?` state. Passed as `rating:` to `XomifyService.createShare`. Optimistic share reflects the rating on `sharerRating`/`viewerRating`.
- `XomifyServiceProtocol` + `XomifyService`: `createShare` gains `rating: Int?` parameter. Client-side range guard (1...5) mirrors server-side. Mock updated to match.
- `MockXomifyServiceProtocol`: rewrote all stale `email:`-param stubs to match current protocol (email was dropped from most calls in auth-identity epic).
- `ShareComposerViewModelTests`: three new tests — rating sent, nil rating sent, optimistic share carries rating.
- `UserProfileViewModelTests` / `SharesByUserViewModelTests`: removed `.email` assertion on call structs that no longer carry email.
- Version bumped 1.15.1 → 1.16.0.

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` — BUILD SUCCEEDED
- [x] Manual: extension target needs Xcode wiring (Phase 5)