### PR TITLE
feat: iOS Share Extension — share Spotify tracks directly to Xomify

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.16.0;
+				MARKETING_VERSION = 1.17.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.16.0;
+				MARKETING_VERSION = 1.17.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/App/Xomify_iOSApp.swift
+++ b/Xomify-iOS/App/Xomify_iOSApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 @main
 struct Xomify_iOSApp: App {
     /// APNs device-token registration + push-open dispatch.
@@ -43,10 +44,15 @@ struct Xomify_iOSApp: App {
                 // scheme) are stashed on `InviteCoordinator`; the Friends
                 // screen picks them up once it loads.
                 //
+                // Share deep links (`xomify://share?trackId=`) are stashed on
+                // `ShareDeepLinkCoordinator`; `FeedView` consumes them on
+                // appearance and pre-loads the composer.
+                //
                 // Also forward to the SDK in case the URL carries a Spotify
                 // auth-handover token (xomify://callback?access_token=...).
                 coordinator.remote.handleOpenURL(url)
                 InviteCoordinator.shared.handle(url)
+                ShareDeepLinkCoordinator.shared.handle(url)
             }
             .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
                 // Universal Link handoff — the user tapped a Safari/Messages

--- a/Xomify-iOS/Navigation/NavigationStore.swift
+++ b/Xomify-iOS/Navigation/NavigationStore.swift
@@ -40,6 +40,10 @@ final class NavigationStore {
     /// Toggled by the Feed screen's FAB and by composer dismissal.
     var composerSheetPresented: Bool = false
 
+    /// When set, the next composer open will pre-populate this track.
+    /// Consumed immediately by `FeedView` when it presents the sheet.
+    var composerPrefilledTrack: SpotifyTrack? = nil
+
     /// Set by the Feed empty-state CTAs. `MainShell` observes this and calls
     /// `consumePendingDeepLink()` on the next runloop so the drawer animation
     /// and destination switch don't race.

--- a/Xomify-iOS/Services/ShareDeepLinkCoordinator.swift
+++ b/Xomify-iOS/Services/ShareDeepLinkCoordinator.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Parses incoming `xomify://share?trackId=<id>` deep links (and equivalent
+/// Spotify HTTPS / URI formats) and stashes the track id so the Feed view can
+/// open the composer pre-loaded with that track once the user is authenticated.
+///
+/// Call sites:
+///   1. `Xomify_iOSApp.onOpenURL` — forwards the raw URL here.
+///   2. `XomifyShareExtension.ShareViewController` — builds the URL and hands
+///      control back to the main app via `extensionContext?.open(_:)`.
+///   3. `FeedView` — observes `pendingTrackId` and consumes it on appearance.
+///
+/// Accepted URL shapes:
+///   xomify://share?trackId=<id>
+///   https://open.spotify.com/track/<id>     (share sheet copy-link)
+///   spotify:track:<id>                       (Spotify URI)
+@Observable
+@MainActor
+final class ShareDeepLinkCoordinator {
+
+    static let shared = ShareDeepLinkCoordinator()
+
+    /// Stashed track id — consumed by `FeedView` once it appears.
+    private(set) var pendingTrackId: String?
+
+    private init() {}
+
+    /// Parse `url` and, if it is a share deep link, stash the track id.
+    /// Safe to call with any URL — unrecognised shapes are ignored.
+    @discardableResult
+    func handle(_ url: URL) -> Bool {
+        guard let trackId = url.xomifyShareTrackId else { return false }
+        pendingTrackId = trackId
+        return true
+    }
+
+    /// Consume and return the pending track id, clearing it immediately so
+    /// subsequent appearances do not re-trigger the composer.
+    func consume() -> String? {
+        defer { pendingTrackId = nil }
+        return pendingTrackId
+    }
+}

--- a/Xomify-iOS/Utilities/URLShareParsing.swift
+++ b/Xomify-iOS/Utilities/URLShareParsing.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+extension URL {
+    /// Returns the Spotify track id embedded in a share deep link, or `nil`.
+    ///
+    /// Recognised formats:
+    ///   - `xomify://share?trackId=<id>`  (Xomify custom scheme)
+    ///   - `https://open.spotify.com/track/<id>`  (Spotify copy-link)
+    ///   - `spotify:track:<id>`  (Spotify URI)
+    var xomifyShareTrackId: String? {
+        // Custom scheme: xomify://share?trackId=<id>
+        if scheme == "xomify", host == "share" {
+            return URLComponents(url: self, resolvingAgainstBaseURL: false)?
+                .queryItems?
+                .first(where: { $0.name == "trackId" })?
+                .value
+        }
+        // Spotify HTTPS: https://open.spotify.com/track/<id>
+        if host == "open.spotify.com" {
+            let parts = path.split(separator: "/")
+            if parts.count >= 2, parts[0] == "track" {
+                // Strip any query params from the id (e.g. ?si=...)
+                return String(parts[1]).components(separatedBy: "?").first
+            }
+        }
+        // Spotify URI: spotify:track:<id>
+        if scheme == "spotify" {
+            let parts = absoluteString.split(separator: ":")
+            if parts.count >= 3, parts[1] == "track" {
+                return String(parts[2]).components(separatedBy: "?").first
+            }
+        }
+        return nil
+    }
+}

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -7,6 +7,9 @@ struct FeedView: View {
     @State private var viewModel = FeedViewModel()
     @State private var showingRefinement = false
     @State private var selectedShare: Share?
+    /// The view model for the composer sheet. Replaced when a deep-link track
+    /// pre-loads the composer; otherwise a fresh instance on each open.
+    @State private var composerViewModel = ShareComposerViewModel()
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -38,6 +41,8 @@ struct FeedView: View {
         .task {
             await viewModel.bootstrap()
             await viewModel.loadGroupsForChips()
+            // Consume any pending share deep link once the feed is loaded.
+            await handlePendingShareDeepLink()
         }
         .refreshable {
             await viewModel.refresh()
@@ -46,7 +51,7 @@ struct FeedView: View {
             get: { navStore.composerSheetPresented },
             set: { navStore.composerSheetPresented = $0 }
         )) {
-            ShareComposerView(viewModel: ShareComposerViewModel()) { share in
+            ShareComposerView(viewModel: composerViewModel) { share in
                 Task { await viewModel.prependShareAndRefresh(share) }
             }
         }
@@ -194,6 +199,25 @@ struct FeedView: View {
     // MARK: - Composer
 
     private func openComposer() {
+        composerViewModel = ShareComposerViewModel()
         navStore.composerSheetPresented = true
+    }
+
+    /// If a share deep link arrived (from the Share Extension or an external
+    /// URL), resolve the track from Spotify and pre-populate the composer.
+    private func handlePendingShareDeepLink() async {
+        guard let trackId = ShareDeepLinkCoordinator.shared.consume() else { return }
+        do {
+            let track = try await SpotifyService.shared.getTrack(id: trackId)
+            let vm = ShareComposerViewModel()
+            vm.selectTrack(track)
+            composerViewModel = vm
+            // Navigate to the feed tab first so the sheet appears over the
+            // right screen.
+            navStore.select(.feed)
+            navStore.composerSheetPresented = true
+        } catch {
+            // Silently ignore — track lookup failed (e.g. not signed in yet).
+        }
     }
 }

--- a/XomifyShareExtension/EXTENSION_SETUP.md
+++ b/XomifyShareExtension/EXTENSION_SETUP.md
@@ -1,0 +1,128 @@
+# Xomify Share Extension — Xcode Setup
+
+The source files in this directory are ready to build but the Xcode target
+must be added manually (editing `project.pbxproj` directly is error-prone).
+Follow these steps once after cloning / checking out the branch.
+
+---
+
+## 1. Add the Share Extension target
+
+1. Open `Xomify-iOS.xcodeproj` in Xcode.
+2. **File → New → Target…**
+3. Select **iOS → Share Extension** and click **Next**.
+4. Set:
+   - **Product Name**: `XomifyShareExtension`
+   - **Bundle Identifier**: `com.xomware.xomify.share`
+     (adjust to match your signing team's prefix, e.g. `com.domgiordano.xomify.share`)
+   - **Language**: Swift
+5. Click **Finish**. When Xcode asks to activate the scheme, click **Cancel**
+   (we don't need a separate scheme for CI builds).
+
+---
+
+## 2. Replace the generated files
+
+Xcode generates boilerplate `ShareViewController.swift` and `Info.plist`
+inside the new target folder. Replace them with the files already in this repo:
+
+```
+XomifyShareExtension/ShareViewController.swift
+XomifyShareExtension/Info.plist
+```
+
+In Xcode's Project Navigator, delete the generated files (move to Trash) and
+add the repo files to the target:
+
+- Right-click the `XomifyShareExtension` group → **Add Files to "Xomify-iOS"…**
+- Select `ShareViewController.swift` and `Info.plist`
+- Make sure only the `XomifyShareExtension` target is checked
+
+---
+
+## 3. Add URLShareParsing.swift to the extension target
+
+`ShareViewController.swift` uses the `URL.xomifyShareTrackId` extension defined
+in `Xomify-iOS/Utilities/URLShareParsing.swift`.
+
+In Xcode's Project Navigator, select `URLShareParsing.swift` and in the
+**File Inspector** (right panel → Target Membership) check
+**XomifyShareExtension** in addition to **Xomify-iOS**.
+
+---
+
+## 4. Configure signing
+
+In the `XomifyShareExtension` target's **Signing & Capabilities** tab:
+- Set the same **Team** as the main `Xomify-iOS` target.
+- Xcode will auto-generate entitlements. No additional capabilities needed.
+
+---
+
+## 5. Verify the activation rule
+
+Open `XomifyShareExtension/Info.plist` and confirm:
+
+```
+NSExtensionAttributes → NSExtensionActivationRule
+```
+
+is set to:
+
+```
+SUBQUERY(extensionItems, $ei, SUBQUERY($ei.attachments, $a,
+  ANY $a.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+).@count > 0).@count > 0
+```
+
+This allows the extension to appear for any incoming URL. Spotify's share
+sheet always passes a `https://open.spotify.com/track/<id>?si=...` URL.
+
+To tighten the rule so the extension only shows for Spotify track URLs, replace
+the predicate with a JavaScript/NSPREDUCATE string:
+
+```
+SUBQUERY(extensionItems, $ei, SUBQUERY($ei.attachments, $a,
+  (ANY $a.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url")
+    AND $a.description CONTAINS "open.spotify.com/track"
+).@count > 0).@count > 0
+```
+
+Note: URL content filtering in activation rules is limited on iOS — the
+simpler `public.url` rule is more reliable across Spotify app versions.
+
+---
+
+## 6. Build and test
+
+```bash
+# Build the main app (extension builds alongside it after wiring):
+xcodebuild -scheme Xomify-iOS \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  build
+```
+
+To test the share flow:
+1. Install the app on a real device (simulator share sheets are unreliable).
+2. Open Spotify, navigate to a track.
+3. Tap **…** → **Share** → **More** → enable Xomify in the share sheet.
+4. Tap Xomify — the extension should open.
+5. Tap **Continue in Xomify** — the main app should launch with the composer
+   pre-populated.
+
+---
+
+## Deep-link flow (for reference)
+
+```
+Spotify share sheet
+  → ShareViewController reads URL
+  → builds xomify://share?trackId=<id>
+  → opens main app via UIApplication.open(_:)
+  → Xomify_iOSApp.onOpenURL dispatches to ShareDeepLinkCoordinator
+  → FeedView.handlePendingShareDeepLink() consumes the pending id
+  → SpotifyService.getTrack(id:) resolves the full track
+  → ShareComposerViewModel.selectTrack(_:) pre-populates the composer
+  → navStore.composerSheetPresented = true opens the sheet
+```

--- a/XomifyShareExtension/Info.plist
+++ b/XomifyShareExtension/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Xomify</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<!--
+			  Activation rule: only activate for items that include a URL
+			  matching Spotify's track link formats.
+
+			  Broad rule (public.url) — Xcode refines further via
+			  NSExtensionActivationRule NSPREDUCATE string:
+			    SUBQUERY(extensionItems, $ei,
+			      SUBQUERY($ei.attachments, $a,
+			        ANY $a.registeredTypeIdentifiers UTI-CONFORMS-TO 'public.url'
+			      ).@count > 0
+			    ).@count > 0
+			-->
+			<key>NSExtensionActivationRule</key>
+			<string>SUBQUERY(extensionItems, $ei, SUBQUERY($ei.attachments, $a, ANY $a.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url").@count > 0).@count > 0</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/XomifyShareExtension/ShareViewController.swift
+++ b/XomifyShareExtension/ShareViewController.swift
@@ -1,0 +1,181 @@
+import UIKit
+import Social
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+/// Minimal Share Extension entry point.
+///
+/// When the user taps Share on a track in Spotify and selects "Xomify",
+/// iOS instantiates this controller. We:
+///   1. Read the incoming URL from the extension context.
+///   2. Parse the Spotify track id.
+///   3. Show a minimal UI — track id preview + "Continue in Xomify" button.
+///   4. On tap, open `xomify://share?trackId=<id>` and dismiss.
+///
+/// ## Xcode Setup (manual — see EXTENSION_SETUP.md)
+/// This file is included in the project repository but the Share Extension
+/// target must be added in Xcode. Follow the steps in `EXTENSION_SETUP.md`.
+final class ShareViewController: UIViewController {
+
+    // MARK: - UI
+
+    private let stackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .vertical
+        sv.alignment = .center
+        sv.spacing = 20
+        sv.translatesAutoresizingMaskIntoConstraints = false
+        return sv
+    }()
+
+    private let logoLabel: UILabel = {
+        let l = UILabel()
+        l.text = "Xomify"
+        l.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        l.textColor = .white
+        return l
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let l = UILabel()
+        l.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        l.textColor = UIColor.lightGray
+        l.textAlignment = .center
+        l.numberOfLines = 2
+        return l
+    }()
+
+    private let continueButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.title = "Continue in Xomify"
+        config.baseForegroundColor = .black
+        config.baseBackgroundColor = UIColor(red: 0.08, green: 0.82, blue: 0.54, alpha: 1) // xomifyGreen
+        config.cornerStyle = .capsule
+        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24)
+        let b = UIButton(configuration: config)
+        b.translatesAutoresizingMaskIntoConstraints = false
+        return b
+    }()
+
+    private let cancelButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.title = "Cancel"
+        config.baseForegroundColor = .lightGray
+        let b = UIButton(configuration: config)
+        return b
+    }()
+
+    // MARK: - State
+
+    private var resolvedTrackId: String?
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        extractTrackId()
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        view.backgroundColor = UIColor(red: 0.05, green: 0.05, blue: 0.12, alpha: 1) // xomifyDark
+
+        stackView.addArrangedSubview(logoLabel)
+        stackView.addArrangedSubview(subtitleLabel)
+        stackView.addArrangedSubview(continueButton)
+        stackView.addArrangedSubview(cancelButton)
+
+        view.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 24),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -24),
+            continueButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 220),
+        ])
+
+        continueButton.addTarget(self, action: #selector(didTapContinue), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+
+        subtitleLabel.text = "Loading track…"
+        continueButton.isEnabled = false
+    }
+
+    // MARK: - Track ID Extraction
+
+    private func extractTrackId() {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let attachments = item.attachments else {
+            subtitleLabel.text = "No track found"
+            return
+        }
+
+        let typeURL = UTType.url.identifier
+
+        for provider in attachments {
+            if provider.hasItemConformingToTypeIdentifier(typeURL) {
+                provider.loadItem(forTypeIdentifier: typeURL, options: nil) { [weak self] item, _ in
+                    DispatchQueue.main.async {
+                        guard let self = self else { return }
+                        let url: URL?
+                        if let u = item as? URL {
+                            url = u
+                        } else if let s = item as? String {
+                            url = URL(string: s)
+                        } else {
+                            url = nil
+                        }
+                        self.handleResolvedURL(url)
+                    }
+                }
+                return
+            }
+        }
+        subtitleLabel.text = "No URL found in share"
+    }
+
+    private func handleResolvedURL(_ url: URL?) {
+        guard let url = url,
+              let trackId = url.xomifyShareTrackId else {
+            subtitleLabel.text = url != nil
+                ? "Not a Spotify track link"
+                : "Could not read URL"
+            return
+        }
+        resolvedTrackId = trackId
+        subtitleLabel.text = "Track: …\(trackId.suffix(8))"
+        continueButton.isEnabled = true
+    }
+
+    // MARK: - Actions
+
+    @objc private func didTapContinue() {
+        guard let trackId = resolvedTrackId,
+              let deepLink = URL(string: "xomify://share?trackId=\(trackId)") else {
+            extensionContext?.cancelRequest(withError: NSError(domain: "XomifyShareExtension", code: 1))
+            return
+        }
+
+        // Open the main app with the deep link.
+        // `extensionContext?.open` is not available on Share extensions targeting
+        // iOS < 17 without a UIApplication reference. The safest approach
+        // cross-version is to use the responder chain trick.
+        var responder: UIResponder? = self
+        while let next = responder?.next {
+            responder = next
+            if let application = responder as? UIApplication {
+                application.open(deepLink, options: [:], completionHandler: nil)
+                break
+            }
+        }
+
+        extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    @objc private func didTapCancel() {
+        extensionContext?.cancelRequest(withError: NSError(domain: "XomifyShareExtension", code: 0))
+    }
+}


### PR DESCRIPTION
## Summary
- `XomifyShareExtension/ShareViewController.swift`: minimal Share Extension that reads an incoming URL from the extension context, parses the Spotify track id, and opens `xomify://share?trackId=<id>` in the main app.
- `XomifyShareExtension/Info.plist`: declares `com.apple.share-services` with `NSExtensionActivationRule` for `public.url`.
- `XomifyShareExtension/EXTENSION_SETUP.md`: step-by-step instructions to wire the extension target in Xcode (add target → replace boilerplate files → add `URLShareParsing.swift` to target membership → configure signing).
- `Xomify-iOS/Utilities/URLShareParsing.swift`: `URL.xomifyShareTrackId` extension that handles `xomify://share?trackId=`, `https://open.spotify.com/track/`, and `spotify:track:` formats.
- `Xomify-iOS/Services/ShareDeepLinkCoordinator.swift`: singleton that captures pending track ids from deep links (same pattern as `InviteCoordinator`).
- `Xomify_iOSApp.swift`: `onOpenURL` now also calls `ShareDeepLinkCoordinator.shared.handle(url)`.
- `NavigationStore`: adds `composerPrefilledTrack` (reserved for future sheet pre-population without full VM replacement).
- `FeedView`: on bootstrap, calls `handlePendingShareDeepLink()` — resolves the pending track via `SpotifyService.getTrack`, pre-populates `ShareComposerViewModel.selectTrack`, and opens the composer sheet.
- Version bumped 1.16.0 → 1.17.0.

## Manual step required
The extension target must be wired in Xcode. See `XomifyShareExtension/EXTENSION_SETUP.md` for the full procedure (Add Target → Share Extension → replace boilerplate files → target membership for `URLShareParsing.swift`).

## Test plan
- [x] `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` — BUILD SUCCEEDED
- [ ] Manual device test: Spotify → Share track → Xomify → Continue in Xomify → composer opens with track pre-populated