### PR TITLE
feat: share listened state (queue/play marks listened, surface viewerHasListened in feed card)

### DIFF
--- a/Xomify-iOS.xcodeproj/project.pbxproj
+++ b/Xomify-iOS.xcodeproj/project.pbxproj
@@ -402,7 +402,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.4;
+				MARKETING_VERSION = 1.18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.17.4;
+				MARKETING_VERSION = 1.18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Xomware.Xomify";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -468,7 +468,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.4;
+				MARKETING_VERSION = 1.18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.XomifyShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -497,7 +497,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.17.4;
+				MARKETING_VERSION = 1.18.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomify.XomifyShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomify-iOS/Models/SocialModels.swift
+++ b/Xomify-iOS/Models/SocialModels.swift
@@ -188,6 +188,17 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
     let viewerRating: Int?
     let sharerRating: Int?
 
+    /// Whether the viewer has played or queued this share at least once.
+    /// Backed by the `shares_listened` table; populated by the same enrichment
+    /// pass that surfaces `viewerHasQueued`. Defaults to `false` when the row
+    /// is absent so legacy / cold-cache decodes don't fail.
+    let viewerHasListened: Bool
+
+    /// Total distinct viewers who have marked this share as listened. Mirrors
+    /// the per-viewer `viewerHasListened` flag on the aggregate side. Defaults
+    /// to `0` when the field is absent.
+    let listenerCount: Int
+
     // Target audience (xomify-backend#138). Legacy rows omit both fields and
     // are treated as public shares with no group targets.
     let groupIds: [String]
@@ -262,6 +273,8 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         viewerHasQueued = try c.decodeIfPresent(Bool.self, forKey: .viewerHasQueued) ?? false
         viewerRating    = try c.decodeIfPresent(Int.self, forKey: .viewerRating)
         sharerRating    = try c.decodeIfPresent(Int.self, forKey: .sharerRating)
+        viewerHasListened = try c.decodeIfPresent(Bool.self, forKey: .viewerHasListened) ?? false
+        listenerCount   = try c.decodeIfPresent(Int.self, forKey: .listenerCount) ?? 0
         groupIds        = try c.decodeIfPresent([String].self, forKey: .groupIds) ?? []
         isPublic        = try c.decodeIfPresent(Bool.self, forKey: .isPublic) ?? true
         commentCount    = try c.decodeIfPresent(Int.self, forKey: .commentCount) ?? 0
@@ -296,7 +309,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         isPublic: Bool = true,
         commentCount: Int = 0,
         reactionCounts: [String: Int] = [:],
-        viewerReactions: [String] = []
+        viewerReactions: [String] = [],
+        viewerHasListened: Bool = false,
+        listenerCount: Int = 0
     ) {
         self.shareId = shareId
         self.sharedBy = sharedBy
@@ -320,6 +335,8 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         self.commentCount = commentCount
         self.reactionCounts = reactionCounts
         self.viewerReactions = viewerReactions
+        self.viewerHasListened = viewerHasListened
+        self.listenerCount = listenerCount
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -330,6 +347,7 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
         case groupIds
         case isPublic = "public"
         case commentCount, reactionCounts, viewerReactions
+        case viewerHasListened, listenerCount
     }
 
     /// Convenience for optimistic UI patches — produce a new Share with the
@@ -346,7 +364,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
             groupIds: groupIds, isPublic: isPublic,
             commentCount: commentCount,
             reactionCounts: counts,
-            viewerReactions: viewerReactions
+            viewerReactions: viewerReactions,
+            viewerHasListened: viewerHasListened,
+            listenerCount: listenerCount
         )
     }
 
@@ -369,7 +389,9 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
             groupIds: groupIds, isPublic: isPublic,
             commentCount: commentCount,
             reactionCounts: reactionCounts,
-            viewerReactions: viewerReactions
+            viewerReactions: viewerReactions,
+            viewerHasListened: viewerHasListened,
+            listenerCount: listenerCount
         )
     }
 
@@ -386,7 +408,37 @@ struct Share: Codable, Identifiable, Sendable, Hashable {
             groupIds: groupIds, isPublic: isPublic,
             commentCount: newCount,
             reactionCounts: reactionCounts,
-            viewerReactions: viewerReactions
+            viewerReactions: viewerReactions,
+            viewerHasListened: viewerHasListened,
+            listenerCount: listenerCount
+        )
+    }
+
+    /// Optimistic patch for "viewer just queued / played this share". Flips
+    /// `viewerHasListened` on and bumps `listenerCount` by one when the flag
+    /// was previously false so the UI count stays in sync without a refetch.
+    /// Idempotent — repeat calls when already listened are no-ops.
+    func withViewerHasListened(_ listened: Bool) -> Share {
+        let wasListened = viewerHasListened
+        let nextCount: Int = {
+            if listened && !wasListened { return listenerCount + 1 }
+            if !listened && wasListened { return max(0, listenerCount - 1) }
+            return listenerCount
+        }()
+        return Share(
+            shareId: shareId, sharedBy: sharedBy, sharedAt: sharedAt,
+            trackId: trackId, trackUri: trackUri, trackName: trackName,
+            artistName: artistName, albumName: albumName, albumArtUrl: albumArtUrl,
+            caption: caption, moodTag: moodTag, genreTags: genreTags,
+            queuedCount: queuedCount, ratedCount: ratedCount,
+            viewerHasQueued: viewerHasQueued, viewerRating: viewerRating,
+            sharerRating: sharerRating,
+            groupIds: groupIds, isPublic: isPublic,
+            commentCount: commentCount,
+            reactionCounts: reactionCounts,
+            viewerReactions: viewerReactions,
+            viewerHasListened: listened,
+            listenerCount: nextCount
         )
     }
 }
@@ -474,6 +526,33 @@ struct ReactionResponse: Codable, Sendable {
 
 struct ShareInteractionResponse: Codable, Sendable {
     let success: Bool?
+}
+
+// MARK: - Mark Listened
+//
+// Backend contract: `POST /shares/listened`. Body
+// `{ shareIds: [...], source: "queue" | "play" }`. Response lists the ids the
+// backend actually wrote (`listened`) versus the ones it dropped (`skipped` —
+// e.g. unknown share, already-listened, malformed id).
+
+/// Source tag for `XomifyService.markListened`. Encodes to lowercase string —
+/// matches the backend `source` enum exactly.
+enum ListenSource: String, Codable, Sendable {
+    case queue
+    case play
+}
+
+/// Response body for `POST /shares/listened`.
+struct MarkListenedResponse: Codable, Sendable {
+    let ok: Bool
+    let listened: [String]
+    let skipped: [String]
+
+    init(ok: Bool, listened: [String] = [], skipped: [String] = []) {
+        self.ok = ok
+        self.listened = listened
+        self.skipped = skipped
+    }
 }
 
 // MARK: - Invite Create Response

--- a/Xomify-iOS/Services/QueueActionController.swift
+++ b/Xomify-iOS/Services/QueueActionController.swift
@@ -13,6 +13,12 @@ import UIKit
 /// Errors are routed to a single `toast` string that `QueueToastHost` renders
 /// at `MainShell`. Per-URI `isQueuing(uri:)` lets buttons show a spinner +
 /// disable themselves while a queue attempt is in flight.
+///
+/// When the queue/play action originated from a feed share, callers pass a
+/// non-nil `shareId` and the controller fires a best-effort
+/// `markListened` write so the share's "viewer has listened" state flips
+/// for the next feed refresh. Failure is silent — a failed listener-write
+/// is invisible to the user, who already saw the queue/play succeed.
 @Observable
 @MainActor
 final class QueueActionController {
@@ -28,9 +34,14 @@ final class QueueActionController {
     private var inFlight: Set<String> = []
 
     private let spotifyService: SpotifyQueueing
+    private let xomifyService: XomifyServiceProtocol
 
-    init(spotifyService: SpotifyQueueing = SpotifyPlaybackCoordinator.shared) {
+    init(
+        spotifyService: SpotifyQueueing = SpotifyPlaybackCoordinator.shared,
+        xomifyService: XomifyServiceProtocol = XomifyService.shared
+    ) {
         self.spotifyService = spotifyService
+        self.xomifyService = xomifyService
     }
 
     func isQueuing(uri: String) -> Bool {
@@ -40,7 +51,12 @@ final class QueueActionController {
     /// Queue a track. Shows a success toast on 2xx, an actionable error
     /// message on failure. Safe to call while another queue is in flight for
     /// a different URI.
-    func queue(uri: String, trackName: String? = nil) async {
+    ///
+    /// When `shareId` is non-nil the controller also fires a best-effort
+    /// `markListened` write tagged `source: queue`. Pass `nil` from contexts
+    /// that aren't a share (track rows in Library, taste stage, etc.) to skip
+    /// the listener-write — the backend has nothing to associate it with.
+    func queue(uri: String, trackName: String? = nil, shareId: String? = nil) async {
         guard !uri.isEmpty else {
             toast = "Couldn't queue — missing track URI."
             return
@@ -57,6 +73,7 @@ final class QueueActionController {
             } else {
                 toast = "Queued on Spotify"
             }
+            markListenedFireAndForget(shareId: shareId, source: .queue)
         } catch SpotifyServiceError.noActiveDevice {
             handleNoDevice(uri: uri, action: "queue")
         } catch let error as SpotifyServiceError {
@@ -69,7 +86,10 @@ final class QueueActionController {
     /// Start playback on the user's active Spotify device. Falls back to
     /// deep-linking into the Spotify app when no device is active so the user
     /// can trivially resume a session.
-    func play(uri: String, trackName: String? = nil) async {
+    ///
+    /// When `shareId` is non-nil the controller also fires a best-effort
+    /// `markListened` write tagged `source: play`.
+    func play(uri: String, trackName: String? = nil, shareId: String? = nil) async {
         guard !uri.isEmpty else {
             toast = "Couldn't play — missing track URI."
             return
@@ -86,12 +106,28 @@ final class QueueActionController {
             } else {
                 toast = "Playing on Spotify"
             }
+            markListenedFireAndForget(shareId: shareId, source: .play)
         } catch SpotifyServiceError.noActiveDevice {
             handleNoDevice(uri: uri, action: "play")
         } catch let error as SpotifyServiceError {
             toast = error.errorDescription
         } catch {
             toast = error.localizedDescription
+        }
+    }
+
+    /// Best-effort `POST /shares/listened`. Errors are logged and swallowed —
+    /// the user already saw the queue/play succeed and a failed listener
+    /// write should not surface as a user-facing toast.
+    private func markListenedFireAndForget(shareId: String?, source: ListenSource) {
+        guard let shareId, !shareId.isEmpty else { return }
+        let service = xomifyService
+        Task {
+            do {
+                _ = try await service.markListened(shareIds: [shareId], source: source)
+            } catch {
+                print("⚠️ markListened failed for \(shareId) (source: \(source.rawValue)): \(error.localizedDescription)")
+            }
         }
     }
 

--- a/Xomify-iOS/Services/XomifyService.swift
+++ b/Xomify-iOS/Services/XomifyService.swift
@@ -234,6 +234,50 @@ actor XomifyService {
         ])
     }
 
+    /// Mark one or more shares as listened by the caller.
+    ///
+    /// Server cap is 25 ids per call; this client mirrors that and chunks
+    /// larger batches sequentially so a future caller that hands in a longer
+    /// list still gets the full write-through. The aggregate response merges
+    /// the per-chunk `listened` / `skipped` arrays.
+    ///
+    /// Empty `shareIds` short-circuits — no network call, returns an empty
+    /// success response. The viewer-level write path is fire-and-forget from
+    /// callers (queue/play already succeeded), so this method intentionally
+    /// surfaces errors via `throws` rather than swallowing them — let the
+    /// caller decide whether to log or ignore.
+    @discardableResult
+    func markListened(
+        shareIds: [String],
+        source: ListenSource = .queue
+    ) async throws -> MarkListenedResponse {
+        guard !shareIds.isEmpty else {
+            return MarkListenedResponse(ok: true, listened: [], skipped: [])
+        }
+
+        let chunkSize = 25
+        var listened: [String] = []
+        var skipped: [String] = []
+        var ok = true
+
+        for chunkStart in stride(from: 0, to: shareIds.count, by: chunkSize) {
+            let chunk = Array(shareIds[chunkStart..<min(chunkStart + chunkSize, shareIds.count)])
+            let body: [String: Any] = [
+                "shareIds": chunk,
+                "source": source.rawValue
+            ]
+            let response: MarkListenedResponse = try await network.xomifyPost(
+                "/shares/listened",
+                body: body
+            )
+            ok = ok && response.ok
+            listened.append(contentsOf: response.listened)
+            skipped.append(contentsOf: response.skipped)
+        }
+
+        return MarkListenedResponse(ok: ok, listened: listened, skipped: skipped)
+    }
+
     /// Create a friend invite code
     func createInvite() async throws -> InviteCreateResponse {
         try await network.xomifyPost("/invites/create", body: [:])

--- a/Xomify-iOS/Services/XomifyServiceProtocol.swift
+++ b/Xomify-iOS/Services/XomifyServiceProtocol.swift
@@ -51,6 +51,14 @@ protocol XomifyServiceProtocol: Sendable {
         sharedAt: String?
     ) async throws -> ShareDetailResponse
 
+    /// Mark shares as listened by the caller. Empty `shareIds` returns a
+    /// no-op success without hitting the network.
+    @discardableResult
+    func markListened(
+        shareIds: [String],
+        source: ListenSource
+    ) async throws -> MarkListenedResponse
+
     // MARK: - Friend profile (used by UserProfileViewModel)
 
     func getFriendProfile(

--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -88,7 +88,9 @@ struct FeedRefinement: Equatable, Sendable {
     /// Selected authors (emails). Empty set = no author filter.
     var authors: Set<String> = []
     var dateWindow: DateWindow = .anytime
-    /// When true, hide shares the viewer has already queued on Spotify.
+    /// When true, hide shares the viewer has already listened to (queued or
+    /// played). Backed by `Share.viewerHasListened` rather than the older
+    /// queued-only signal so a play-via-Spotify also counts as listened.
     var onlyUnlistened: Bool = false
     var sortOrder: SortOrder = .newest
 
@@ -408,7 +410,7 @@ final class FeedViewModel {
             if !authors.isEmpty, !authors.contains(share.sharedBy) {
                 return false
             }
-            if onlyUnlistened, share.viewerHasQueued {
+            if onlyUnlistened, share.viewerHasListened {
                 return false
             }
             if let minDate = window, let shareDate = share.sharedAtDate, shareDate < minDate {

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -141,6 +141,17 @@ final class ShareCardViewModel {
         }
     }
 
+    // MARK: - Listened
+
+    /// Flip `viewerHasListened` on locally so the card hides its "Not heard"
+    /// badge the instant the user taps Play / Queue, without waiting for the
+    /// backend write to come back. The actual backend write is fired by
+    /// `QueueActionController` — this is purely an optimistic UI patch.
+    func markListenedOptimistically() {
+        guard !share.viewerHasListened else { return }
+        share = share.withViewerHasListened(true)
+    }
+
     // MARK: - Reactions
 
     /// Toggle a reaction on/off. Optimistic patch via `withReactionSummary`,

--- a/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift
@@ -306,7 +306,15 @@ final class ShareComposerViewModel {
                 viewerRating: capturedRating,
                 sharerRating: capturedRating,
                 groupIds: capturedGroupIds,
-                isPublic: capturedIsPublic
+                isPublic: capturedIsPublic,
+                commentCount: 0,
+                reactionCounts: [:],
+                viewerReactions: [],
+                // Author has obviously heard their own track — server backfill
+                // sets this on insert; mirror it locally so the optimistic
+                // copy doesn't briefly show a "Not heard" badge to the author.
+                viewerHasListened: true,
+                listenerCount: 1
             )
         } catch {
             submitError = error.localizedDescription

--- a/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
+++ b/Xomify-iOS/Views/Feed/FeedRefinementSheet.swift
@@ -164,10 +164,10 @@ struct FeedRefinementSheet: View {
             sectionHeader("Listening status", icon: "headphones")
             Toggle(isOn: $viewModel.refinement.onlyUnlistened) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Only show posts I haven't queued")
+                    Text("Only show posts I haven't heard")
                         .font(.subheadline)
                         .foregroundStyle(.white)
-                    Text("Hides anything you've already added to your Spotify queue.")
+                    Text("Hides shares you've already played or queued on Spotify.")
                         .font(.caption)
                         .foregroundStyle(.gray)
                 }

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -329,7 +329,9 @@ struct ShareCardView: View {
             TrackActionsMenu(
                 track: makeTrackForActions(),
                 style: .icon,
-                onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil
+                onDelete: (isOwnPost && onDelete != nil) ? { showDeleteConfirm = true } : nil,
+                shareId: viewModel.share.shareId,
+                onListened: { viewModel.markListenedOptimistically() }
             )
             rateButton
             commentButton
@@ -342,10 +344,34 @@ struct ShareCardView: View {
                 }
             )
             Spacer(minLength: 0)
+            if !viewModel.share.viewerHasListened && !isOwnPost {
+                notHeardBadge
+            }
             if viewModel.displayedQueueCount > 0 {
                 queueCountChip
             }
         }
+    }
+
+    /// Visual hint that the viewer has never queued or played this share.
+    /// Backed by `share.viewerHasListened` (server-enriched, optimistically
+    /// flipped on Play / Queue tap). Suppressed on the viewer's own posts —
+    /// the backend backfill marks the author as listened, but local
+    /// optimistic copies (composer prepend) won't have it set yet.
+    private var notHeardBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "headphones")
+                .font(.caption2)
+            Text("Not heard")
+                .font(.caption2)
+                .fontWeight(.semibold)
+        }
+        .foregroundStyle(Color.xomifyPurple)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.xomifyPurple.opacity(0.15))
+        .clipShape(Capsule())
+        .accessibilityLabel("You haven't listened to this yet")
     }
 
     /// Compact comment-thread shortcut. Mirrors how Instagram/Twitter surface

--- a/Xomify-iOS/Views/Feed/ShareDetailView.swift
+++ b/Xomify-iOS/Views/Feed/ShareDetailView.swift
@@ -284,7 +284,11 @@ struct ShareDetailView: View {
 
     private var actionRow: some View {
         HStack(spacing: 12) {
-            TrackActionsMenu(track: makeTrackForActions(), style: .pill)
+            TrackActionsMenu(
+                track: makeTrackForActions(),
+                style: .pill,
+                shareId: viewModel.share.shareId
+            )
             rateButton
             Spacer()
         }

--- a/Xomify-iOS/Views/Shared/QueueButton.swift
+++ b/Xomify-iOS/Views/Shared/QueueButton.swift
@@ -18,11 +18,22 @@ struct QueueButton: View {
     let trackName: String?
     var style: Style = .icon
 
+    /// When the button is rendered for a feed share, pass the share id so the
+    /// backend listener-write can fire after a successful queue. Nil for
+    /// non-share contexts (Library, taste stage, etc.).
+    var shareId: String? = nil
+
+    /// Fires on tap (when `shareId` is non-nil) so the host can optimistically
+    /// flip the share's `viewerHasListened` flag without waiting on the
+    /// backend.
+    var onListened: (() -> Void)? = nil
+
     @State private var queueAction = QueueActionController.shared
 
     var body: some View {
         Button {
-            Task { await queueAction.queue(uri: uri, trackName: trackName) }
+            if shareId != nil { onListened?() }
+            Task { await queueAction.queue(uri: uri, trackName: trackName, shareId: shareId) }
         } label: {
             switch style {
             case .icon:

--- a/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
+++ b/Xomify-iOS/Views/Shared/TrackActionsMenu.swift
@@ -31,6 +31,18 @@ struct TrackActionsMenu: View {
     /// affordance as the standard track actions instead of a second button.
     var onDelete: (() -> Void)? = nil
 
+    /// Set by share-context callers (feed card, share detail) so the play /
+    /// queue actions can plumb a `shareId` into `QueueActionController` for
+    /// the listener write. Nil for non-share contexts (track rows in Library,
+    /// taste stage, etc.) which intentionally skip the listener write.
+    var shareId: String? = nil
+
+    /// Optional callback fired the moment the viewer taps Play or Add to
+    /// Queue. Used by `ShareCardView` to optimistically flip
+    /// `viewerHasListened` so the "Not heard" badge disappears immediately,
+    /// before the backend write returns. Fires on `shareId != nil` only.
+    var onListened: (() -> Void)? = nil
+
     @State private var queueAction = QueueActionController.shared
     @State private var playlistBuilder = PlaylistBuilderManager.shared
     @State private var isComposerShown = false
@@ -38,14 +50,16 @@ struct TrackActionsMenu: View {
     var body: some View {
         Menu {
             Button {
-                Task { await queueAction.play(uri: resolvedUri, trackName: track.name) }
+                if shareId != nil { onListened?() }
+                Task { await queueAction.play(uri: resolvedUri, trackName: track.name, shareId: shareId) }
             } label: {
                 Label("Play now", systemImage: "play.circle.fill")
             }
             .disabled(resolvedUri.isEmpty || queueAction.isQueuing(uri: resolvedUri))
 
             Button {
-                Task { await queueAction.queue(uri: resolvedUri, trackName: track.name) }
+                if shareId != nil { onListened?() }
+                Task { await queueAction.queue(uri: resolvedUri, trackName: track.name, shareId: shareId) }
             } label: {
                 Label(
                     queueAction.isQueuing(uri: resolvedUri) ? "Queueing…" : "Add to queue",

--- a/Xomify-iOSTests/MarkListenedTests.swift
+++ b/Xomify-iOSTests/MarkListenedTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import Xomify_iOS
+
+/// Coverage for the listened-state contract:
+/// - `Share` decode falls back to `false` / `0` when the new fields are absent
+///   (legacy / cold-cache responses must keep decoding cleanly).
+/// - `Share.withViewerHasListened` flips the flag and bumps `listenerCount`
+///   exactly once when called twice (idempotent).
+/// - `MockXomifyServiceProtocol.markListened` records the call exactly as
+///   passed and short-circuits on empty input via the protocol surface used
+///   by `XomifyService` itself (covered by checking the default response).
+@MainActor
+final class MarkListenedTests: XCTestCase {
+
+    // MARK: - Decode fallbacks
+
+    func test_share_decode_defaultsListenedFieldsWhenAbsent() throws {
+        let json = """
+        {
+          "shareId": "s-1",
+          "sharedBy": "me@example.com",
+          "sharedAt": "2026-04-23 10:00:00",
+          "trackId": "t-1",
+          "trackUri": "spotify:track:t-1",
+          "trackName": "Song",
+          "artistName": "Artist"
+        }
+        """.data(using: .utf8)!
+
+        let share = try JSONDecoder().decode(Share.self, from: json)
+
+        XCTAssertFalse(share.viewerHasListened)
+        XCTAssertEqual(share.listenerCount, 0)
+    }
+
+    func test_share_decode_readsListenedFieldsWhenPresent() throws {
+        let json = """
+        {
+          "shareId": "s-1",
+          "sharedBy": "me@example.com",
+          "sharedAt": "2026-04-23 10:00:00",
+          "trackId": "t-1",
+          "trackUri": "spotify:track:t-1",
+          "trackName": "Song",
+          "artistName": "Artist",
+          "viewerHasListened": true,
+          "listenerCount": 7
+        }
+        """.data(using: .utf8)!
+
+        let share = try JSONDecoder().decode(Share.self, from: json)
+
+        XCTAssertTrue(share.viewerHasListened)
+        XCTAssertEqual(share.listenerCount, 7)
+    }
+
+    // MARK: - Optimistic flip
+
+    func test_withViewerHasListened_flipsAndBumpsCountOnce() {
+        let share = Share(
+            shareId: "s-1",
+            sharedBy: "me@example.com",
+            sharedAt: "2026-04-23 10:00:00",
+            trackId: "t-1",
+            trackUri: "spotify:track:t-1",
+            trackName: "Song",
+            artistName: "Artist",
+            viewerHasListened: false,
+            listenerCount: 3
+        )
+
+        let firstFlip = share.withViewerHasListened(true)
+        XCTAssertTrue(firstFlip.viewerHasListened)
+        XCTAssertEqual(firstFlip.listenerCount, 4)
+
+        // Idempotent: flipping again when already true is a no-op.
+        let secondFlip = firstFlip.withViewerHasListened(true)
+        XCTAssertTrue(secondFlip.viewerHasListened)
+        XCTAssertEqual(secondFlip.listenerCount, 4)
+    }
+
+    func test_withViewerHasListened_decrementsCountOnUnflip() {
+        let share = Share(
+            shareId: "s-1",
+            sharedBy: "me@example.com",
+            sharedAt: "2026-04-23 10:00:00",
+            trackId: "t-1",
+            trackUri: "spotify:track:t-1",
+            trackName: "Song",
+            artistName: "Artist",
+            viewerHasListened: true,
+            listenerCount: 1
+        )
+
+        let unflipped = share.withViewerHasListened(false)
+        XCTAssertFalse(unflipped.viewerHasListened)
+        XCTAssertEqual(unflipped.listenerCount, 0)
+
+        // Floor at zero so a desynced row can't go negative.
+        let unflippedAgain = unflipped.withViewerHasListened(false)
+        XCTAssertEqual(unflippedAgain.listenerCount, 0)
+    }
+
+    // MARK: - ShareCardViewModel.markListenedOptimistically
+
+    func test_shareCardVM_markListenedOptimistically_flipsLocalShare() {
+        let mock = MockXomifyServiceProtocol()
+        let share = Share(
+            shareId: "s-1",
+            sharedBy: "friend@example.com",
+            sharedAt: "2026-04-23 10:00:00",
+            trackId: "t-1",
+            trackUri: "spotify:track:t-1",
+            trackName: "Song",
+            artistName: "Artist",
+            viewerHasListened: false,
+            listenerCount: 2
+        )
+        let vm = ShareCardViewModel(
+            share: share,
+            viewerEmail: "me@example.com",
+            xomifyService: mock,
+            spotifyService: MockSpotifyQueueing()
+        )
+
+        XCTAssertFalse(vm.share.viewerHasListened)
+        vm.markListenedOptimistically()
+
+        XCTAssertTrue(vm.share.viewerHasListened)
+        XCTAssertEqual(vm.share.listenerCount, 3)
+    }
+
+    // MARK: - Service mock contract
+
+    func test_mockMarkListened_recordsCallAndEchoesIds() async throws {
+        let mock = MockXomifyServiceProtocol()
+        let response = try await mock.markListened(
+            shareIds: ["a", "b"],
+            source: .play
+        )
+
+        XCTAssertTrue(response.ok)
+        XCTAssertEqual(response.listened, ["a", "b"])
+        XCTAssertEqual(mock.markListenedCalls.first?.shareIds, ["a", "b"])
+        XCTAssertEqual(mock.markListenedCalls.first?.source, .play)
+    }
+}
+
+// MARK: - Test doubles
+
+/// Minimal `SpotifyQueueing` stub used here so `ShareCardViewModel` can be
+/// constructed without dragging the real Spotify service into the test.
+private final class MockSpotifyQueueing: SpotifyQueueing, @unchecked Sendable {
+    func queueTrack(uri: String) async throws {}
+    func playTrack(uri: String) async throws {}
+}

--- a/Xomify-iOSTests/MockXomifyServiceProtocol.swift
+++ b/Xomify-iOSTests/MockXomifyServiceProtocol.swift
@@ -104,6 +104,28 @@ final class MockXomifyServiceProtocol: XomifyServiceProtocol, @unchecked Sendabl
         return getShareDetailResponses.removeFirst()
     }
 
+    // MARK: - markListened
+
+    struct MarkListenedCall: Equatable {
+        let shareIds: [String]
+        let source: ListenSource
+    }
+
+    private(set) var markListenedCalls: [MarkListenedCall] = []
+    var markListenedResult: MarkListenedResponse?
+    var markListenedError: Error?
+
+    func markListened(
+        shareIds: [String],
+        source: ListenSource
+    ) async throws -> MarkListenedResponse {
+        markListenedCalls.append(MarkListenedCall(shareIds: shareIds, source: source))
+        if let markListenedError { throw markListenedError }
+        if let markListenedResult { return markListenedResult }
+        // Default: pretend the backend wrote every requested id.
+        return MarkListenedResponse(ok: true, listened: shareIds, skipped: [])
+    }
+
     // MARK: - getFriendProfile
 
     struct GetFriendProfileCall: Equatable {


### PR DESCRIPTION
Wires the iOS side of the new `/shares/listened` contract (Bug 2 + Bug 3).

## Summary
- `Share` gets `viewerHasListened: Bool` + `listenerCount: Int` (Codable fallback when absent so cold-cache decodes don't fail).
- `XomifyService.markListened(shareIds:source:)` posts to `/shares/listened`; chunks at 25 ids to mirror the server cap and short-circuits on empty input. Added to `XomifyServiceProtocol` so it's mockable.
- `QueueActionController.queue/play` take an optional `shareId`; on success they fire a best-effort `markListened` write tagged `.queue` or `.play`. Errors are logged, not toasted — the play/queue itself already landed for the user.
- `ShareCardView` shows a "Not heard" badge driven by `share.viewerHasListened`. Tapping Play / Add to Queue calls `ShareCardViewModel.markListenedOptimistically()` so the badge disappears immediately, before the backend write returns. Hidden on own posts.
- `FeedRefinement.onlyUnlistened` filter switched from `viewerHasQueued` to `viewerHasListened`. Sheet copy updated to "Only show posts I haven't heard".
- Bumps `MARKETING_VERSION` to **1.18.0** (`feat`).

## File-by-file
- `Xomify-iOS/Models/SocialModels.swift` — new fields + decode fallbacks; `ListenSource` enum, `MarkListenedResponse` struct; `withViewerHasListened(_:)` helper; copy helpers carry the new fields through.
- `Xomify-iOS/Services/XomifyService.swift` — `markListened(shareIds:source:)` (chunked, empty-input short-circuit).
- `Xomify-iOS/Services/XomifyServiceProtocol.swift` — adds `markListened` to the protocol surface.
- `Xomify-iOS/Services/QueueActionController.swift` — adds optional `shareId` to `queue` and `play`, plus a private `markListenedFireAndForget(shareId:source:)`. Now constructed with both `SpotifyQueueing` and `XomifyServiceProtocol`.
- `Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift` — `markListenedOptimistically()` for the local flip.
- `Xomify-iOS/ViewModels/Feed/ShareComposerViewModel.swift` — author's optimistic local share now sets `viewerHasListened: true` so a freshly-posted card never briefly shows "Not heard" to its author.
- `Xomify-iOS/ViewModels/Feed/FeedViewModel.swift` — `onlyUnlistened` filter reads `viewerHasListened`.
- `Xomify-iOS/Views/Feed/FeedRefinementSheet.swift` — toggle copy + subtitle updated.
- `Xomify-iOS/Views/Feed/ShareCardView.swift` — passes `share.shareId` + `onListened` through to `TrackActionsMenu`; renders "Not heard" badge.
- `Xomify-iOS/Views/Feed/ShareDetailView.swift` — passes `share.shareId` through to `TrackActionsMenu` so detail-screen play/queue also marks listened.
- `Xomify-iOS/Views/Shared/QueueButton.swift` — accepts optional `shareId` + `onListened`.
- `Xomify-iOS/Views/Shared/TrackActionsMenu.swift` — accepts optional `shareId` + `onListened`; non-share callers (track rows, library, taste stage) keep the nil default and skip the listener write.
- `Xomify-iOSTests/MockXomifyServiceProtocol.swift` — mock conformance for `markListened` (records calls, default echoes input).
- `Xomify-iOSTests/MarkListenedTests.swift` — new: decode fallbacks, optimistic flip idempotency + decrement floor, VM helper, and mock contract.
- `Xomify-iOS.xcodeproj/project.pbxproj` — version bump to 1.18.0.

## Test plan
- [ ] Tap Queue on a share → "Not heard" badge disappears immediately (optimistic flip), backend listener-write fires in the background.
- [ ] Tap Play Now on a share → "Not heard" badge disappears immediately, backend listener-write fires.
- [ ] Author opens own share → "Not heard" not shown (suppressed for own posts; backend backfill also keeps the field true).
- [ ] Refinement sheet → "Only show posts I haven't heard" toggle hides shares where `viewerHasListened == true` (was previously `viewerHasQueued`).
- [ ] Build succeeds, no new warnings (`xcodebuild -scheme Xomify-iOS -sdk iphonesimulator build` is clean; pre-existing `TRUEPREDICATE` extension warning unchanged).

## Open questions
- The "Not heard" affordance on the card is **new** — the spec investigation suggested one already existed driven by Spotify recently-played, but I could only find a refinement-sheet filter (no badge). I opted to add a small purple "Not heard" pill to the action row so the optimistic flip described in the spec has something visible to react to. Easy to revert / restyle if you'd rather it live elsewhere.
- `QueueActionController` now construction-injects `XomifyServiceProtocol` (default `XomifyService.shared`). Other call sites still use the singleton — non-share contexts pass `shareId: nil` and skip the listener write entirely.