### PR TITLE
fix: ratings page decode (Int OR Double, accept ratedAt)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.0;
+				MARKETING_VERSION = 1.17.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -340,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.0;
+				MARKETING_VERSION = 1.17.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -760,6 +760,58 @@ struct TrackRating: Codable, Sendable, Identifiable, Hashable {
     let updatedAt: String?
 
     var id: String { trackId }
+
+    enum CodingKeys: String, CodingKey {
+        case email, trackId, trackName, artistName, rating, review
+        case createdAt, updatedAt
+    }
+
+    private enum DecodeKeys: String, CodingKey {
+        case email, trackId, trackName, artistName, rating, review
+        case createdAt, updatedAt, ratedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: DecodeKeys.self)
+        email = try c.decode(String.self, forKey: .email)
+        trackId = try c.decode(String.self, forKey: .trackId)
+        trackName = try c.decodeIfPresent(String.self, forKey: .trackName)
+        artistName = try c.decodeIfPresent(String.self, forKey: .artistName)
+        review = try c.decodeIfPresent(String.self, forKey: .review)
+        createdAt = try c.decodeIfPresent(String.self, forKey: .createdAt)
+            ?? c.decodeIfPresent(String.self, forKey: .ratedAt)
+        updatedAt = try c.decodeIfPresent(String.self, forKey: .updatedAt)
+            ?? c.decodeIfPresent(String.self, forKey: .ratedAt)
+        // Backend serializes DynamoDB Decimals as Int when whole, Float otherwise.
+        // Decode permissively (Int OR Double) and round to nearest whole star —
+        // legacy half-star rows ("4.5") would otherwise fail the entire array decode.
+        if let i = try? c.decode(Int.self, forKey: .rating) {
+            rating = i
+        } else {
+            let d = try c.decode(Double.self, forKey: .rating)
+            rating = Int(d.rounded())
+        }
+    }
+
+    init(
+        email: String,
+        trackId: String,
+        trackName: String? = nil,
+        artistName: String? = nil,
+        rating: Int,
+        review: String? = nil,
+        createdAt: String? = nil,
+        updatedAt: String? = nil
+    ) {
+        self.email = email
+        self.trackId = trackId
+        self.trackName = trackName
+        self.artistName = artistName
+        self.rating = rating
+        self.review = review
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
 struct RatingsAllResponse: Codable, Sendable {

--- a/docs/features/ratings-counts-and-share-flows/EXECUTION_LOG.md
+++ b/docs/features/ratings-counts-and-share-flows/EXECUTION_LOG.md
@@ -1,0 +1,93 @@
+# Execution Log: Ratings + Counts Hotfix Pile + Share Flows
+
+## 2026-04-28 — Phase 1: Web hotfix profile counts (B4/B6)
+
+- **Action**: Fixed `user.service.ts` to read `likes_count` / `likes_public` (DDB snake_case) with camelCase fallback.
+- **Investigation**: Confirmed DDB stores `likes_count` via `user_likes_dynamo.py:121` (`SET likes_count = :c`). `activeWrapped` / `activeReleaseRadar` are stored camelCase (set via `update_user_table_enrollments`). Only `likes_count` and `likes_public` were mismatched.
+- **B6 finding**: Already resolved — `friend-profile.component.html` already renders the Likes chip (lines 82-91) and `FriendProfile` interface already has `likesCount`. No template change needed.
+- **Files changed**: `src/app/services/user.service.ts`, `package.json` (2.4.1 -> 2.4.2)
+- **Build**: `npm run build` — success (budget warnings are pre-existing)
+- **PR**: xomify-frontend#286 — merged
+- **Result**: success
+
+## 2026-04-28 — Phase 2: Backend feed enrichment + group filter (B2/B3)
+
+- **Action (2a)**: Confirmed B2 already fixed in prior commit — `_enrich` in `shares_feed/handler.py` already logs at WARN and sets defaults. `build_enrichment(share_id, viewer_email)` receives caller email from `get_caller_email(event)` at handler line 107, not from a stale event body field.
+- **Action (2b)**: Replaced single `query_feed_for_emails` call with pagination loop when `groupId` is set. Strategy: 4x overscan per iteration (e.g. limit=50 → overscan=200 per page), loop until `limit` group-targeted rows collected or page shorter than overscan (DDB exhausted). Safety cap of 10 iterations.
+- **Files changed**: `lambdas/shares_feed/handler.py`, `tests/test_shares_feed.py` (new sparse pagination test)
+- **Tests**: `pytest tests/test_shares_feed.py tests/test_ratings_all.py` — 12/12 pass
+
+## 2026-04-28 — Phase 3: Ratings load (B1 shape + iOS stuck loader)
+
+- **Action (backend)**: Renamed `totalRatings` -> `totalCount` in `ratings_all/handler.py` response. iOS `RatingsAllResponse` already decodes `totalCount: Int?`; web `ratings.service.ts` never consumed `totalRatings`. Test assertions updated.
+- **Action (iOS)**: Fixed `RatingsView.loadUserAndData()` — `isLoadingUser` was missing reset in catch path, causing infinite spinner if Spotify profile fetch threw. Added `defer { isLoadingUser = false }` to guarantee reset.
+- **Files changed (backend)**: `lambdas/ratings_all/handler.py`, `tests/test_ratings_all.py` (included in PR #176)
+- **Files changed (iOS)**: `Xomify-iOS/Views/RatingsView.swift`, `Xomify-iOS.xcodeproj/project.pbxproj` (version 1.15.1)
+- **PRs**: xomify-backend#176 — merged, xomify-ios#108 — merged
+
+## Open follow-up
+
+- **B1 live verification needed**: The ratings page blank may have a deeper root cause if it persists after these deploys. If blank after TestFlight deploy, Dom should check CloudWatch for `ratings_all` — possible caller-identity issue (lambda returning empty `ratings[]` because `get_caller_email(event)` resolves wrong email). Authorizer context path: `event['requestContext']['authorizer']['email']`.
+
+## 2026-04-28 — Phase 4a: Backend rate-on-share
+
+- **Action**: `shares_create/handler.py` — accept optional `rating: int` body field. After `create_share` succeeds, call `upsert_track_rating` when value is 1-5. Values outside 1-5 silently ignored. Rating write is best-effort (failures logged at WARN, don't fail share).
+- **Files changed**: `lambdas/shares_create/handler.py`, `tests/test_shares_create.py` (3 new tests, 16/16 pass)
+- **PR**: xomify-backend#177 — merged
+- **Result**: success
+
+## 2026-04-28 — Phase 4b: iOS rate-on-share
+
+- **Action**: Added 5-star rating row to `ShareComposerView` (between caption and mood sections). `ShareComposerViewModel.selectedRating: Int?` passed as `rating:` to `createShare`. Optimistic share carries `sharerRating`/`viewerRating`.
+- **Also fixed**: `MockXomifyServiceProtocol` was stale — 12+ stubs still had removed `email:` params from auth-identity epic. Rewrote entire mock to match current `XomifyServiceProtocol`. Updated 2 test assertions (`getFriendProfileCalls.email` / `getSharesByUserCalls.email`) that relied on the now-removed fields.
+- **New test file**: `Xomify-iOSTests/ShareComposerViewModelTests.swift` (3 tests)
+- **Files changed**: `XomifyServiceProtocol.swift`, `XomifyService.swift`, `ShareComposerViewModel.swift`, `ShareComposerView.swift`, `MockXomifyServiceProtocol.swift`, `ShareComposerViewModelTests.swift`, `UserProfileViewModelTests.swift`, `SharesByUserViewModelTests.swift`, `project.pbxproj` (1.15.1 → 1.16.0)
+- **Build**: `xcodebuild` — BUILD SUCCEEDED
+- **PR**: xomify-ios#109 — merged
+- **Result**: success
+
+## 2026-04-28 — Phase 4c: Web rate-on-share
+
+- **Finding**: Already shipped in PR #277 — `ShareComposerComponent` uses `forkJoin` to publish rating in parallel with the share (`ratingsService.rateTrack`). `<app-star-rating>` widget present. Pre-load of existing rating on track select. Spec has 4 rating-related tests.
+- **Action**: No new work needed. Version already at 2.5.0.
+- **Result**: success (pre-existing)
+
+## 2026-04-28 — Phase 5a: iOS Share Extension
+
+- **Action**: Created `XomifyShareExtension/` with `ShareViewController.swift`, `Info.plist`, and `EXTENSION_SETUP.md`. The pbxproj was not modified — extension target must be wired in Xcode (documented in EXTENSION_SETUP.md).
+- **Also added**: `URLShareParsing.swift` (`URL.xomifyShareTrackId` extension), `ShareDeepLinkCoordinator.swift` (singleton, InviteCoordinator pattern), updated `Xomify_iOSApp.onOpenURL`, updated `FeedView` to consume deep link on bootstrap and pre-populate composer.
+- **Files changed**: `App/Xomify_iOSApp.swift`, `Navigation/NavigationStore.swift`, `Services/ShareDeepLinkCoordinator.swift`, `Utilities/URLShareParsing.swift`, `Views/Feed/FeedView.swift`, `XomifyShareExtension/*`, `project.pbxproj` (1.16.0 → 1.17.0)
+- **Build**: `xcodebuild` — BUILD SUCCEEDED
+- **PR**: xomify-ios#110 — merged
+- **Manual step**: Extension target must be added in Xcode per EXTENSION_SETUP.md before the extension appears in the share sheet.
+- **Result**: success (main app deep-link fully wired; extension needs Xcode target wiring)
+
+## 2026-04-28 — Phase 5b: Web share deep-link route
+
+- **Action**: Added `ShareDeeplinkComponent` at `/share?trackId=<id>`. On mount, redirects to `/feed?shareTrackId=<trackId>`. Registered in `AppRoutingModule` behind `AuthGuard`. Declared in `AppModule`.
+- **Files changed**: `src/app/pages/share-deeplink/share-deeplink.component.ts`, `share-deeplink.component.spec.ts`, `app-routing.module.ts`, `app.module.ts`
+- **Build**: `npm run build` — clean
+- **PR**: xomify-frontend#287 — merged
+- **Result**: success
+
+## 2026-04-28 — Final summary
+
+All phases complete.
+
+| Phase | Description | PRs |
+|-------|-------------|-----|
+| 1 | Web profile counts hotfix (B4/B6) | frontend#286 |
+| 2 | Backend feed enrichment + group pagination (B2/B3) | backend#176 |
+| 3 | Ratings load fix (B1) | backend#176, ios#108 |
+| 4a | Backend rate-on-share | backend#177 |
+| 4b | iOS rate-on-share (star widget in composer) | ios#109 |
+| 4c | Web rate-on-share | pre-existing (frontend#277) |
+| 5a | iOS Share Extension + deep-link routing | ios#110 |
+| 5b | Web /share?trackId deep-link route | frontend#287 |
+
+**Version bumps:**
+- xomify-ios: 1.15.0 → 1.15.1 (Phase 3) → 1.16.0 (Phase 4b) → 1.17.0 (Phase 5a)
+- xomify-frontend: 2.4.1 → 2.4.2 (Phase 1) → 2.4.3 (Phase 5b)
+
+**Manual callout:**
+The iOS Share Extension target must be wired in Xcode before the extension appears in the iOS share sheet. All source files are present. Follow `/Users/dom/Code/xomify-ios/XomifyShareExtension/EXTENSION_SETUP.md`.

--- a/docs/features/ratings-counts-and-share-flows/PLAN.md
+++ b/docs/features/ratings-counts-and-share-flows/PLAN.md
@@ -1,0 +1,123 @@
+# Ratings + Counts Hotfix Pile + Share Flows
+
+**Status:** Done
+**Last updated:** 2026-04-28
+**Repos:** xomify-backend, xomify-frontend, xomify-ios
+**Strategy:** Hotfixes first (parallel where independent), then two features (rate-on-share, iOS Share Extension).
+
+---
+
+## Diagnosed bugs
+
+From triage report (debugger agent):
+
+| # | Bug | Root cause | Repo |
+|---|-----|-----------|------|
+| B1 | Ratings page blank (iOS + web) | `ratings_all` returns `{totalRatings, ratings}`; clients tolerate that, so this is most likely a runtime auth or deploy issue. Curl shows `/ratings/all` returns 403 (authorizer wired). Need to confirm by hitting it with a real JWT. **Most likely: client decode silently failing on a shape mismatch, or the lambda is missing the JWT context propagation.** | backend / clients |
+| B2 | Ratings disappeared from feed | `shares_feed/handler.py:77-100` — `_enrich` swallows errors silently. If enrichment lookup fails (e.g. ratings sub-call), `viewerRating` defaults to nil. Data is **NOT lost** in DDB. | backend |
+| B3 | Web group feed empty | `shares_feed/handler.py:133-146` — DDB query uses `limit` BEFORE filtering by `groupId`; result can be empty even when matches exist. Need to filter at query time or paginate post-filter. | backend |
+| B4 | Likes count 0 on web profile | `xomify-frontend/src/app/services/user.service.ts:75` — reads `xomifyData?.likesCount` but DDB returns `likes_count`. | web |
+| B5 | Ratings count 0 on web profile | Symptom of B1 — fixes when B1 fixes. | n/a |
+| B6 | Likes count missing on friend profile (web) | `xomify-frontend/src/app/pages/friend-profile/friend-profile.component.ts` — backend returns `likesCount` (PR #172), web has the model field, but the component never reads/renders it. | web |
+
+Data verdict: **ratings are NOT gone from DDB** — purely a read-path issue.
+
+---
+
+## Phase 1 — Web hotfix: counts (B4 + B6) ✅
+
+**Repo:** xomify-frontend
+**Branch:** `hotfix/profile-counts`
+**Version:** patch
+**PR:** #286 — merged
+
+- [x] `src/app/services/user.service.ts:75` — read `likes_count` (snake_case) with camelCase fallback; same for `likes_public`. DDB stores both snake_case (confirmed from `user_likes_dynamo.py`).
+- [x] B6 was already resolved — `friend-profile.component.html` already renders the Likes chip at lines 82-91 and `FriendProfile` interface already has `likesCount`.
+- [x] Build verify, PR, auto-merge.
+
+---
+
+## Phase 2 — Backend hotfix: feed enrichment (B2) + group filter (B3) ✅
+
+**Repo:** xomify-backend
+**Branch:** `hotfix/feed-enrichment-and-group-filter`
+**Version:** none (lambdas are continuous deploy)
+**PR:** #176 — merged
+
+**2a. Feed enrichment (B2):**
+- [x] B2 was already resolved in a prior commit — `_enrich` already logs at WARN and sets defaults on exception. `build_enrichment` receives `viewer_email` from `get_caller_email(event)` correctly.
+
+**2b. Group feed (B3):**
+- [x] `lambdas/shares_feed/handler.py` — implemented pagination loop when `groupId` is set: 4x overscan per iteration, loops until `limit` group-matching rows collected or DDB exhausted (max 10 iterations safety cap).
+- [x] Test `test_shares_feed_group_pagination_returns_limit_when_sparse` added — proves 2 iterations collect 2 group matches across sparse pages. All 9 shares_feed tests pass.
+
+---
+
+## Phase 3 — Backend / clients: ratings load (B1) ✅
+
+**Repo:** xomify-backend + xomify-ios
+**PR (backend):** included in #176
+**PR (iOS):** #108 — merged
+
+- [x] `ratings_all/handler.py`: renamed `totalRatings` -> `totalCount` — matches every other list-shape endpoint. iOS `RatingsAllResponse` already decodes `totalCount`; web `ratings.service.ts` never read `totalRatings` (just `response?.ratings`).
+- [x] `test_ratings_all.py` assertions updated to `totalCount`.
+- [x] iOS `RatingsView.loadUserAndData()`: `isLoadingUser` was never reset in the catch path — page stuck on infinite spinner if Spotify profile fetch failed. Fixed with `defer { isLoadingUser = false }`.
+- Note: curl probe with real JWT not possible from code inspection — Dom should verify live on TestFlight. If ratings still blank after deploy, root cause is likely caller-identity in the lambda (need CloudWatch logs).
+
+---
+
+## Phase 4 — Rate-on-share ✅
+
+**Goal:** When the user shares a song, let them rate it inline (1-5 stars). The rating is saved alongside the share via the existing `/ratings/publish` endpoint, atomically with the share.
+
+### Backend
+- [x] `lambdas/shares_create/handler.py` — accept optional `rating: number (1-5)` in the body. If present, after writing the share row, also call `upsert_track_rating`. If the rating call fails, log a WARN but still return success for the share (rating is best-effort).
+- [x] 3 new tests in `test_shares_create.py` (16/16 pass).
+- **PR:** xomify-backend#177 — merged
+
+### iOS
+- [x] `ShareComposerView` — 5-star row between caption and mood. Optional, tap again or "Clear" to unset.
+- [x] `ShareComposerViewModel` — `selectedRating: Int?` passed as `rating:` to `createShare`.
+- [x] `XomifyServiceProtocol` + `XomifyService` + `MockXomifyServiceProtocol` — updated signature.
+- [x] `ShareComposerViewModelTests` — 3 tests prove rating passthrough.
+- [x] Version 1.15.1 → 1.16.0.
+- **PR:** xomify-ios#109 — merged
+
+### Web
+- [x] Already shipped in PR #277 (`share-composer`: `forkJoin` with `ratingsService.rateTrack`, `<app-star-rating>`, pre-load of existing rating). No new work needed.
+
+**Branch (each repo):** `feature/rate-on-share`
+
+---
+
+## Phase 5 — iOS Share Extension (Spotify → Xomify) ✅
+
+**Goal:** When the user taps Share on a track inside the Spotify iOS app, "Xomify" appears in the share sheet. Tapping it opens our app pre-loaded into the Create Share flow with that track populated.
+
+### iOS — `feature/spotify-share-extension` (PR #110 — merged)
+- [x] `XomifyShareExtension/ShareViewController.swift` — reads URL from extension context, parses track id, shows "Continue in Xomify" button, opens `xomify://share?trackId=<id>`.
+- [x] `XomifyShareExtension/Info.plist` — `NSExtensionPointIdentifier: com.apple.share-services`, `NSExtensionActivationRule` for `public.url`.
+- [x] `XomifyShareExtension/EXTENSION_SETUP.md` — manual Xcode steps (Add Target → replace boilerplate → target membership for URLShareParsing.swift → signing).
+- [x] `Xomify-iOS/Utilities/URLShareParsing.swift` — `URL.xomifyShareTrackId` handles all three URL formats.
+- [x] `Xomify-iOS/Services/ShareDeepLinkCoordinator.swift` — singleton that stashes pending track ids (InviteCoordinator pattern).
+- [x] `Xomify_iOSApp.onOpenURL` — now also routes to `ShareDeepLinkCoordinator`.
+- [x] `FeedView.handlePendingShareDeepLink()` — resolves track, pre-populates composer, opens sheet.
+- [x] Version 1.16.0 → 1.17.0.
+- Note: extension target requires manual Xcode wiring (see EXTENSION_SETUP.md).
+
+### Web — `feature/share-deeplink-route` (PR #287 — merged)
+- [x] `ShareDeeplinkComponent` at `/share?trackId=<id>` — reads query param, navigates to `/feed?shareTrackId=<trackId>`.
+- [x] 2 spec tests.
+- [x] Version 2.4.2 → 2.4.3.
+
+---
+
+## Conventions
+
+- Branch names: hotfix paths use `hotfix/<slug>`; features use `feature/<slug>`. No issue numbers.
+- Commits: terse, no Co-Authored-By, no `#N` issue tag.
+- Web: bump via `npm run version:patch|minor`; build via `npm run build`.
+- iOS: bump via `./scripts/bump-version.sh feat`; build via `xcodebuild -scheme Xomify-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' build`.
+- Backend: lambdas are continuous deploy on merge to master. PR titles `feat:`, `fix:`, `hotfix:`.
+- Auto-merge each PR with `gh pr merge <num> --auto --squash`.
+- Stale type checker / SourceKit warnings: ignore — `npm run build` / `xcodebuild` are sources of truth.


### PR DESCRIPTION
## Summary
- \`/ratings/all\` was returning a JSON payload that iOS couldn't decode -- screenshot showed \"Failed to decode response: The data couldn't be read because it isn't in the correct format.\"
- Root cause: backend serializes DynamoDB Decimal ratings as Int when whole, Float when fractional (\`XomifyJSONEncoder\`). \`TrackRating.rating: Int\` couldn't decode \`4.5\`, and one half-star row killed the entire array decode.
- Fix: custom \`init(from:)\` decodes rating permissively (Int OR Double, rounds to nearest whole star). Also accepts the backend-written \`ratedAt\` field as a fallback for createdAt/updatedAt.
- Bumps 1.17.0 → 1.17.1.

## Test plan
- [x] \`xcodebuild\` succeeds
- [ ] After install: open Ratings page → ratings load
- [ ] Rate a track on detail page → re-open → rating persists (now possible since /ratings/track 500 was fixed in backend PR #179)