### PR TITLE
fix: 13 bugs - stableId, rollback crashes, logout race, pagination, rate sheet

### DIFF
--- a/Xomify-iOS/Models/XomifyModels.swift
+++ b/Xomify-iOS/Models/XomifyModels.swift
@@ -197,9 +197,17 @@ struct Release: Codable, Sendable {
         artistName ?? "Unknown Artist"
     }
     
-    /// Stable ID for ForEach - use albumId or fall back to id
+    /// Stable ID for ForEach - use albumId, then id, then a deterministic
+    /// composite of the remaining identifying fields. Never generate a fresh
+    /// UUID here: `stableId` is read on every render, so a random fallback
+    /// gives the row a new identity each pass and makes the list flicker.
     var stableId: String {
-        albumId ?? id ?? UUID().uuidString
+        if let albumId, !albumId.isEmpty { return albumId }
+        if let id, !id.isEmpty { return id }
+        // Deterministic fallback — same inputs always yield the same key.
+        return [uri, spotifyUrl, albumName ?? name, artistName, releaseDate]
+            .compactMap { $0 }
+            .joined(separator: "|")
     }
 }
 
@@ -254,9 +262,12 @@ struct MonthlyWrap: Codable, Identifiable, Sendable {
 // MARK: - Wrapped Data Response
 
 struct WrappedDataResponse: Codable, Sendable {
-    let active: Bool
-    let activeWrapped: Bool
-    let activeReleaseRadar: Bool
+    // Optional — the backend omits these flags for users who have never
+    // enrolled, and a non-optional Bool makes the whole decode throw on a
+    // missing key, blanking the Wrapped screen instead of degrading.
+    let active: Bool?
+    let activeWrapped: Bool?
+    let activeReleaseRadar: Bool?
     let wraps: [MonthlyWrap]?
 }
 

--- a/Xomify-iOS/Services/AuthService.swift
+++ b/Xomify-iOS/Services/AuthService.swift
@@ -560,17 +560,19 @@ final class AuthService: NSObject, Sendable {
     
     // MARK: - Logout
 
-    /// Synchronous logout — kept for existing call sites. For new call sites
-    /// prefer `logout()` (async) so the APNs token can be unregistered from the
-    /// backend before the Spotify access token is cleared.
-    func logout() {
-        // Fire-and-forget: unregister the APNs device token with the backend.
-        // `NotificationsService.unregister()` internally resolves the current
-        // user email via Spotify, so we dispatch it *before* clearing tokens.
-        // It swallows errors — stale backend tokens get pruned on next 410.
-        Task { @MainActor in
-            await NotificationsService.shared.unregister()
-        }
+    /// Logout. Unregisters the APNs device token from the backend *before*
+    /// clearing credentials, then wipes local tokens.
+    ///
+    /// Ordering matters: `NotificationsService.unregister()` makes an
+    /// authenticated call that relies on the Xomify JWT (and the cached
+    /// email). The previous fire-and-forget `Task` raced token teardown —
+    /// `xomifyJwt` was usually nil'd before the request authenticated, so the
+    /// unregister 401'd and the device kept receiving pushes after sign-out.
+    /// Awaiting it here guarantees it completes against valid credentials.
+    /// It swallows its own errors — stale backend tokens get pruned on next 410.
+    @MainActor
+    func logout() async {
+        await NotificationsService.shared.unregister()
 
         accessToken = nil
         refreshToken = nil

--- a/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/FeedViewModel.swift
@@ -211,6 +211,12 @@ final class FeedViewModel {
             shares = cached
         }
 
+        // Show the loading state while we resolve the user and kick off the
+        // first refresh. Without this the feed reads as "empty" rather than
+        // "loading" during email resolution. `refresh()` clears it on
+        // completion; the early-return path below clears it too.
+        isLoading = true
+
         // 2. Resolve the current user. Prefer the network, fall back to the
         //    last-known email from UserDefaults on failure.
         if userEmail.isEmpty {
@@ -223,6 +229,7 @@ final class FeedViewModel {
                 if shares.isEmpty {
                     errorMessage = "Could not load feed — please try again."
                 }
+                isLoading = false
                 return
             }
         }
@@ -267,16 +274,22 @@ final class FeedViewModel {
         isRefreshing = true
         errorMessage = nil
 
+        // Capture the filter this request is for. If the user switches filters
+        // while the request is in flight, the response is stale — discard it
+        // rather than writing another filter's shares into the live list.
+        let requestedFilter = selectedFilter
+
         do {
             let response = try await xomifyService.getFeed(
-                groupId: selectedFilter.groupId,
+                groupId: requestedFilter.groupId,
                 limit: FeedCacheService.maxSharesPerFilter,
                 before: nil
             )
+            guard requestedFilter == selectedFilter else { return }
             shares = response.shares
             nextBefore = response.nextBefore
             hasMorePages = response.nextBefore != nil
-            await cacheService.save(response.shares, forKey: selectedFilter.cacheKey)
+            await cacheService.save(response.shares, forKey: requestedFilter.cacheKey)
         } catch {
             // Don't blow the UI away over a refresh hiccup if we already
             // have content painted from cache.
@@ -303,12 +316,19 @@ final class FeedViewModel {
         isLoading = true
         defer { isLoading = false }
 
+        // Pin the request to the active filter. Switching filters resets
+        // `shares`/`nextBefore`, so a late page from the previous filter must
+        // not be appended into the new filter's list — that's what made
+        // pagination "break" after a filter change.
+        let requestedFilter = selectedFilter
+
         do {
             let response = try await xomifyService.getFeed(
-                groupId: selectedFilter.groupId,
+                groupId: requestedFilter.groupId,
                 limit: FeedCacheService.maxSharesPerFilter,
                 before: before
             )
+            guard requestedFilter == selectedFilter else { return }
             shares.append(contentsOf: response.shares)
             nextBefore = response.nextBefore
             hasMorePages = response.nextBefore != nil

--- a/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareCardViewModel.swift
@@ -163,6 +163,10 @@ final class ShareCardViewModel {
         reactingSlugs.insert(slug)
         defer { reactingSlugs.remove(slug) }
 
+        // Clear any stale error from a previous failed toggle so a successful
+        // retry doesn't leave the error banner stuck on screen.
+        reactError = nil
+
         let previousCounts = share.reactionCounts
         let previousViewer = share.viewerReactions
 

--- a/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift
@@ -222,7 +222,9 @@ final class ShareDetailViewModel {
                 commentId: comment.commentId
             )
         } catch {
-            comments.insert(removed, at: removeIndex)
+            // Clamp: another in-flight delete may have shortened the list,
+            // so `removeIndex` can now be past the end. Inserting there traps.
+            comments.insert(removed, at: min(removeIndex, comments.count))
             share = share.withCommentCount(share.commentCount + 1)
             commentsError = error.localizedDescription
         }
@@ -247,6 +249,10 @@ final class ShareDetailViewModel {
         guard !reactingSlugs.contains(slug) else { return }
         reactingSlugs.insert(slug)
         defer { reactingSlugs.remove(slug) }
+
+        // Clear any stale error from a previous failed toggle so a successful
+        // retry doesn't leave the error banner stuck on screen.
+        reactError = nil
 
         let previousCounts = share.reactionCounts
         let previousViewer = share.viewerReactions

--- a/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
+++ b/Xomify-iOS/ViewModels/GroupDetailViewModel.swift
@@ -110,8 +110,9 @@ final class GroupDetailViewModel {
     func refresh() async {
         guard !groupId.isEmpty else { return }
         isRefreshing = true
+        // `load` already calls `loadShares()` as its last step — don't fetch
+        // the group-scoped feed a second time here.
         await load(email: userEmail, groupId: groupId)
-        await loadShares()
         isRefreshing = false
     }
 

--- a/Xomify-iOS/ViewModels/LoginViewModel.swift
+++ b/Xomify-iOS/ViewModels/LoginViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// ViewModel for the Login screen
 @Observable
+@MainActor
 final class LoginViewModel {
     
     // MARK: - Properties

--- a/Xomify-iOS/ViewModels/SettingsViewModel.swift
+++ b/Xomify-iOS/ViewModels/SettingsViewModel.swift
@@ -212,8 +212,8 @@ final class SettingsViewModel {
 
     // MARK: - Auth
 
-    func logout() {
-        authService.logout()
+    func logout() async {
+        await authService.logout()
     }
 
     // MARK: - Private
@@ -222,8 +222,8 @@ final class SettingsViewModel {
         do {
             _ = email
             let userData = try await xomifyService.getUserData()
-            isWrappedEnrolled = userData.activeWrapped
-            isReleaseRadarEnrolled = userData.activeReleaseRadar
+            isWrappedEnrolled = userData.activeWrapped ?? false
+            isReleaseRadarEnrolled = userData.activeReleaseRadar ?? false
             print("✅ Settings: enrollment loaded — Wrapped: \(isWrappedEnrolled), RR: \(isReleaseRadarEnrolled)")
         } catch {
             // User may not exist yet in Xomify — that's fine.

--- a/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
+++ b/Xomify-iOS/ViewModels/Social/RatingsHistoryViewModel.swift
@@ -30,14 +30,8 @@ final class RatingsHistoryViewModel {
         errorMessage = nil
 
         do {
-            let user = try await spotifyService.getCurrentUser()
-            guard let email = user.email, !email.isEmpty else {
-                errorMessage = "Could not load ratings — missing email."
-                isLoading = false
-                return
-            }
-
-            _ = email
+            // Ratings are scoped server-side by the Xomify JWT — no Spotify
+            // user lookup needed here.
             let response = try await xomifyService.getAllRatings()
             let loaded = response.ratings ?? []
             ratings = loaded.sorted(by: Self.isMoreRecent)
@@ -77,17 +71,15 @@ final class RatingsHistoryViewModel {
         let removed = ratings.remove(at: index)
 
         do {
-            let user = try await spotifyService.getCurrentUser()
-            guard let email = user.email, !email.isEmpty else {
-                ratings.insert(removed, at: index)
-                errorMessage = "Could not delete rating — missing email."
-                return
-            }
-            _ = email
+            // Deletion is authorized server-side by the Xomify JWT — no Spotify
+            // user lookup needed here.
             _ = try await xomifyService.removeRating(trackId: rating.trackId)
             print("🗑️ RatingsHistory: removed rating for \(rating.trackId)")
         } catch {
-            ratings.insert(removed, at: index)
+            // Clamp: the list may have shrunk further (another delete) while
+            // the network call was in flight, so the original index can now be
+            // past the end. Inserting there would trap.
+            ratings.insert(removed, at: min(index, ratings.count))
             errorMessage = "Could not delete rating: \(error.localizedDescription)"
             print("❌ RatingsHistory: delete failed - \(error)")
         }

--- a/Xomify-iOS/Views/Feed/FeedView.swift
+++ b/Xomify-iOS/Views/Feed/FeedView.swift
@@ -132,7 +132,11 @@ struct FeedView: View {
                     )
                     .padding(.horizontal, 16)
                     .onAppear {
-                        if share.id == viewModel.shares.last?.id {
+                        // Compare against the filtered list the ForEach actually
+                        // renders — using `shares.last` means the trigger row is
+                        // never visible when a refinement hides the tail, so
+                        // pagination silently stops working under active filters.
+                        if share.id == viewModel.filteredShares.last?.id {
                             Task { await viewModel.loadMore() }
                         }
                     }

--- a/Xomify-iOS/Views/Feed/ShareCardView.swift
+++ b/Xomify-iOS/Views/Feed/ShareCardView.swift
@@ -470,7 +470,11 @@ private struct RateSheet: View {
                     Button {
                         Task {
                             await viewModel.rate(stars)
-                            isPresented = false
+                            // Keep the sheet open on failure so the inline
+                            // error below stays visible; only dismiss on success.
+                            if viewModel.rateError == nil {
+                                isPresented = false
+                            }
                         }
                     } label: {
                         Image(systemName: (viewModel.myRating ?? 0) >= stars ? "star.fill" : "star")

--- a/Xomify-iOS/Views/Feed/ShareDetailView.swift
+++ b/Xomify-iOS/Views/Feed/ShareDetailView.swift
@@ -627,7 +627,11 @@ private struct DetailRateSheet: View {
                     Button {
                         Task {
                             await viewModel.rate(stars)
-                            isPresented = false
+                            // Keep the sheet open on failure so the inline
+                            // error below stays visible; only dismiss on success.
+                            if viewModel.rateError == nil {
+                                isPresented = false
+                            }
                         }
                     } label: {
                         Image(systemName: (viewModel.myRating ?? 0) >= stars ? "star.fill" : "star")

--- a/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
+++ b/Xomify-iOS/Views/Shell/Destinations/SettingsView.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Sign out", role: .destructive) {
-                viewModel.logout()
+                Task { await viewModel.logout() }
             }
             Button("Cancel", role: .cancel) {}
         }

--- a/Xomify-iOS/Views/WrappedView.swift
+++ b/Xomify-iOS/Views/WrappedView.swift
@@ -544,6 +544,9 @@ struct WrappedContent: View {
     private func loadContent() async {
         guard let wrap = currentWrap else { return }
 
+        // Clear any prior error so a successful reload (tab/term switch or
+        // retry) doesn't leave a stale error message rendered.
+        errorMessage = nil
         isLoadingContent = true
 
         switch selectedTab {

--- a/docs/features/dms-and-notifications/BRAINSTORM.md
+++ b/docs/features/dms-and-notifications/BRAINSTORM.md
@@ -1,0 +1,276 @@
+# BRAINSTORM — DMs and Notifications
+
+> Topic: `dms-and-notifications`
+> Date: 2026-04-28
+> Author: Dom + Claude
+> Surface: xomify-ios (SwiftUI), xomify-frontend (Angular 18), xomify-backend (Python/Lambda + DynamoDB + APNS)
+
+---
+
+## Phase 1 — Explore (loose ideas)
+
+### DMs — angles considered
+- 1:1 only vs group DMs (Dom's spec is 1:1; group posts already cover N-way)
+- Thread-per-pair (deterministic id from sorted user ids) vs server-generated thread id
+- Single `xomify-dms` table holding messages, with thread-id partition key
+- Two-table split: `xomify-threads` (thread metadata, last-message preview, unread counts) + `xomify-messages` (per-message rows)
+- WebSockets via API Gateway WS for live delivery vs simple polling vs APNS-as-transport
+- "Share-a-track in DM" = a message with a `kind: track` payload (uri, name, artist, art) — same shape as a share record, just delivered through DM thread
+- Read receipts: per-user `lastReadAt` on the thread membership row
+- Typing indicators: out of scope for v1, full stop
+- Blocking: a `xomify-blocks` table — `(blockerUserId, blockedUserId)` — checked on send. Cheap to add, expensive to retrofit
+- Friendship gate: only allow DMs between mutual friends? Or open to anyone you can resolve by handle? Dom's `xomify-friendships` table is the natural gate
+- Reactions on messages — out of scope v1
+- Editing/deleting messages — soft delete only, v1
+- Attachments / images — out of scope. Track shares only
+- Pagination: query thread messages by `sk` descending with limit + LastEvaluatedKey
+- TTL on messages? Probably not — leave them
+- E2E encryption — not happening, JWT-authed transport is fine for a Spotify-companion app
+
+### Notifications — angles considered
+- All four triggers funnel through one shared `send_push(userId, payload)` helper that wraps the existing APNS pipeline
+- Per-user notification prefs row: `xomify-notif-prefs` or fold into the user profile row as a map (`{dm: true, wrapped: true, releaseRadar: true, groupPost: true}`)
+- Trigger sources differ:
+  - **DM** → fires inline from the `dms_send` lambda (synchronous post-write)
+  - **Group post by friend** → fires from `groups_post_create` lambda; fan-out to group members minus author, filtered by `xomify-friendships` so only friends-of-author get pinged (or just all members — simpler)
+  - **Wrapped** → scheduled lambda, runs daily Nov 25–Dec 15, polls each opted-in user's playlists for the year's Wrapped playlist id pattern
+  - **Release Radar** → scheduled lambda, runs Mondays (RR refreshes Friday but users open Mon AM); diff playlist track-ids vs last-seen set
+- Detecting "new" Wrapped: Spotify's Wrapped playlist appears in user's library with a name pattern `Your [YEAR] Wrapped` or via a known playlist id format. Easiest: scan user's playlists once/day in late Nov/early Dec, look for a playlist with `wrapped` in the name owned by Spotify, store `wrappedPlaylistIdSeen` on profile. First time it's seen → fire notif
+- Detecting "new" Release Radar: RR playlist id is stable per user once known (`spotify:playlist:<id>`); store `releaseRadarPlaylistId` + `releaseRadarLastTrackIds` (set hash or just a small array of ids) on profile. Diff weekly. Any new track id = notif
+- Deep links: custom scheme `xomify://` already implied. Targets: `xomify://dm/<threadId>`, `xomify://group/<id>/post/<postId>`, `xomify://wrapped`, `xomify://release-radar`
+- Notification grouping (APNS `thread-id`): use thread ids per category so iOS stacks them sensibly
+- Web push (Angular) — out of scope v1. iOS only for push. Web can show in-app toast/badge if user is online
+- Quiet hours / batching — out of scope
+- Backoff for failed device tokens — already handled in existing pipeline (assumption; verify in `notifications_register`)
+- Storing notif history server-side for an in-app inbox — nice but out of scope; APNS-only delivery is fine
+- Wrapped/RR re-fire prevention: store last-fired marker so we don't re-notify if the lambda runs again
+
+### Premise challenges
+- **Friend-of-author filter on group posts**: do we want "friends only" or "all group members"? Dom's spec says "by a friend." Stricter filter = fewer notifs but requires a friendship lookup per recipient. All-members is simpler. **Flag for Dom.**
+- **Wrapped detection** is fragile — if Spotify changes the naming convention or playlist visibility, the poller breaks. Acceptable risk for an annual event; we monitor in late Nov.
+- **Release Radar polling cost**: one Spotify API call per opted-in user per week. Trivial for hundreds of users, watch it at thousands.
+- **Do we need a thread-list endpoint that returns unread counts?** Yes for the inbox UI. That pushes us toward the two-table split (threads table holds counts).
+
+---
+
+## Phase 2 — Converge
+
+# Section 1: DMs
+
+## Option A: Single-table, thread-id derived, polling-only
+
+**One-line**: One DynamoDB table holds all messages, thread id is `sorted(uidA)#sorted(uidB)`, clients poll for new messages.
+
+**Schema sketch**:
+```
+xomify-dms
+  PK: THREAD#<threadId>           // threadId = sha1(min(uidA,uidB) + "#" + max(uidA,uidB))
+  SK: MSG#<ulid>                  // ulid is time-ordered
+  attrs: senderId, body, kind ("text"|"track"), trackPayload?, createdAt, deleted?
+
+  // Thread metadata as a sibling row
+  PK: THREAD#<threadId>
+  SK: META
+  attrs: participants[2], lastMessageAt, lastMessagePreview
+
+  // Per-user thread index (for inbox list + unread)
+  PK: USER#<userId>
+  SK: THREAD#<lastMessageAt>#<threadId>
+  attrs: threadId, otherUserId, lastReadAt, unreadCount
+```
+
+**Endpoints**:
+- `POST /dms/send` `{ toUserId, kind, body?, trackPayload? }` → writes message + updates META + bumps both USER index rows
+- `GET /dms/threads` → query `PK=USER#me, SK begins_with THREAD#` desc, returns inbox
+- `GET /dms/threads/:threadId/messages?before=<sk>&limit=50` → paginated
+- `POST /dms/threads/:threadId/read` → updates `lastReadAt`, zeros unreadCount
+
+**Real-time vs polling**: **Polling**. Client polls thread list every 15s when app is foreground; opens a thread = polls every 5s. Push notifs cover background delivery. No WebSocket infra needed.
+
+**Share-a-track in DM**: **In scope** — `kind: "track"` payload reuses the existing share record shape so the iOS message bubble and Angular bubble can render a track card.
+
+**Blocking**: **In scope, minimal**. Add `xomify-blocks` table: `PK=USER#<blockerId>, SK=BLOCK#<blockedId>`. `dms_send` does a single GetItem before writing; if blocked either direction → 403. Cheap now, miserable to bolt on later.
+
+**Effort**: **M** (3–5 days). Mostly schema + 4 lambdas + iOS/Angular thread list + chat view.
+
+**Biggest tradeoff vs Option B**: No live "typing now" or sub-second delivery while both users are in-app. Polling at 5s feels fine for Spotify-companion DMs.
+
+---
+
+## Option B: Same schema, API Gateway WebSocket for live delivery
+
+**One-line**: Option A's schema + API Gateway WebSocket connection per active client for instant delivery while both users are in-thread.
+
+**Schema sketch**: Same as A, plus:
+```
+xomify-ws-connections
+  PK: USER#<userId>
+  SK: CONN#<connectionId>
+  attrs: connectedAt, ttl (1hr)
+```
+
+**Endpoints**: A's endpoints + WS routes (`$connect`, `$disconnect`, `$default`). On `dms_send`, lambda also looks up recipient's active connections and posts via `@connections` API.
+
+**Real-time vs polling**: **Hybrid** — WS when foreground, APNS when background, polling as fallback if WS drops.
+
+**Share-a-track in DM**: In scope, same shape as A.
+
+**Blocking**: In scope, same as A.
+
+**Effort**: **L** (7–10 days). API Gateway WS is straightforward but it's a new surface to monitor (connection table cleanup, dropped sockets, retry logic on send).
+
+**Biggest tradeoff vs A**: 2x infra surface for a UX delta most users won't notice. Worth it only if real-time chat is core to retention — and for a Spotify companion, it isn't.
+
+---
+
+## Option C: Minimal-viable, single table, no thread metadata table
+
+**One-line**: Just messages. Inbox is computed by querying GSI on senderId/recipientId. No unread counts server-side — client tracks `lastReadAt` locally.
+
+**Schema sketch**:
+```
+xomify-dms
+  PK: THREAD#<threadId>
+  SK: MSG#<ulid>
+  attrs: senderId, recipientId, body, kind, trackPayload?, createdAt
+  GSI1PK: USER#<recipientId>
+  GSI1SK: <createdAt>
+```
+
+**Endpoints**: `POST /dms/send`, `GET /dms/threads/:id/messages`, `GET /dms/inbox` (GSI scan of recent messages, group client-side by threadId).
+
+**Real-time vs polling**: Polling only.
+
+**Share-a-track in DM**: In scope.
+
+**Blocking**: Out of scope (skipped to keep "minimal").
+
+**Effort**: **S** (1–2 days).
+
+**Biggest tradeoff vs A**: No unread counts on server, no blocking, no thread previews. Inbox UI is jankier and we'll regret skipping blocks the first time someone harasses someone.
+
+---
+
+# Section 2: Notification triggers
+
+All four use a shared helper: `send_push(userId, payload)` that:
+1. Looks up the user's notif prefs (fold into `xomify-users` row as `notifPrefs` map: `{dm, wrapped, releaseRadar, groupPost}`, default all true)
+2. Looks up active device tokens from `xomify-devices` (or whatever the existing register/unregister tables are named)
+3. Calls APNS via the existing pipeline
+
+### Trigger 1: New DM
+- **Fires from**: `dms_send` lambda, after successful message write, before returning 200
+- **Event**: New row written to `xomify-dms` with `SK begins_with MSG#`
+- **Opt-in/opt-out**: Yes — `notifPrefs.dm` (default on)
+- **Deep link**: `xomify://dm/<threadId>`
+- **Payload**:
+  ```
+  alert.title: "<senderDisplayName>"
+  alert.body: <message preview, truncated 80 chars; "Sent you a track" if kind=track>
+  thread-id: "dm-<threadId>"   // APNS grouping
+  data.type: "dm"
+  data.threadId: <threadId>
+  ```
+- **Notes**: Skip push if recipient has an active WS connection (Option B only) — message already delivered live.
+
+### Trigger 2: Spotify Wrapped release
+- **Fires from**: Scheduled lambda `wrapped_poller`, EventBridge rule running once daily Nov 25 – Dec 15 (UTC noon)
+- **Event**: First time we detect a Wrapped playlist for a user that we haven't seen before
+- **Detection**:
+  - For each opted-in user, hit `GET /me/playlists` (or specifically search owned-by-spotify playlists in their library) using their Spotify access token
+  - Look for a playlist whose name matches `Your [YEAR] Wrapped` (or owner is Spotify and name contains "Wrapped" + current year)
+  - Store `wrappedPlaylistIdSeen.<year>` on `xomify-users` row
+  - If the playlist exists and the marker doesn't → fire push, then write the marker
+- **Opt-in/opt-out**: Yes — `notifPrefs.wrapped` (default on)
+- **Deep link**: `xomify://wrapped` (in-app screen) with payload also carrying `spotifyPlaylistUri` so the screen can offer "Open in Spotify" button
+- **Payload**:
+  ```
+  alert.title: "Your [YEAR] Wrapped is here"
+  alert.body: "Tap to see your top tracks and artists."
+  data.type: "wrapped"
+  data.year: 2026
+  data.spotifyPlaylistUri: "spotify:playlist:<id>"
+  data.spotifyPlaylistUrl: "https://open.spotify.com/playlist/<id>"
+  ```
+- **Notes**: We need a fresh Spotify access token per user. If the refresh token is expired/revoked, skip silently. Re-firing prevention = the year-keyed marker.
+
+### Trigger 3: Release Radar release
+- **Fires from**: Scheduled lambda `release_radar_poller`, EventBridge rule running every Monday 10:00 user-local-ish (in practice: run hourly, only fire if user's local time is between 9am–11am Mon — or just run once at 14:00 UTC Mon and accept the timing isn't perfect)
+- **Event**: User's Release Radar playlist has new track ids vs last-seen set
+- **Detection**:
+  - Resolve user's Release Radar playlist id once (search `/me/playlists` for owner=spotify, name="Release Radar"), cache on profile as `releaseRadarPlaylistId`
+  - Pull current track ids (top 30 should be enough — RR caps at 30)
+  - Compare against `releaseRadarLastTrackIds` (array of ~30 strings on profile row)
+  - If symmetric difference is non-empty → new releases exist → fire push, store the new list
+  - First-ever run for a user → just store the list, no notif
+- **Opt-in/opt-out**: Yes — `notifPrefs.releaseRadar` (default on)
+- **Deep link**: `xomify://release-radar` with `spotifyPlaylistUri` in payload
+- **Payload**:
+  ```
+  alert.title: "New Release Radar"
+  alert.body: "<N> new tracks for you this week."
+  data.type: "releaseRadar"
+  data.spotifyPlaylistUri: "spotify:playlist:<id>"
+  data.spotifyPlaylistUrl: "https://open.spotify.com/playlist/<id>"
+  data.newTrackCount: <N>
+  ```
+- **Notes**: Same access-token concern as Wrapped. Polling cost: 1 Spotify call per opted-in user per week — fine.
+
+### Trigger 4: New post in a group by a friend
+- **Fires from**: `groups_post_create` lambda, after the post write
+- **Event**: New post row in `xomify-groups` (or wherever group posts live)
+- **Detection / fan-out**:
+  - Query group membership for groupId
+  - For each member ≠ author, check if they're friends with the author (`xomify-friendships` GetItem) — **if Dom wants strict "by a friend" filter** — OR skip the friendship check and notify all members (simpler, matches "Slack channel" mental model)
+  - Send push to remaining members
+- **Opt-in/opt-out**: Yes — `notifPrefs.groupPost` (default on). Per-group mute is out of scope v1
+- **Deep link**: `xomify://group/<groupId>/post/<postId>`
+- **Payload**:
+  ```
+  alert.title: "<groupName>"
+  alert.body: "<authorDisplayName>: <post preview 80 chars>"
+  thread-id: "group-<groupId>"
+  data.type: "groupPost"
+  data.groupId: <groupId>
+  data.postId: <postId>
+  ```
+- **Notes**: The friendship-filter question is a real fork in the spec. See open questions.
+
+---
+
+# Section 3: Recommendation
+
+**DMs: Option A (single-table-ish with thread metadata + per-user index, polling, blocking in scope, share-a-track in scope).**
+
+It hits the spec, gives us unread counts and a real inbox, and includes blocking — which is a 1-hour add now and a refactor later. Option C saves a couple of days but ships without blocks and without server-side unread counts, which we'll immediately want once the iOS inbox UI renders. Option B's WebSocket layer is a cool toy but Spotify-companion DMs don't need sub-second delivery; APNS + 5s polling while a thread is open is indistinguishable in practice and skips a whole infra surface.
+
+**Notifications: shared `send_push(userId, payload)` helper + the four triggers as specified above, prefs folded into the existing `xomify-users` row as a `notifPrefs` map.**
+
+Two of the four triggers (DM, group post) are inline lambda fires — basically free given the existing APNS pipeline. The other two (Wrapped, Release Radar) are scheduled pollers with simple "have we seen this before" markers on the user profile row. No new infra primitives, no fan-out queue, no notification history table. We can add an in-app inbox later if we want, but APNS-only is correct for v1.
+
+This depends on:
+- The existing `notifications_register` lambda actually storing device tokens in a way we can query by `userId` (need to verify the table shape — listed in open questions)
+- Spotify refresh tokens being available server-side per user (needed for Wrapped + RR pollers to call Spotify on the user's behalf without them opening the app)
+
+---
+
+# Section 4: Open questions
+
+1. **Group-post filter**: Does "new post in a group by a friend" mean (a) only notify members who are friends with the author, or (b) notify all group members (since they opted into the group)? (a) is the literal spec; (b) is simpler and probably what users actually want.
+2. **Backend device-token table shape**: Need to confirm `notifications_register` stores tokens keyed by `userId` so we can fan-out by user. If it's keyed by token only, we need a GSI or schema tweak.
+3. **Spotify refresh tokens server-side**: Are refresh tokens stored on the `xomify-users` row, or only the access token (which expires hourly)? Wrapped + RR pollers need refresh tokens to call Spotify without the user being active.
+4. **Friendship gate on DMs**: Can any user DM any other user (handle-resolvable), or only mutual friends? Recommend mutual-friends-only for v1 to avoid spam vectors.
+5. **Wrapped polling window**: Confirm Nov 25 – Dec 15 covers the release. Spotify dropped Wrapped on Dec 4 in 2024, Nov 29 in 2023. The window is conservative.
+6. **Release Radar timing**: RR refreshes Friday morning. Notify Monday morning (when most people check phones) or Friday afternoon (immediately fresh)? Recommend Friday afternoon UTC, simpler scheduling.
+7. **Notification prefs UI surface**: Settings screen on iOS + Angular, or in-line toggles? Out of scope for this brainstorm but flagging for the plan.
+8. **Existing `xomify-shares` track payload shape**: Confirm the schema so the DM `kind: track` payload mirrors it exactly — avoids two formats for "a track inside a message."
+9. **Web push for Angular**: Confirmed out of scope for v1? (Recommend: yes, out of scope.)
+10. **Notification deep link handler**: Does iOS already have a `xomify://` URL scheme handler registered, or does this PR introduce it?
+
+---
+
+```
+Brainstorm saved: docs/features/dms-and-notifications/BRAINSTORM.md
+Recommendation: Option A — Single-table threads + polling + blocking + share-a-track
+Next: /plan dms-and-notifications — I'll use this doc as context
+```

--- a/docs/features/dms-and-notifications/PLAN.md
+++ b/docs/features/dms-and-notifications/PLAN.md
@@ -1,0 +1,315 @@
+# Plan: DMs and Notifications
+
+**Status**: Draft
+**Created**: 2026-04-28
+**Last updated**: 2026-04-28
+**Spans repos**: `xomify-backend` (Python/Lambda/DynamoDB/APNS), `xomify-ios` (SwiftUI)
+**Brainstorm**: `docs/features/dms-and-notifications/BRAINSTORM.md`
+
+---
+
+## 1. Goal + Non-Goals
+
+### Goal
+Ship 1:1 direct messaging (with track-share inline messages) and four new push-notification categories (DM, Spotify Wrapped, Release Radar, group post by any member) on top of the existing APNS pipeline. Add a notification-prefs surface on iOS so users can toggle each category and mute individual groups.
+
+### Non-Goals (v1)
+- Group DMs (1:1 only — group posts already cover N-way)
+- WebSockets / live delivery — polling + APNS only
+- Typing indicators, message reactions, message edit
+- Attachments other than track shares
+- E2E encryption
+- In-app notification inbox / history (APNS-only delivery)
+- Web push for the Angular frontend
+- Quiet hours / batching
+- Read receipts beyond `lastReadAt` on the user's own thread index row
+
+---
+
+## 2. Decision Summary (already locked in)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | DMs: BRAINSTORM Option A (single-table threads, polling, blocking, share-a-track) | Matches spec; avoids WebSocket infra; keeps blocks in scope so we don't retrofit later |
+| 2 | Friends-only DM gate (server-enforced via `friendships` `status=accepted`) | Anti-spam; reuses existing `are_users_friends()` helper |
+| 3 | Group-post notification fans out to **all group members** (not friends-only) | Simpler, matches Slack-channel mental model. Per-group mute covers the noise case |
+| 4 | Notification triggers reuse existing `notifications_send` + `device_tokens_dynamo`; copy `_invoke_threshold_push` pattern from `shares_react` | Don't re-architect — the pipeline already does APNS + 410-prune |
+| 5 | Notification prefs stored as a `notifPrefs` map on the `xomify-users` row (single read on send) | Folds into existing user profile row; one less table |
+| 6 | Per-group mute stored on the `xomify-users` row as a `mutedGroupIds: Set<String>` | See section 3 for tradeoff vs. dedicated table — the set fits the existing pattern and stays in the single profile read |
+| 7 | All notification categories default to ON for new users | Conservative-on-discoverability beats conservative-on-volume; users will opt out if noisy |
+
+---
+
+## 3. Backend Work (`xomify-backend`)
+
+### 3a. Table schemas
+
+**New table — `xomify-dms`** (single-table style, mirrors `shares` conventions):
+
+```
+PK: threadId           (string — sha1(min(emailA,emailB) + "#" + max(emailA,emailB)))
+SK: rowType            (string — "META" | "MSG#<ulid>")
+attrs (META row):
+  participants: [emailA, emailB]
+  createdAt: ISO8601
+  lastMessageAt: ISO8601
+  lastMessagePreview: string (<=80 chars)
+  lastMessageKind: "text" | "track"
+attrs (MSG row):
+  senderEmail, kind ("text"|"track"), body?, trackPayload?, createdAt, deleted? (bool)
+```
+
+**New table — `xomify-thread-index`** (per-user inbox + unread):
+
+```
+PK: email
+SK: lastMessageAt#threadId   (ISO8601 sort, desc-readable)
+attrs:
+  threadId, otherEmail, otherDisplayName (denorm), lastReadAt, unreadCount,
+  lastMessagePreview, lastMessageKind, lastMessageAt
+```
+
+`SK` is composite so we can `ScanIndexForward=False` for inbox order without a GSI.
+
+**New table — `xomify-blocks`** (kept tiny; wired in v1 even if UI lands later):
+
+```
+PK: blockerEmail
+SK: blockedEmail
+attrs: createdAt
+```
+
+**Modify — `xomify-users` row** (no migration; new attrs default-absent treated as "all on"):
+
+```
++ notifPrefs: {
+    dm: bool,           # default true
+    wrapped: bool,      # default true
+    releaseRadar: bool, # default true
+    groupPost: bool,    # default true
+    threshold: bool     # existing queue-threshold; default true
+  }
++ mutedGroupIds: Set<String>            # default absent == empty
++ wrappedPlaylistIdSeen: { "<year>": "<playlistId>" }
++ releaseRadarPlaylistId: string
++ releaseRadarLastTrackIds: List<String>  # ~30 ids
+```
+
+**Why the user-row map vs a separate `group_notification_settings` table:**
+The other reaction/share helpers all read the user row anyway (e.g. `get_user`); folding `notifPrefs` + `mutedGroupIds` into it means notification dispatch costs **one** GetItem instead of two. The set-on-profile pattern is already used elsewhere (e.g. `genreTags` on shares, similar shape). A dedicated table only earns its keep if mute counts get into the thousands per user — not realistic. Trade-off: a single row gets hot if a user mutes/unmutes rapidly, but writes are infrequent enough that this isn't a concern.
+
+### 3b. New helpers (`lambdas/common/`)
+
+| Helper file | Purpose |
+|-------------|---------|
+| `dms_dynamo.py` | `compute_thread_id`, `get_or_create_thread`, `append_message`, `list_messages`, `bump_thread_index`, `mark_read` |
+| `blocks_dynamo.py` | `is_blocked_either_way(a, b)` (single GetItem on each direction; OR result) |
+| `notif_prefs_dynamo.py` | `get_notif_prefs(email) -> dict`, `set_notif_prefs(email, partial)`, `is_group_muted(email, groupId)` — wraps reads/writes against `xomify-users` row |
+| `push_dispatch.py` | `send_push(email, category, title, body, custom_data, collapse_id?, thread_id?)` — single entry point that: (a) checks `notifPrefs[category]`, (b) checks per-group mute when `category=="groupPost"`, (c) async-invokes `notifications_send` with the right kind. Mirrors `_invoke_threshold_push` shape. |
+
+### 3c. Modified lambdas
+
+| Lambda | Change |
+|--------|--------|
+| `notifications_send/handler.py` | Extend `VALID_KINDS` to include `dm`, `wrapped`, `release_radar`, `group_post`. Extend `OPT_IN_FLAG_BY_KIND` mapping (or short-circuit the flag check for these — the `notifPrefs` check now happens upstream in `push_dispatch.send_push`, so `notifications_send` becomes the dumb APNS pipe). Document the split. |
+| `shares_create/handler.py` | After successful share write, if `groupIds` non-empty: query group memberships, filter out author, call `push_dispatch.send_push(category="groupPost", ...)` per recipient. Fire-and-forget, do not block the response. |
+| `notifications_register/handler.py` | No change (existing opt-in flags `digestEnabled` / `queueNotificationsEnabled` keep working) |
+
+### 3d. New lambdas
+
+| Lambda | Trigger | Notes |
+|--------|---------|-------|
+| `dms_send` | `POST /dms/send` | Validates friendship + block check. Writes MSG row, updates META, bumps both `xomify-thread-index` rows (sender unreadCount=0, recipient unreadCount+=1). Fires `push_dispatch.send_push(category="dm")` for recipient. |
+| `dms_list_threads` | `GET /dms/threads` | Query `xomify-thread-index` PK=email, ScanIndexForward=False, limit. Returns inbox. |
+| `dms_list_messages` | `GET /dms/threads/{threadId}/messages` | Query `xomify-dms` PK=threadId SK begins_with `MSG#`, ScanIndexForward=False, limit + `before` cursor. **Must verify caller is a participant** before returning. |
+| `dms_mark_read` | `POST /dms/threads/{threadId}/read` | Updates caller's `xomify-thread-index` row: `lastReadAt=now`, `unreadCount=0`. |
+| `dms_block` / `dms_unblock` | `POST /dms/block`, `POST /dms/unblock` | Writes/deletes `xomify-blocks` row. |
+| `notif_prefs_get` / `notif_prefs_update` | `GET/PATCH /me/notif-prefs` | Reads/writes `notifPrefs` map + `mutedGroupIds` set on user row. PATCH accepts partial. |
+| `wrapped_poller` | EventBridge cron, daily Nov 25 – Dec 15 at 17:00 UTC | For each user with `notifPrefs.wrapped` ≠ false AND a valid Spotify refresh token: call Spotify `/me/playlists`, look for the year's Wrapped playlist, compare against `wrappedPlaylistIdSeen[year]`, fire push + write marker if first-seen. Skip silently on token failure. |
+| `release_radar_poller` | EventBridge cron, weekly Friday 18:00 UTC | For each opted-in user: resolve `releaseRadarPlaylistId` (cache on profile if absent), pull current track ids, diff vs `releaseRadarLastTrackIds`, fire push + overwrite list if non-empty diff. First-ever run = store list, no push. |
+
+### 3e. Backend tests
+
+Per-lambda unit tests under `lambdas/<name>/tests/`:
+- `dms_send`: happy path, friendship-rejected, block-rejected, self-DM rejected, track payload shape, push fired
+- `dms_list_threads`: ordering, limit, empty inbox
+- `dms_list_messages`: pagination cursor, participant gate (non-participant gets 403)
+- `dms_mark_read`: zeros unreadCount idempotently
+- `notif_prefs_get/update`: defaults when attrs absent, partial PATCH preserves other keys, mute-group set ops
+- `push_dispatch.send_push`: gates on prefs, gates on per-group mute, no-op when category disabled
+- `wrapped_poller`: first-seen fires, second-seen no-op, missing refresh token silent-skip
+- `release_radar_poller`: first run no-fire, diff-fires, no-diff no-fire
+- `shares_create` (regression): single-recipient, multi-group fan-out, no-groupIds path unchanged
+
+---
+
+## 4. iOS Work (`xomify-ios`)
+
+### 4a. Models (Codable)
+
+- `DMThread { threadId, otherEmail, otherDisplayName, otherAvatarUrl?, lastMessagePreview, lastMessageAt, unreadCount }`
+- `DMMessage { messageId, threadId, senderEmail, kind: DMKind, body?, trackPayload?, createdAt, deleted }`
+- `DMKind = .text | .track`
+- `DMTrackPayload` mirrors `Share` track fields (`trackId, trackUri, trackName, artistName, albumName, albumArtUrl`) so the existing track bubble component renders unchanged
+- `NotifPrefs { dm, wrapped, releaseRadar, groupPost, threshold }` (all `Bool`, default true)
+- `MutedGroupIds = Set<String>`
+
+### 4b. Networking (services layer)
+
+- `DMService`: `sendMessage`, `listThreads`, `listMessages(threadId, before:)`, `markRead(threadId)`, `block(email)`, `unblock(email)`
+- `NotifPrefsService`: `getPrefs()`, `updatePrefs(partial:)`, `muteGroup(groupId)`, `unmuteGroup(groupId)`
+- `PushNotificationRouter`: maps incoming APNS `data.type` → deep-link target (`dm`, `wrapped`, `releaseRadar`, `groupPost`)
+
+### 4c. View models
+
+- `InboxViewModel` (polls `listThreads` every 15s while foreground; pauses on background)
+- `ChatViewModel` (polls `listMessages` every 5s while view is on screen + `markRead` on open and on app-foreground)
+- `NotifPrefsViewModel` (loads on Settings open, debounced PATCH on toggle)
+- `BlockListViewModel` (settings sub-screen, lists blocked users + unblock action)
+
+### 4d. Views
+
+- `InboxView` — list of `DMThread`s, unread badge, tap to open chat, "New Message" entry that picks from friends list (friends-only — no handle search)
+- `ChatView` — message list (text + track bubbles), input bar, "Share a track" inline picker (reuses existing track-search sheet), block menu in nav bar
+- `NotifSettingsView` — section on the Profile/Settings screen with 5 toggles (DMs, Wrapped, Release Radar, Group posts, Threshold pushes) and a "Muted groups" sub-list
+- `MutedGroupsView` — list of muted groups with unmute swipe action
+- Empty states: "No messages yet — share a track with a friend to start a thread"
+
+### 4e. Navigation / deep links
+
+- Register `xomify://` URL scheme handler if not already (open question — see §6)
+- Routes: `xomify://dm/<threadId>`, `xomify://group/<id>/post/<postId>`, `xomify://wrapped`, `xomify://release-radar`
+- APNS `userNotificationCenter(_:didReceive:)` → `PushNotificationRouter.handle(userInfo:)` → push the right view onto the active nav stack
+
+### 4f. Polling cadence (locked)
+
+| Surface | Cadence | Notes |
+|---------|---------|-------|
+| Inbox open | 15s | Pause when app backgrounded |
+| Chat open | 5s | Mark read on open + on each new-message arrival while focused |
+| Background | n/a | APNS handles delivery |
+
+---
+
+## 5. Phasing / Order
+
+Two independent tracks. Notifications-prefs UI is a prerequisite for Phase 2 user-facing toggles, but the backend `notifPrefs` plumbing can ship first behind defaults.
+
+### Phase 0 — Foundations (1 PR, backend only)
+- Add `notifPrefs` defaults + `push_dispatch.send_push` helper
+- Extend `notifications_send` to accept new kinds
+- Add `notif_prefs_get` / `notif_prefs_update` lambdas + `/me/notif-prefs` routes
+
+**Ships independently. No iOS dependency. Verifiable by hitting the endpoint with curl.**
+
+### Phase 1 — DMs (2 PRs, backend + iOS — landed together behind a feature flag)
+- Backend: `xomify-dms` + `xomify-thread-index` + `xomify-blocks` tables, all 6 DM lambdas
+- iOS: models, services, Inbox + Chat views, friends-only thread creation, block/unblock, polling, push handler for `dm` category
+- Wire DM push trigger inside `dms_send` via `push_dispatch.send_push(category="dm", ...)`
+
+### Phase 2 — Group post notifications (1 PR, backend only)
+- Modify `shares_create` to fan out push when `groupIds` non-empty
+- Per-group mute already wired via `push_dispatch` from Phase 0
+- Regression test on `shares_create` paths
+- iOS already has the deep-link handler from Phase 1
+
+### Phase 3 — Wrapped + Release Radar pollers (1 PR, backend only)
+- `wrapped_poller` + `release_radar_poller` lambdas + EventBridge schedules
+- `xomify-users` schema additions for markers (no migration — attrs default-absent)
+- **Depends on**: Spotify refresh tokens being persisted server-side (open question §6)
+
+### Phase 4 — iOS notification settings UI polish (1 PR, iOS only)
+- `NotifSettingsView` + `MutedGroupsView` wired up
+- Profile screen integration
+
+**Dependency tree:**
+```
+Phase 0 ─┬─> Phase 1 (DMs)
+         ├─> Phase 2 (Group push) ──┐
+         ├─> Phase 3 (Wrapped/RR)   ├─> Phase 4 (Settings UI)
+         └──────────────────────────┘
+```
+
+Phases 1, 2, 3 can run in parallel after Phase 0 lands.
+
+---
+
+## 6. Risks + Open Questions
+
+### Risks
+- **Spotify API fragility (Wrapped detection)**. Naming convention can change year-over-year. Mitigation: log + alarm on the poller's "found a wrapped playlist" counter in late November; manual-trigger lambda exists for hot-fix. Acceptable risk for an annual event.
+- **Spotify rate limits (Release Radar weekly poll)**. 1 call per opted-in user per week. Trivial at hundreds, watch at low-thousands. Mitigation: chunk the poller into batches with sleeps if user count grows past ~1k.
+- **Notification fatigue**. Four new categories on top of existing threshold pushes. Mitigation: defaults stay ON but the prefs UI ships in the same release; per-group mute provides escape valve for chatty groups.
+- **Polling cost on DMs**. 5s during chat open is fine for a couple of users; thousands of concurrent open-chat sessions adds up. Mitigation: cheap query (single PK GetItem-ish), but keep an eye on read-capacity metrics. Future: switch open-chat to longer poll if needed.
+- **Block bypass via group post**. A blocked user could still pop into your notification stream via a shared group. Acceptable for v1 — block is DM-scope only. Document this on the block UI.
+- **Friendship-gate UX**: opening a thread with someone who's no longer a friend (unfriend mid-conversation) — the thread still exists but new sends 403. Spec'd as "frozen thread, read-only" — confirm this matches Dom's mental model (open question).
+
+### Open Questions
+- [ ] **Do Spotify refresh tokens already persist on the `xomify-users` row?** If only access tokens are cached, Wrapped + Release Radar pollers cannot function. Phase 3 blocks on this — needs a 5-min check in the auth lambda. If missing, prepend a sub-phase: "persist refresh tokens at OAuth callback."
+- [ ] **iOS `xomify://` URL scheme** — already registered in `Info.plist`, or new in this PR? Affects effort estimate for Phase 1.
+- [ ] **Frozen thread on unfriend** — read-only or hidden entirely from inbox? Recommend read-only with a banner ("You and X are no longer friends — replies disabled").
+- [ ] **`shares_create` group-post recipients** — query existing groups membership table directly, or is there a `list_group_members` helper? If neither, Phase 2 needs that helper added first.
+- [ ] **Wrapped polling year window** — Spotify dropped Wrapped on Nov 29 in 2023, Dec 4 in 2024. Confirm Nov 25 – Dec 15 is the right window for 2026.
+- [ ] **Release Radar timing** — Friday 18:00 UTC vs. Monday morning local. Recommend Friday (simpler, fresh content) unless there's a usage data argument otherwise.
+- [ ] **Notification volume budget** — APNS has no per-user cap, but is there a per-app warning threshold we want to set in CloudWatch?
+
+---
+
+## 7. Test Plan
+
+### Backend
+- Unit tests per new lambda (see §3e)
+- **Friendship gate regression**: explicit test that `dms_send` with `(emailA, emailB)` where status≠accepted returns 403 with a structured error
+- **Block gate regression**: same, for `xomify-blocks` row in either direction
+- **Idempotency**: `dms_mark_read` called twice produces the same state; `wrapped_poller` re-run on the same day no-ops
+- **`shares_create` regression suite**: existing tests pass unchanged; new tests for group-post fan-out
+
+### iOS
+- **Unit**: ViewModel logic with mocked services (polling pause on background, mark-read on open, debounce on prefs PATCH)
+- **Preview**: SwiftUI previews for `InboxView`, `ChatView` (text + track bubble), `NotifSettingsView`, empty + populated states
+- **Manual checklist**:
+  - Send DM A→B, verify push lands on B's device
+  - Send DM A→B with B muted via `notifPrefs.dm=false`, verify no push
+  - Block A from B, verify A's send returns 403
+  - Open thread, send 5 messages, verify polling picks them up
+  - Background app, send DM, verify APNS deep-links into chat on tap
+  - Toggle off "Group posts" prefs, verify no push on new group share
+  - Mute one group, post in two groups, verify only the unmuted one fires
+  - Force-fire `wrapped_poller` via direct invoke, verify push + deep link
+  - Force-fire `release_radar_poller` after seeding a non-empty diff, verify push
+
+---
+
+## 8. Cutover / Rollout
+
+### Feature flag
+- iOS: `featureFlags.dmsEnabled` (defaults false in the first TestFlight build, flip true after smoke test)
+- Backend: lambdas + tables can ship live (no flag needed — endpoints just 404 until the iOS app calls them)
+- Notification triggers: gate each category behind `notifPrefs.<category>` defaults — flip to ON globally once smoke-tested on Dom's device
+
+### Gradual rollout
+- TestFlight internal-only build: Dom + 1-2 friends for a week
+- Watch CloudWatch metrics:
+  - `dms_send` invocation count + p99 latency
+  - `notifications_send` invocations grouped by `kind`
+  - APNS 410 prune rate (should not spike)
+- Promote to TestFlight external once metrics look clean
+
+### Telemetry to add
+- Log line in `dms_send` with `threadId, hasTrack=bool, pushDispatched=bool`
+- CloudWatch metric filter on `push_dispatch` for `category` cardinality
+- iOS: log notification-tap → deep-link resolution events to existing analytics surface
+
+### Rollback plan
+- DMs: feature flag flip on iOS hides the inbox tab; backend tables stay (zero blast radius if tab is hidden)
+- Notification categories: server-side, set `notifPrefs.<category>=false` for all users via a one-shot script (or just flip `VALID_KINDS` in `notifications_send` to drop the kind silently)
+- Wrapped/RR pollers: disable EventBridge rule
+
+---
+
+## Skills / Agents to Use
+- **backend-engineer**: Phase 0, 2, 3 — Python/Lambda/DynamoDB work in `xomify-backend`
+- **ios-engineer**: Phase 1 (iOS half), Phase 4 — SwiftUI views, view models, deep-link routing
+- **test-engineer**: per-phase unit-test pass before each PR opens
+- **code-reviewer**: final pass on every PR — friend-gate and block-gate are the easy-to-miss correctness bugs
+


### PR DESCRIPTION
## Summary
Critical:
- Release.stableId: deterministic fallback instead of fresh UUID
- RatingsHistoryViewModel: clamp rollback index to prevent crash
- AuthService.logout: await unregister before clearing JWT

High:
- FeedView: pagination uses filteredShares.last for trigger
- ShareDetailViewModel: clamp comment rollback index
- GroupDetailViewModel: remove duplicate loadShares call
- RatingsHistoryViewModel: remove redundant getCurrentUser calls
- WrappedDataResponse: make Bool fields optional
- Rate sheet: only dismiss on success

Medium:
- Clear reactError on retry
- LoginViewModel: add @MainActor
- FeedViewModel.bootstrap: set isLoading
- WrappedView: clear error on load

## Test plan
- [ ] Feed doesn't flicker on scroll
- [ ] Deleting ratings doesn't crash
- [ ] Logout properly unregisters push token
- [ ] Feed pagination works with filters

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>