### PR TITLE
fix: suppress duplicate rating chip on own posts

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -500,7 +500,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -529,7 +529,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.ShareFromSpotify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.ShareFromSpotify;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -587,7 +587,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.XomifyShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -616,7 +616,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.2;
+				MARKETING_VERSION = 1.17.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.XomifyShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -144,7 +144,9 @@ struct ShareCardView: View {
             }
             Spacer()
 
-            if let rating = viewModel.share.sharerRating {
+            // Suppress on own posts -- the actions row already shows the
+            // viewer's myRating chip, which is the same value here.
+            if !isOwnPost, let rating = viewModel.share.sharerRating {
                 HStack(spacing: 3) {
                     Image(systemName: "star.fill")
                         .font(.caption2)


### PR DESCRIPTION
## Summary
- Feed card rendered both a \`sharerRating\` chip (header) and the viewer's \`myRating\` button (actions row). On your own posts these are the same value — redundant.
- Skip the header chip when \`isOwnPost\` is true. Other people's posts still show their rating in the header.
- Pairs with backend PR #180 (track-rating fallback in feed enrichment) so rated-on-feed values now persist across refreshes.
- 1.17.2 → 1.17.3.

## Test plan
- [x] Build succeeds
- [ ] Open feed → rate a track on a friend's post → reload → chip + actions row both show
- [ ] Open feed → rate a track on your own post → only one chip visible (actions row)